### PR TITLE
Fix Quick Clean state handling

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -76,7 +76,7 @@ fun AnalyzeScreen(
                         LottieAnimation(composition = composition, iterations = LottieConstants.IterateForever)
                     }
 
-                    CleaningState.Success -> {
+                    CleaningState.ReadyToClean -> {
                         if (groupedFiles.isNotEmpty()) {
                             println("Showing TabsContent")
                             TabsContent(
@@ -88,6 +88,11 @@ fun AnalyzeScreen(
                                 data = data,
                             )
                         }
+                    }
+
+                    CleaningState.Result -> {
+                        println("Showing NoFilesFoundScreen")
+                        NoFilesFoundScreen(viewModel = viewModel)
                     }
                     CleaningState.Error -> {
                         if (groupedFiles.isEmpty()) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/CleaningState.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/CleaningState.kt
@@ -7,7 +7,20 @@ package com.d4rk.cleaner.app.clean.home.domain.data.model.ui
 enum class CleaningState {
     Idle,
     Analyzing,
+    /**
+     * Files have been analyzed and the user can review the results.
+     */
+    ReadyToClean,
+
+    /**
+     * Deleting or moving the selected files is in progress.
+     */
     Cleaning,
-    Success,
+
+    /**
+     * Cleaning finished and a short summary/result should be shown.
+     */
+    Result,
+
     Error
 }


### PR DESCRIPTION
## Summary
- add `ReadyToClean` and `Result` states
- emit `ReadyToClean` when analysis finishes
- update cleaning actions to require `ReadyToClean`
- show Result state in UI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685677caf9b4832d852763bf3d445bc0