### PR TITLE
Standardize snackbar dismissal on Home screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/actions/HomeEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/domain/actions/HomeEvent.kt
@@ -18,4 +18,5 @@ sealed class HomeEvent : UiEvent {
     object MoveSelectedToTrash : HomeEvent()
     data class SetDeleteForeverConfirmationDialogVisibility(val isVisible : Boolean) : HomeEvent()
     data class SetMoveToTrashConfirmationDialogVisibility(val isVisible : Boolean) : HomeEvent()
+    data object DismissSnackbar : HomeEvent()
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setLoading
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
@@ -86,6 +87,7 @@ class HomeViewModel(
             is HomeEvent.SetMoveToTrashConfirmationDialogVisibility -> setMoveToTrashConfirmationDialogVisibility(
                 isVisible = event.isVisible
             )
+            is HomeEvent.DismissSnackbar -> screenState.dismissSnackbar()
         }
     }
 


### PR DESCRIPTION
## Summary
- allow HomeScreen snackbar dismiss using `HomeEvent.DismissSnackbar`
- update HomeViewModel to handle snackbar dismiss events

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c06192908832da64b6c465e4c4e30