### PR TITLE
Fix display of empty folders

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -319,11 +319,16 @@ class HomeViewModel(
             }
         }
 
-        if (emptyFolders.isNotEmpty() && preferences[ExtensionsConstants.EMPTY_FOLDERS] == true) {
-            filesMap[baseFinalTitles[8]] = emptyFolders.toMutableList()
+        val emptyFoldersTitle = baseFinalTitles[8]
+        if (preferences[ExtensionsConstants.EMPTY_FOLDERS] == true) {
+            filesMap[emptyFoldersTitle] = emptyFolders.toMutableList()
         }
 
-        return filesMap.filter { it.value.isNotEmpty() } to duplicateOriginals
+        val filteredMap = filesMap.filter { (key, value) ->
+            value.isNotEmpty() || (key == emptyFoldersTitle && preferences[ExtensionsConstants.EMPTY_FOLDERS] == true)
+        }
+
+        return filteredMap to duplicateOriginals
     }
 
     private fun findDuplicateGroups(files: List<File>): List<List<File>> {


### PR DESCRIPTION
## Summary
- include empty folder category even when it has no items

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c66148c68832d919fb25d24d1e259