### PR TITLE
Fix onboarding permission flows

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/PermissionsHelper.kt
@@ -64,6 +64,8 @@ object PermissionsHelper {
                 val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION)
                 val uri : Uri = Uri.fromParts("package" , activity.packageName , null)
                 intent.data = uri
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
                 activity.startActivity(intent)
             }
 
@@ -89,6 +91,8 @@ object PermissionsHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             if (! isAccessGranted(activity)) {
                 val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
                 activity.startActivity(intent)
             }
         }


### PR DESCRIPTION
## Summary
- keep onboarding activity in back stack when opening system settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531743f0d4832db301c09f0978da59