### PR TITLE
Refactor duplicate file layout

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/DuplicateGroupsSection.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/DuplicateGroupsSection.kt
@@ -1,0 +1,68 @@
+package com.d4rk.cleaner.app.clean.analyze.components
+
+import android.view.View
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import coil3.ImageLoader
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@Composable
+fun DuplicateGroupsSection(
+    modifier : Modifier ,
+    filesByDate : Map<String , List<List<File>>> ,
+    fileSelectionStates : Map<File , Boolean> ,
+    imageLoader : ImageLoader ,
+    onFileSelectionChange : (File , Boolean) -> Unit ,
+    onDateSelectionChange: (List<File>, Boolean) -> Unit ,
+    originals: Set<File> = emptySet(),
+    view : View ,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        val sortedDates : List<String> = filesByDate.keys.sortedByDescending { dateString ->
+            SimpleDateFormat("yyyy-MM-dd" , Locale.getDefault()).parse(dateString)
+        }
+
+        sortedDates.forEach { date ->
+            val groups : List<List<File>> = filesByDate[date] ?: emptyList()
+            val allFiles : List<File> = groups.flatten()
+            item(key = date) {
+                DateHeader(
+                    files = allFiles , fileSelectionStates = fileSelectionStates , onFileSelectionChange = onFileSelectionChange , onDateSelectionChange = onDateSelectionChange , view = view
+                )
+            }
+
+            items(groups) { group ->
+                Row(
+                    modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = SizeConstants.SmallSize)
+                            .horizontalScroll(rememberScrollState())
+                ) {
+                    group.forEach { file ->
+                        FileCard(
+                            file = file,
+                            imageLoader = imageLoader,
+                            isChecked = fileSelectionStates[file] == true,
+                            onCheckedChange = { checked -> onFileSelectionChange(file, checked) },
+                            isOriginal = file in originals,
+                            view = view,
+                            modifier = Modifier.padding(end = SizeConstants.SmallSize)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
@@ -67,7 +67,6 @@ fun FileCard(
 
     Card(
         modifier = modifier
-                .fillMaxWidth()
                 .aspectRatio(ratio = 1f)
                 .bounceClick()
                 .clickable {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
@@ -30,6 +30,7 @@ import coil3.ImageLoader
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.cleaner.app.clean.analyze.components.FilesByDateSection
+import com.d4rk.cleaner.app.clean.analyze.components.DuplicateGroupsSection
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
 import com.d4rk.cleaner.app.clean.home.ui.HomeViewModel
 import com.d4rk.cleaner.app.clean.home.utils.helpers.groupDuplicatesByOriginal
@@ -112,21 +113,32 @@ fun TabsContent(
             SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(file.lastModified()))
         }
 
-        val filesByDate = if (tabs[page] == tabs.last()) {
-            filesByDateRaw.mapValues { (_, list) ->
-                groupDuplicatesByOriginal(list).flatten()
+        if (tabs[page] == tabs.last()) {
+            val filesByDate = filesByDateRaw.mapValues { (_, list) ->
+                groupDuplicatesByOriginal(list)
             }
-        } else filesByDateRaw
 
-        FilesByDateSection(
-            modifier = Modifier,
-            filesByDate = filesByDate,
-            fileSelectionStates = data.analyzeState.fileSelectionMap,
-            imageLoader = imageLoader,
-            onFileSelectionChange = viewModel::onFileSelectionChange,
-            onDateSelectionChange = { files, checked -> viewModel.onEvent(HomeEvent.ToggleSelectFilesForDate(files, checked)) },
-            originals = data.analyzeState.duplicateOriginals,
-            view = view
-        )
+            DuplicateGroupsSection(
+                modifier = Modifier,
+                filesByDate = filesByDate,
+                fileSelectionStates = data.analyzeState.fileSelectionMap,
+                imageLoader = imageLoader,
+                onFileSelectionChange = viewModel::onFileSelectionChange,
+                onDateSelectionChange = { files, checked -> viewModel.onEvent(HomeEvent.ToggleSelectFilesForDate(files, checked)) },
+                originals = data.analyzeState.duplicateOriginals,
+                view = view
+            )
+        } else {
+            FilesByDateSection(
+                modifier = Modifier,
+                filesByDate = filesByDateRaw,
+                fileSelectionStates = data.analyzeState.fileSelectionMap,
+                imageLoader = imageLoader,
+                onFileSelectionChange = viewModel::onFileSelectionChange,
+                onDateSelectionChange = { files, checked -> viewModel.onEvent(HomeEvent.ToggleSelectFilesForDate(files, checked)) },
+                originals = data.analyzeState.duplicateOriginals,
+                view = view
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `FileCard` to allow horizontal groups
- add `DuplicateGroupsSection` to show duplicates by original on one line
- switch duplicates tab to use the new layout

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9e103c0832da18a4e3ce8daec8f