### PR TITLE
Improve storage permission onboarding tab

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/onboarding/ui/tabs/PermissionsOnboardingTabs.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/onboarding/ui/tabs/PermissionsOnboardingTabs.kt
@@ -1,21 +1,30 @@
 package com.d4rk.cleaner.app.onboarding.ui.tabs
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,15 +40,76 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 @Composable
+private fun PermissionCard(
+    title: String,
+    description: String,
+    granted: Boolean,
+    onClick: () -> Unit,
+    note: String? = null
+) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(text = title, style = MaterialTheme.typography.titleMedium)
+                    SmallVerticalSpacer()
+                    Text(text = description, style = MaterialTheme.typography.bodySmall)
+                    note?.let {
+                        SmallVerticalSpacer()
+                        Text(text = it, style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+                if (granted) {
+                    Icon(
+                        imageVector = Icons.Outlined.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+            if (!granted) {
+                LargeVerticalSpacer()
+                OutlinedButton(onClick = onClick, colors = ButtonDefaults.outlinedButtonColors()) {
+                    Text(text = stringResource(id = R.string.button_grant_permission))
+                }
+            }
+        }
+    }
+}
+
+@Composable
 fun StoragePermissionOnboardingTab() {
     val context = LocalContext.current
     val dataStore: DataStore = koinInject()
     val coroutineScope = rememberCoroutineScope()
 
+    val storageGranted by dataStore.storagePermissionGranted.collectAsState(initial = false)
+    val usageGranted by dataStore.usagePermissionGranted.collectAsState(initial = false)
+    val treeGranted by dataStore.documentTreePermissionGranted.collectAsState(initial = false)
+
+    val documentTreeLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        if (uri != null) {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            coroutineScope.launch {
+                dataStore.saveDocumentTreeUri(uri.toString())
+                dataStore.saveDocumentTreePermissionGranted(true)
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        dataStore.saveStoragePermissionGranted(PermissionsHelper.hasStoragePermissions(context))
+        dataStore.saveUsagePermissionGranted(PermissionsHelper.hasUsageAccessPermissions(context))
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(SizeConstants.LargeSize),
+        verticalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(
@@ -47,29 +117,60 @@ fun StoragePermissionOnboardingTab() {
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary
         )
-        LargeVerticalSpacer()
         Text(
             text = stringResource(id = R.string.onboarding_permission_storage_title),
             style = MaterialTheme.typography.titleLarge
         )
-        SmallVerticalSpacer()
         Text(
             text = stringResource(id = R.string.onboarding_permission_storage_description),
             style = MaterialTheme.typography.bodyMedium
         )
-        LargeVerticalSpacer()
-        OutlinedButton(onClick = {
-            PermissionsHelper.requestStoragePermissions(context as Activity)
-            PermissionsHelper.requestUsageAccess(context as Activity)
-            coroutineScope.launch {
-                val granted = PermissionsHelper.hasStoragePermissions(context)
-                val usage = PermissionsHelper.hasUsageAccessPermissions(context)
-                dataStore.saveStoragePermissionGranted(granted)
-                dataStore.saveUsagePermissionGranted(usage)
+
+        PermissionCard(
+            title = stringResource(id = R.string.permission_section_public_title),
+            description = stringResource(id = R.string.permission_section_public_description),
+            granted = storageGranted,
+            onClick = {
+                PermissionsHelper.requestStoragePermissions(context as Activity)
+                coroutineScope.launch {
+                    dataStore.saveStoragePermissionGranted(PermissionsHelper.hasStoragePermissions(context))
+                }
             }
-        }, colors = ButtonDefaults.outlinedButtonColors()) {
-            Text(text = stringResource(id = R.string.button_grant_permission))
-        }
+        )
+
+        PermissionCard(
+            title = stringResource(id = R.string.permission_section_manage_title),
+            description = stringResource(id = R.string.permission_section_manage_description),
+            granted = storageGranted,
+            onClick = {
+                PermissionsHelper.requestStoragePermissions(context as Activity)
+                coroutineScope.launch {
+                    dataStore.saveStoragePermissionGranted(PermissionsHelper.hasStoragePermissions(context))
+                }
+            },
+            note = stringResource(id = R.string.manage_external_storage)
+        )
+
+        PermissionCard(
+            title = stringResource(id = R.string.permission_section_usage_title),
+            description = stringResource(id = R.string.permission_section_usage_description),
+            granted = usageGranted,
+            onClick = {
+                PermissionsHelper.requestUsageAccess(context as Activity)
+                coroutineScope.launch {
+                    dataStore.saveUsagePermissionGranted(PermissionsHelper.hasUsageAccessPermissions(context))
+                }
+            },
+            note = stringResource(id = R.string.package_usage_stats)
+        )
+
+        PermissionCard(
+            title = stringResource(id = R.string.permission_section_saf_title),
+            description = stringResource(id = R.string.permission_section_saf_description),
+            granted = treeGranted,
+            onClick = { documentTreeLauncher.launch(null) },
+            note = stringResource(id = R.string.action_open_document_tree)
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -295,4 +295,26 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
             prefs[usagePermissionGrantedKey] = granted
         }
     }
+
+    private val documentTreePermissionGrantedKey = booleanPreferencesKey("permission_document_tree_granted")
+    val documentTreePermissionGranted: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[documentTreePermissionGrantedKey] == true
+    }
+
+    private val documentTreeUriKey = stringPreferencesKey("document_tree_uri")
+    val documentTreeUri: Flow<String?> = dataStore.data.map { prefs ->
+        prefs[documentTreeUriKey]
+    }
+
+    suspend fun saveDocumentTreePermissionGranted(granted: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[documentTreePermissionGrantedKey] = granted
+        }
+    }
+
+    suspend fun saveDocumentTreeUri(uri: String) {
+        dataStore.edit { prefs ->
+            prefs[documentTreeUriKey] = uri
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,16 @@
     <string name="onboarding_permission_notifications_description">Enable notifications to receive cleaning reminders.</string>
     <string name="button_grant_permission">Grant permission</string>
 
+    <string name="permission_section_public_title">Public storage access</string>
+    <string name="permission_section_public_description">Allows Cleaner to read and write files on public storage.</string>
+    <string name="permission_section_manage_title">Full file management</string>
+    <string name="permission_section_manage_description">Required to fully manage all files on your device.</string>
+    <string name="permission_section_usage_title">App usage access</string>
+    <string name="permission_section_usage_description">Allows Cleaner to analyze storage based on app usage.</string>
+    <string name="permission_section_saf_title">Document tree access</string>
+    <string name="permission_section_saf_description">Use the system file picker if other storage permissions fail.</string>
+    <string name="permission_granted">Granted</string>
+
     <string name="notifications">Notifications</string>
     <string name="summary_preference_settings_notifications">Manage app notifications</string>
 


### PR DESCRIPTION
## Summary
- redesign StoragePermissionOnboardingTab with individual permission cards
- add document tree permission state in DataStore
- update string resources with new permission section texts

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853052e0f7c832dafdd1dc206de165b