### PR TITLE
Add translations for delete duplicates setting

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -144,6 +144,7 @@
     <string name="summary_preference_settings_delete_invalid_media">حذف الصور التالفة</string>
     <string name="scanner">الماسح</string>
     <string name="clipboard_clean">تنظيف الحافظة</string>
+    <string name="summary_preference_settings_delete_duplicates">حذف الملفات المكررة أثناء التنظيف</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">طلب حذف الحزم [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Изтриване на повредени изображения</string>
     <string name="scanner">Скенер</string>
     <string name="clipboard_clean">Почистване на клипборда</string>
+    <string name="summary_preference_settings_delete_duplicates">Изтрийте дублиращи се файлове по време на почистване</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Заявка за изтриване на пакети [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">ত্রুটিপূর্ণ ছবি মুছুন</string>
     <string name="scanner">স্ক্যানার</string>
     <string name="clipboard_clean">ক্লিপবোর্ড পরিষ্কার করুন</string>
+    <string name="summary_preference_settings_delete_duplicates">পরিষ্কারের সময় সদৃশ ফাইলগুলি মুছুন</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">প্যাকেজ মোছার অনুরোধ [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Beschädigte Bilder löschen</string>
     <string name="scanner">Scanner</string>
     <string name="clipboard_clean">Zwischenablage bereinigen</string>
+    <string name="summary_preference_settings_delete_duplicates">Löschen Sie doppelte Dateien während der Reinigung</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Löschen von Paketen anfordern [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -138,6 +138,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Eliminar imágenes corruptas</string>
     <string name="scanner">Escáner</string>
     <string name="clipboard_clean">Limpiar portapapeles</string>
+    <string name="summary_preference_settings_delete_duplicates">Eliminar archivos duplicados durante la limpieza</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar eliminación de paquetes [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -138,6 +138,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Eliminar imágenes corruptas</string>
     <string name="scanner">Escáner</string>
     <string name="clipboard_clean">Limpiar portapapeles</string>
+    <string name="summary_preference_settings_delete_duplicates">Eliminar archivos duplicados durante la limpieza</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar eliminación de paquetes [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Burahin ang mga sirang imahe</string>
     <string name="scanner">Scanner</string>
     <string name="clipboard_clean">Linisin ang clipboard</string>
+    <string name="summary_preference_settings_delete_duplicates">Tanggalin ang mga dobleng file sa panahon ng paglilinis</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Humiling ng pagbura ng mga package [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -139,6 +139,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Supprimer les images corrompues</string>
     <string name="scanner">Scanner</string>
     <string name="clipboard_clean">Nettoyer le presse-papiers</string>
+    <string name="summary_preference_settings_delete_duplicates">Supprimer les fichiers en double pendant le nettoyage</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Demander la suppression de paquets [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">भ्रष्ट छवियां हटाएं</string>
     <string name="scanner">स्कैनर</string>
     <string name="clipboard_clean">क्लिपबोर्ड साफ़ करें</string>
+    <string name="summary_preference_settings_delete_duplicates">सफाई के दौरान डुप्लिकेट फ़ाइलों को हटाएं</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">पैकेज हटाने का अनुरोध करें [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Sérült képek törlése</string>
     <string name="scanner">Kereső</string>
     <string name="clipboard_clean">Vágólap tisztítása</string>
+    <string name="summary_preference_settings_delete_duplicates">Törölje a duplikált fájlokat a tisztítás során</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Csomagok törlésének kérése [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Hapus gambar yang rusak</string>
     <string name="scanner">Pemindai</string>
     <string name="clipboard_clean">Bersihkan clipboard</string>
+    <string name="summary_preference_settings_delete_duplicates">Hapus file duplikat selama pembersihan</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Minta hapus paket [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -138,6 +138,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Elimina immagini corrotte</string>
     <string name="scanner">Scanner</string>
     <string name="clipboard_clean">Pulisci appunti</string>
+    <string name="summary_preference_settings_delete_duplicates">Elimina file duplicati durante la pulizia</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Richiedi eliminazione pacchetti [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">破損した画像を削除します</string>
     <string name="scanner">スキャナー</string>
     <string name="clipboard_clean">クリップボードをクリア</string>
+    <string name="summary_preference_settings_delete_duplicates">クリーニング中に複製ファイルを削除します</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">パッケージ削除のリクエスト [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">손상된 이미지를 삭제합니다.</string>
     <string name="scanner">스캐너</string>
     <string name="clipboard_clean">클립보드 정리</string>
+    <string name="summary_preference_settings_delete_duplicates">청소 중에 중복 파일을 삭제하십시오</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">패키지 삭제 요청 [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -140,6 +140,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Usuń uszkodzone obrazy</string>
     <string name="scanner">Skaner</string>
     <string name="clipboard_clean">Wyczyść schowek</string>
+    <string name="summary_preference_settings_delete_duplicates">Usuń zduplikowane pliki podczas czyszczenia</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Żądanie usunięcia pakietów [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -138,6 +138,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Excluir imagens corrompidas</string>
     <string name="scanner">Scanner</string>
     <string name="clipboard_clean">Limpar área de transferência</string>
+    <string name="summary_preference_settings_delete_duplicates">Excluir arquivos duplicados durante a limpeza</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar exclusão de pacotes [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -138,6 +138,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Șterge imaginile corupte</string>
     <string name="scanner">Scaner</string>
     <string name="clipboard_clean">Curăță clipboard</string>
+    <string name="summary_preference_settings_delete_duplicates">Ștergeți fișierele duplicate în timpul curățării</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Solicită ștergerea pachetelor [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -140,6 +140,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Удалить поврежденные изображения</string>
     <string name="scanner">Сканер</string>
     <string name="clipboard_clean">Очистить буфер обмена</string>
+    <string name="summary_preference_settings_delete_duplicates">Удалить дубликаты файлов во время очистки</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Запросить удаление пакетов [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Radera korrupta bilder</string>
     <string name="scanner">Skanner</string>
     <string name="clipboard_clean">Rensa urklipp</string>
+    <string name="summary_preference_settings_delete_duplicates">Ta bort duplicerade filer under rengöring</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Begär radering av paket [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">ลบรูปภาพที่เสียหาย</string>
     <string name="scanner">สแกนเนอร์</string>
     <string name="clipboard_clean">ล้างคลิปบอร์ด</string>
+    <string name="summary_preference_settings_delete_duplicates">ลบไฟล์ที่ซ้ำกันระหว่างการทำความสะอาด</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">ร้องขอการลบแพ็คเกจ [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Bozuk görüntüleri sil</string>
     <string name="scanner">Tarayıcı</string>
     <string name="clipboard_clean">Panoyu temizle</string>
+    <string name="summary_preference_settings_delete_duplicates">Temizlik sırasında yinelenen dosyaları silin</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Paket silme isteği [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -140,6 +140,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Видалення пошкоджених зображень</string>
     <string name="scanner">Сканер</string>
     <string name="clipboard_clean">Очищення буфера обміну</string>
+    <string name="summary_preference_settings_delete_duplicates">Видалити повторювані файли під час очищення</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Запит на видалення пакетів [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -136,6 +136,7 @@
     <string name="summary_preference_settings_delete_invalid_media">خراب تصاویر حذف کریں</string>
     <string name="scanner">اسکینر</string>
     <string name="clipboard_clean">کلپ بورڈ صاف کریں</string>
+    <string name="summary_preference_settings_delete_duplicates">صفائی کے دوران ڈپلیکیٹ فائلوں کو حذف کریں</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">پیکیجز حذف کرنے کی درخواست کریں [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">Xóa hình ảnh bị hỏng</string>
     <string name="scanner">Trình quét</string>
     <string name="clipboard_clean">Dọn dẹp bảng tạm</string>
+    <string name="summary_preference_settings_delete_duplicates">Xóa các tệp trùng lặp trong khi làm sạch</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">Yêu cầu xóa gói [REQUEST_DELETE_PACKAGES]</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -134,6 +134,7 @@
     <string name="summary_preference_settings_delete_invalid_media">刪除損毀的圖片</string>
     <string name="scanner">掃描器</string>
     <string name="clipboard_clean">清理剪貼簿</string>
+    <string name="summary_preference_settings_delete_duplicates">清潔過程中刪除重複文件</string>
 
     <!-- Permissions -->
     <string name="request_delete_packages">請求刪除套件 [REQUEST_DELETE_PACKAGES]</string>


### PR DESCRIPTION
## Summary
- translate "Delete duplicate files during cleaning" string to all available languages

## Testing
- `./gradlew test` *(fails: process stuck)*
- `./gradlew tasks --all` *(fails: process stuck)*

------
https://chatgpt.com/codex/tasks/task_e_685c0cc8e9f4832d8406e167192b1f70