### PR TITLE
Improve MemoryManager shimmer placeholders

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/MemoryManagerShimmer.kt
@@ -16,10 +16,16 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import com.d4rk.android.libs.apptoolkit.core.ui.components.carousel.DotsIndicator
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.shimmerEffect
@@ -43,9 +49,10 @@ fun MemoryManagerShimmer(paddingValues : PaddingValues) {
             modifier = Modifier
                 .fillMaxWidth()
                 .hapticPagerSwipe(pagerState = pagerState),
+            userScrollEnabled = false,
             contentPadding = PaddingValues(horizontal = 24.dp)
         ) { _ ->
-            CarouselShimmerItem()
+            CarouselShimmerCard()
         }
 
         LargeVerticalSpacer()
@@ -53,7 +60,8 @@ fun MemoryManagerShimmer(paddingValues : PaddingValues) {
         DotsIndicator(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
-                .padding(bottom = SizeConstants.SmallSize),
+                .padding(bottom = SizeConstants.SmallSize)
+                .shimmerEffect(),
             totalDots = 2,
             selectedIndex = pagerState.currentPage,
             dotSize = SizeConstants.MediumSize / 2,
@@ -61,73 +69,108 @@ fun MemoryManagerShimmer(paddingValues : PaddingValues) {
 
         LargeVerticalSpacer()
 
-        Column(modifier = Modifier.fillMaxWidth()) {
-            repeat(3) {
-                Row(modifier = Modifier.fillMaxWidth()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp)
-                            .clip(RoundedCornerShape(SizeConstants.MediumSize))
-                            .shimmerEffect()
-                    )
-                    SmallHorizontalSpacer()
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp)
-                            .clip(RoundedCornerShape(SizeConstants.MediumSize))
-                            .shimmerEffect()
-                    )
-                }
-                SmallVerticalSpacer()
-            }
-            Box(
+        StorageBreakdownGridShimmer()
+    }
+}
+
+@Composable
+private fun CarouselShimmerCard() {
+    val headlineHeight = with(LocalDensity.current) { MaterialTheme.typography.headlineSmall.fontSize.toDp() }
+    val bodyHeight = with(LocalDensity.current) { MaterialTheme.typography.bodyMedium.fontSize.toDp() }
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.MediumSize),
+        colors = CardDefaults.cardColors()
+    ) {
+        Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
+            Spacer(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
-                    .clip(RoundedCornerShape(SizeConstants.MediumSize))
+                    .fillMaxWidth(0.6f)
+                    .height(headlineHeight)
+                    .clip(RoundedCornerShape(SizeConstants.SmallSize))
                     .shimmerEffect()
             )
+
+            SmallVerticalSpacer()
+
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(SizeConstants.SmallSize)
+                    .clip(RoundedCornerShape(SizeConstants.SmallSize))
+                    .shimmerEffect()
+            )
+
+            SmallVerticalSpacer()
+
+            repeat(3) {
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth(0.8f)
+                        .height(bodyHeight)
+                        .clip(RoundedCornerShape(SizeConstants.SmallSize))
+                        .shimmerEffect()
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun CarouselShimmerItem() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(SizeConstants.MediumSize))
-            .padding(SizeConstants.LargeSize)
+private fun StorageBreakdownGridShimmer() {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        repeat(3) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+                SmallHorizontalSpacer()
+                StorageBreakdownItemShimmer(modifier = Modifier.weight(1f))
+            }
+            SmallVerticalSpacer()
+        }
+        StorageBreakdownItemShimmer(modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+private fun StorageBreakdownItemShimmer(modifier: Modifier = Modifier) {
+    val bodyHeight = with(LocalDensity.current) { MaterialTheme.typography.bodyMedium.fontSize.toDp() }
+    val bodySmallHeight = with(LocalDensity.current) { MaterialTheme.typography.bodySmall.fontSize.toDp() }
+    Card(
+        modifier = modifier
+            .padding(all = SizeConstants.ExtraSmallSize),
+        colors = CardDefaults.cardColors()
     ) {
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth(0.6f)
-                .height(SizeConstants.MediumSize)
-                .clip(RoundedCornerShape(SizeConstants.SmallSize))
-                .shimmerEffect()
-        )
-
-        SmallVerticalSpacer()
-
-        Spacer(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(SizeConstants.SmallSize)
-                .clip(RoundedCornerShape(SizeConstants.SmallSize))
-                .shimmerEffect()
-        )
-
-        repeat(3) {
-            SmallVerticalSpacer()
-            Spacer(
+                .padding(all = SizeConstants.LargeSize),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Card(
                 modifier = Modifier
-                    .fillMaxWidth(0.8f)
-                    .height(SizeConstants.MediumSize)
-                    .clip(RoundedCornerShape(SizeConstants.SmallSize))
-                    .shimmerEffect()
-            )
+                    .size(48.dp)
+                    .shimmerEffect(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+            ) {}
+
+            Spacer(modifier = Modifier.padding(horizontal = SizeConstants.ExtraSmallSize))
+
+            Column {
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth(0.6f)
+                        .height(bodyHeight)
+                        .clip(RoundedCornerShape(SizeConstants.SmallSize))
+                        .shimmerEffect()
+                )
+                Spacer(
+                    modifier = Modifier
+                        .fillMaxWidth(0.4f)
+                        .height(bodySmallHeight)
+                        .clip(RoundedCornerShape(SizeConstants.SmallSize))
+                        .shimmerEffect()
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- improve MemoryManagerShimmer to better mimic the final layout
- disable pager interaction while loading
- make carousel card, dots, and breakdown placeholders shimmer

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d93907c0832d8a05832e84c80ded