### PR TITLE
Add memory manager shimmer skeleton

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/MemoryManagerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/MemoryManagerScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.carousel.CustomCarousel
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
@@ -50,6 +49,7 @@ import com.d4rk.cleaner.app.clean.memory.domain.data.model.ui.UiMemoryManagerScr
 import com.d4rk.cleaner.app.clean.memory.ui.components.RamInfoCard
 import com.d4rk.cleaner.app.clean.memory.ui.components.StorageBreakdownGrid
 import com.d4rk.cleaner.app.clean.memory.ui.components.StorageInfoCard
+import com.d4rk.cleaner.app.clean.memory.ui.components.MemoryManagerShimmer
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -70,7 +70,7 @@ fun MemoryManagerComposable(paddingValues : PaddingValues) {
     }
 
     ScreenStateHandler(screenState = uiState , onLoading = {
-        LoadingScreen()
+        MemoryManagerShimmer(paddingValues = paddingValues)
     } , onEmpty = {
         NoDataScreen(icon = Icons.Outlined.Memory , showRetry = true , onRetry = { viewModel.onEvent(MemoryEvent.LoadMemoryData) })
     } , onSuccess = { screenData ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
@@ -1,0 +1,79 @@
+package com.d4rk.cleaner.app.clean.memory.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.shimmerEffect
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
+@Composable
+fun MemoryManagerShimmer(paddingValues: androidx.compose.foundation.layout.PaddingValues) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            repeat(2) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .size(160.dp)
+                        .clip(CircleShape)
+                        .shimmerEffect()
+                )
+            }
+        }
+
+        LargeVerticalSpacer()
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+            repeat(3) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp)
+                            .clip(RoundedCornerShape(SizeConstants.MediumSize))
+                            .shimmerEffect()
+                    )
+                    SmallHorizontalSpacer()
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(56.dp)
+                            .clip(RoundedCornerShape(SizeConstants.MediumSize))
+                            .shimmerEffect()
+                    )
+                }
+                SmallVerticalSpacer()
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .clip(RoundedCornerShape(SizeConstants.MediumSize))
+                    .shimmerEffect()
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add new `MemoryManagerShimmer` composable for loading state
- use the new shimmer skeleton in `MemoryManagerScreen`

## Testing
- `./gradlew lintVitalRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d39ff50c832d9a3790908e534f03