### PR TITLE
Improve progress state handling

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -234,6 +234,15 @@ class HomeViewModel(
                 sendAction(HomeAction.ShowSnackbar(UiSnackbar(message = UiTextHelper.DynamicString("No files selected to delete.") , isError = false)))
                 return@launch
             }
+            _uiState.update { state : UiStateScreen<UiHomeModel> ->
+                val currentData : UiHomeModel = state.data ?: UiHomeModel()
+                state.copy(
+                    data = currentData.copy(
+                        analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)
+                    )
+                )
+            }
+
 
             deleteFilesUseCase(filesToDelete = files).collectLatest { result : DataState<Unit , Errors> ->
                 _uiState.applyResult(result = result , errorMessage = UiTextHelper.DynamicString("Failed to delete files:")) { data , currentData ->
@@ -265,6 +274,15 @@ class HomeViewModel(
                 sendAction(HomeAction.ShowSnackbar(UiSnackbar(message = UiTextHelper.DynamicString("No files selected to move to trash.") , isError = false)))
                 return@launch
             }
+            _uiState.update { state : UiStateScreen<UiHomeModel> ->
+                val currentData : UiHomeModel = state.data ?: UiHomeModel()
+                state.copy(
+                    data = currentData.copy(
+                        analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)
+                    )
+                )
+            }
+
 
             val totalFileSizeToMove : Long = files.sumOf { it.length() }
 


### PR DESCRIPTION
## Summary
- show `Cleaning` state before moving or deleting selected files

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855da41749c832db9152badc1bc8cf2