### PR TITLE
Add missing DataStore constants

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.map
 class DataStore(val context : Context) : CommonDataStore(context = context) {
 
     // Cleaning
-    private val cleanedSpaceKey = longPreferencesKey(name = "cleaned_space")
+    private val cleanedSpaceKey = longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_CLEANED_SPACE)
     val cleanedSpace : Flow<Long> = dataStore.data.map { preferences ->
         preferences[cleanedSpaceKey] ?: 0L
     }
@@ -25,7 +25,7 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
-    private val lastScanTimestampKey = longPreferencesKey(name = "last_scan_timestamp")
+    private val lastScanTimestampKey = longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_LAST_SCAN_TIMESTAMP)
 
     suspend fun saveLastScanTimestamp(timestamp : Long) {
         dataStore.edit { preferences ->
@@ -34,7 +34,7 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
-    private val trashFileOriginalPathsKey = stringSetPreferencesKey("trash_file_original_paths")
+    private val trashFileOriginalPathsKey = stringSetPreferencesKey(AppDataStoreConstants.DATA_STORE_TRASH_FILE_ORIGINAL_PATHS)
 
     val trashFileOriginalPaths : Flow<Set<String>> = dataStore.data.map { preferences ->
         preferences[trashFileOriginalPathsKey] ?: emptySet()
@@ -55,7 +55,7 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
     }
 
 
-    private val trashSizeKey = longPreferencesKey(name = "trash_size")
+    private val trashSizeKey = longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_TRASH_SIZE)
     val trashSize : Flow<Long> = dataStore.data.map { preferences ->
         preferences[trashSizeKey] ?: 0L
     }
@@ -228,7 +228,7 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
-    private val storagePermissionGrantedKey = booleanPreferencesKey("permission_storage_granted")
+    private val storagePermissionGrantedKey = booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_PERMISSION_STORAGE_GRANTED)
     val storagePermissionGranted: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[storagePermissionGrantedKey] == true
     }
@@ -240,7 +240,7 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
     }
 
 
-    private val usagePermissionGrantedKey = booleanPreferencesKey("permission_usage_stats_granted")
+    private val usagePermissionGrantedKey = booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_PERMISSION_USAGE_STATS_GRANTED)
     val usagePermissionGranted: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[usagePermissionGrantedKey] == true
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -3,6 +3,12 @@ package com.d4rk.cleaner.core.utils.constants.datastore
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
 
 object AppDataStoreConstants : DataStoreNamesConstants() {
+    const val DATA_STORE_CLEANED_SPACE = "cleaned_space"
+    const val DATA_STORE_LAST_SCAN_TIMESTAMP = "last_scan_timestamp"
+    const val DATA_STORE_TRASH_FILE_ORIGINAL_PATHS = "trash_file_original_paths"
+    const val DATA_STORE_TRASH_SIZE = "trash_size"
+    const val DATA_STORE_PERMISSION_STORAGE_GRANTED = "permission_storage_granted"
+    const val DATA_STORE_PERMISSION_USAGE_STATS_GRANTED = "permission_usage_stats_granted"
     const val DATA_STORE_STARTUP_PAGE = "startup_page"
     const val DATA_STORE_SHOW_BOTTOM_BAR_LABELS = "show_bottom_bar_labels"
     const val DATA_STORE_GENERIC_FILTER = "generic_filter"


### PR DESCRIPTION
## Summary
- add new preference key constants for the app DataStore
- use these constants in `DataStore`

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c97603a8832db1c06f6002e7ca75