### PR TITLE
Handle cleaning type and cleanup unused fields

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -27,6 +27,7 @@ import com.d4rk.cleaner.app.clean.analyze.components.StatusRowSelectAll
 import com.d4rk.cleaner.app.clean.analyze.components.dialogs.DeleteOrTrashConfirmation
 import com.d4rk.cleaner.app.clean.analyze.components.tabs.TabsContent
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.CleaningState
+import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.CleaningType
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
 import com.d4rk.cleaner.app.clean.home.ui.HomeViewModel
 import com.d4rk.cleaner.app.clean.home.ui.components.TwoRowButtons
@@ -66,7 +67,15 @@ fun AnalyzeScreen(
 
                 CleaningState.Cleaning -> {
                     println("Showing LottieAnimation")
-                    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.delete_anim))
+                    val composition by rememberLottieComposition(
+                        LottieCompositionSpec.RawRes(
+                            if (data.analyzeState.cleaningType == CleaningType.MOVE_TO_TRASH) {
+                                R.raw.cleaning_loop
+                            } else {
+                                R.raw.delete_anim
+                            }
+                        )
+                    )
                     LottieAnimation(composition = composition, iterations = LottieConstants.IterateForever)
                 }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/CleaningType.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/CleaningType.kt
@@ -1,0 +1,10 @@
+package com.d4rk.cleaner.app.clean.home.domain.data.model.ui
+
+/**
+ * Represents the type of cleaning action being performed.
+ */
+enum class CleaningType {
+    NONE,
+    DELETE,
+    MOVE_TO_TRASH,
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/UiHomeModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/data/model/ui/UiHomeModel.kt
@@ -2,6 +2,8 @@ package com.d4rk.cleaner.app.clean.home.domain.data.model.ui
 
 /** State of the cleaning process. */
 import com.d4rk.cleaner.app.clean.memory.domain.data.model.StorageInfo
+
+import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.CleaningType
 import java.io.File
 
 data class UiHomeModel(
@@ -13,6 +15,7 @@ data class UiHomeModel(
 
 data class UiAnalyzeModel(
     var state : CleaningState = CleaningState.Idle ,
+    var cleaningType : CleaningType = CleaningType.NONE ,
     var isAnalyzeScreenVisible : Boolean = false ,
     var scannedFileList : List<File> = emptyList() ,
     var emptyFolderList : List<File> = emptyList() ,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -16,6 +16,7 @@ import com.d4rk.cleaner.app.clean.home.domain.actions.HomeEvent
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.CleaningState
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.FileTypesData
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
+import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.CleaningType
 import com.d4rk.cleaner.app.clean.home.domain.usecases.AnalyzeFilesUseCase
 import com.d4rk.cleaner.app.clean.home.domain.usecases.DeleteFilesUseCase
 import com.d4rk.cleaner.app.clean.home.domain.usecases.GetFileTypesUseCase
@@ -146,7 +147,10 @@ class HomeViewModel(
                         is DataState.Loading -> currentState.copy(
                             screenState = ScreenState.IsLoading(),
                             data = currentData.copy(
-                                analyzeState = currentData.analyzeState.copy(state = CleaningState.Analyzing)
+                                analyzeState = currentData.analyzeState.copy(
+                                    state = CleaningState.Analyzing,
+                                    cleaningType = CleaningType.NONE
+                                )
                             )
                         )
                         is DataState.Success -> {
@@ -177,7 +181,8 @@ class HomeViewModel(
                                         groupedFiles = groupedFiles,
                                         // Files are ready for the user to review
                                         // before starting the cleaning step
-                                        state = CleaningState.ReadyToClean
+                                        state = CleaningState.ReadyToClean,
+                                        cleaningType = CleaningType.NONE
                                     )
                                 )
                             )
@@ -186,7 +191,10 @@ class HomeViewModel(
                         is DataState.Error -> currentState.copy(
                             screenState = ScreenState.Error(),
                             data = currentData.copy(
-                                analyzeState = currentData.analyzeState.copy(state = CleaningState.Error)
+                                analyzeState = currentData.analyzeState.copy(
+                                    state = CleaningState.Error,
+                                    cleaningType = CleaningType.NONE
+                                )
                             ),
                             errors = currentState.errors + UiSnackbar(
                                 message = UiTextHelper.DynamicString("Failed to analyze files: ${result.error}"),
@@ -240,7 +248,10 @@ class HomeViewModel(
                 val currentData : UiHomeModel = state.data ?: UiHomeModel()
                 state.copy(
                     data = currentData.copy(
-                        analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)
+                        analyzeState = currentData.analyzeState.copy(
+                            state = CleaningState.Cleaning,
+                            cleaningType = CleaningType.DELETE
+                        )
                     )
                 )
             }
@@ -260,7 +271,6 @@ class HomeViewModel(
                 }
 
                 if (result is DataState.Success) {
-                    val clearedSpaceTotalSize : Long = files.sumOf { it.length() } // FIXME: Property "clearedSpaceTotalSize" is never used
                     launch {
                         dataStore.saveLastScanTimestamp(timestamp = System.currentTimeMillis())
                     }
@@ -280,7 +290,10 @@ class HomeViewModel(
                 val currentData : UiHomeModel = state.data ?: UiHomeModel()
                 state.copy(
                     data = currentData.copy(
-                        analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)
+                        analyzeState = currentData.analyzeState.copy(
+                            state = CleaningState.Cleaning,
+                            cleaningType = CleaningType.MOVE_TO_TRASH
+                        )
                     )
                 )
             }
@@ -334,7 +347,8 @@ class HomeViewModel(
                         fileSelectionMap = emptyMap() ,
                         selectedFilesCount = 0 ,
                         areAllFilesSelected = false ,
-                        state = CleaningState.Idle
+                        state = CleaningState.Idle,
+                        cleaningType = CleaningType.NONE
                     )
                 )
             )
@@ -392,7 +406,14 @@ class HomeViewModel(
 
             _uiState.update { state : UiStateScreen<UiHomeModel> ->
                 val currentData = state.data ?: UiHomeModel()
-                state.copy(data = currentData.copy(analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)))
+                state.copy(
+                    data = currentData.copy(
+                        analyzeState = currentData.analyzeState.copy(
+                            state = CleaningState.Cleaning,
+                            cleaningType = CleaningType.DELETE
+                        )
+                    )
+                )
             }
 
             val currentScreenData : UiHomeModel = screenData ?: run {
@@ -422,7 +443,6 @@ class HomeViewModel(
 
                 if (result is DataState.Success) {
                     println(message = "Debugging ---> Clean Files triggered, result is success")
-                    val clearedSpaceTotalSize : Long = filesToDelete.sumOf { it.length() } // FIXME: Property "clearedSpaceTotalSize" is never used
                     launch {
                         dataStore.saveLastScanTimestamp(timestamp = System.currentTimeMillis())
                     }
@@ -448,7 +468,10 @@ class HomeViewModel(
                 val currentData = state.data ?: UiHomeModel()
                 state.copy(
                     data = currentData.copy(
-                        analyzeState = currentData.analyzeState.copy(state = CleaningState.Cleaning)
+                        analyzeState = currentData.analyzeState.copy(
+                            state = CleaningState.Cleaning,
+                            cleaningType = CleaningType.MOVE_TO_TRASH
+                        )
                     )
                 )
             }
@@ -534,7 +557,8 @@ class HomeViewModel(
                             fileSelectionMap = emptyMap() ,
                             selectedFilesCount = 0 ,
                             areAllFilesSelected = false ,
-                            state = CleaningState.Idle
+                            state = CleaningState.Idle,
+                            cleaningType = CleaningType.NONE
                         )
                     )
                 )
@@ -549,7 +573,8 @@ class HomeViewModel(
                         selectedFilesCount = 0 ,
                         areAllFilesSelected = false ,
                         isAnalyzeScreenVisible = false ,
-                        state = CleaningState.Idle
+                        state = CleaningState.Idle,
+                        cleaningType = CleaningType.NONE
                     )
                 )
             }


### PR DESCRIPTION
## Summary
- add `CleaningType` enum to track delete vs move-to-trash
- record `cleaningType` in `UiAnalyzeModel`
- update `HomeViewModel` to set `cleaningType` when operations start
- choose Lottie animation based on `cleaningType`
- remove unused `clearedSpaceTotalSize` variable

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567b7b288c832d8705bbd3afbcf116