### PR TITLE
Ensure new scan after cleaning

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -485,21 +485,37 @@ class HomeViewModel(
     }
 
     private fun toggleAnalyzeScreen(visible : Boolean) {
-        _uiState.updateData(ScreenState.Success()) { currentData ->
-            currentData.copy(
-                analyzeState = currentData.analyzeState.copy(
-                    isAnalyzeScreenVisible = visible,
-                    state = if (visible) currentData.analyzeState.state else CleaningState.Idle
-                )
-            )
-        }
-
         if (visible) {
+            _uiState.update { state : UiStateScreen<UiHomeModel> ->
+                val currentData : UiHomeModel = state.data ?: UiHomeModel()
+                state.copy(
+                    data = currentData.copy(
+                        analyzeState = currentData.analyzeState.copy(
+                            isAnalyzeScreenVisible = true ,
+                            scannedFileList = emptyList() ,
+                            emptyFolderList = emptyList() ,
+                            groupedFiles = emptyMap() ,
+                            fileSelectionMap = emptyMap() ,
+                            selectedFilesCount = 0 ,
+                            areAllFilesSelected = false ,
+                            state = CleaningState.Idle
+                        )
+                    )
+                )
+            }
             analyzeFiles()
         }
         else {
-            _uiState.updateData(_uiState.value.screenState) { currentData ->
-                currentData.copy(analyzeState = currentData.analyzeState.copy(fileSelectionMap = emptyMap() , selectedFilesCount = 0 , areAllFilesSelected = false))
+            _uiState.updateData(ScreenState.Success()) { currentData ->
+                currentData.copy(
+                    analyzeState = currentData.analyzeState.copy(
+                        fileSelectionMap = emptyMap() ,
+                        selectedFilesCount = 0 ,
+                        areAllFilesSelected = false ,
+                        isAnalyzeScreenVisible = false ,
+                        state = CleaningState.Idle
+                    )
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- reset Analyze screen state before each scan so old scan data isn't reused

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853db2e754c832dbeef80f625e48a0e