### PR TITLE
Share singleton ImageLoader

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
@@ -7,6 +7,11 @@ import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.cleaner.core.di.initializeKoin
@@ -16,13 +21,14 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
 import org.koin.android.ext.android.getKoin
 
-class Cleaner : BaseCoreManager() {
+class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory {
     private var currentActivity : Activity? = null
 
     private val adsCoreManager : AdsCoreManager by lazy { getKoin().get<AdsCoreManager>() }
 
     override fun onCreate() {
         initializeKoin(context = this)
+        SingletonImageLoader.setSafe { newImageLoader(this) }
         super.onCreate()
         registerActivityLifecycleCallbacks(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(observer = this)
@@ -45,5 +51,19 @@ class Cleaner : BaseCoreManager() {
 
     override fun onActivityStarted(activity : Activity) {
         currentActivity = activity
+    }
+
+    override fun newImageLoader(context: android.content.Context): ImageLoader {
+        return ImageLoader.Builder(context)
+            .memoryCache {
+                MemoryCache.Builder().maxSizePercent(context = context, percent = 0.24).build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache"))
+                    .maxSizePercent(percent = 0.02)
+                    .build()
+            }
+            .build()
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/DuplicateGroupsSection.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/DuplicateGroupsSection.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
+import coil3.imageLoader
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
 import java.io.File
@@ -28,7 +28,6 @@ fun DuplicateGroupsSection(
     modifier : Modifier ,
     filesByDate : Map<String , List<List<File>>> ,
     fileSelectionStates : Map<File , Boolean> ,
-    imageLoader : ImageLoader ,
     onFileSelectionChange : (File , Boolean) -> Unit ,
     onDateSelectionChange: (List<File>, Boolean) -> Unit ,
     originals: Set<File> = emptySet(),
@@ -37,6 +36,7 @@ fun DuplicateGroupsSection(
     val context = LocalContext.current
     val windowInfo = LocalWindowInfo.current
     val density = LocalDensity.current
+    val imageLoader = LocalContext.current.imageLoader
     val columns = if (ScreenHelper.isTablet(context = context)) 6 else 3
     val containerWidth = with(density) { windowInfo.containerSize.width.toDp() }
     val cardSize = (containerWidth - SizeConstants.SmallSize * 2) / columns
@@ -69,7 +69,6 @@ fun DuplicateGroupsSection(
                     group.forEach { file ->
                         FileCard(
                             file = file,
-                            imageLoader = imageLoader,
                             isChecked = fileSelectionStates[file] == true,
                             onCheckedChange = { checked -> onFileSelectionChange(file, checked) },
                             isOriginal = file in originals,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
-import coil3.ImageLoader
+import coil3.imageLoader
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -51,13 +51,14 @@ import java.io.File
 
 @Composable
 fun FileCard(
-    file : File , imageLoader : ImageLoader , onCheckedChange : (Boolean) -> Unit ,
+    file : File , onCheckedChange : (Boolean) -> Unit ,
     isChecked : Boolean ,
     isOriginal: Boolean = false,
     view : View ,
     modifier : Modifier = Modifier ,
 ) {
     val isFolder : Boolean = file.isDirectory
+    val imageLoader = LocalContext.current.imageLoader
     val context : Context = LocalContext.current
     val fileExtension : String = remember(key1 = file.name) { getFileExtension(file.name) }
 
@@ -99,7 +100,6 @@ fun FileCard(
                             contentScale = ContentScale.FillWidth ,
                             contentDescription = file.name ,
                             modifier = Modifier.fillMaxWidth() ,
-                            imageLoader = imageLoader ,
                         )
                     }
 
@@ -108,7 +108,7 @@ fun FileCard(
                             ImageRequest.Builder(context = context).data(data = file).decoderFactory { result , options , _ ->
                                 VideoFrameDecoder(source = result.source , options = options)
                             }.videoFramePercent(framePercent = 0.5).crossfade(enable = true).build()
-                        } , imageLoader = imageLoader , contentDescription = file.name , contentScale = ContentScale.Crop , modifier = Modifier.fillMaxSize())
+                        } , contentDescription = file.name , contentScale = ContentScale.Crop , modifier = Modifier.fillMaxSize())
                     }
 
                     in officeExtensions -> {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FilesByDateSection.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FilesByDateSection.kt
@@ -5,7 +5,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import coil3.ImageLoader
+import androidx.compose.ui.platform.LocalContext
+import coil3.imageLoader
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -15,12 +16,12 @@ fun FilesByDateSection(
     modifier : Modifier ,
     filesByDate : Map<String , List<File>> ,
     fileSelectionStates : Map<File , Boolean> ,
-    imageLoader : ImageLoader ,
     onFileSelectionChange : (File , Boolean) -> Unit ,
     onDateSelectionChange: (List<File>, Boolean) -> Unit ,
     originals: Set<File> = emptySet(),
     view : View ,
 ) {
+    val imageLoader = LocalContext.current.imageLoader
     LazyColumn(
         modifier = modifier.fillMaxSize()
     ) {
@@ -40,7 +41,6 @@ fun FilesByDateSection(
                 item(key = "$date-grid") {
                     FilesGrid(
                         files = files ,
-                        imageLoader = imageLoader ,
                         fileSelectionStates = fileSelectionStates ,
                         onFileSelectionChange = onFileSelectionChange ,
                         originals = originals ,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FilesGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FilesGrid.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import coil3.ImageLoader
+import coil3.imageLoader
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NonLazyGrid
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
@@ -16,13 +16,13 @@ import java.io.File
 @Composable
 fun FilesGrid(
     files : List<File> ,
-    imageLoader : ImageLoader ,
     fileSelectionStates : Map<File , Boolean> ,
     onFileSelectionChange : (File , Boolean) -> Unit ,
     originals: Set<File> = emptySet(),
     view : View ,
 ) {
     val columns : Int = if (ScreenHelper.isTablet(context = LocalContext.current)) 6 else 3
+    val imageLoader = LocalContext.current.imageLoader
 
     Box(
         modifier = Modifier.fillMaxSize()
@@ -33,7 +33,6 @@ fun FilesGrid(
             val file : File = files[index]
             FileCard(
                 file = file,
-                imageLoader = imageLoader,
                 isChecked = fileSelectionStates[file] == true,
                 onCheckedChange = { isChecked -> onFileSelectionChange(file, isChecked) },
                 isOriginal = file in originals,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
@@ -26,7 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
+import androidx.compose.ui.platform.LocalContext
+import coil3.imageLoader
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
@@ -45,10 +46,11 @@ import java.util.Locale
 
 @Composable
 fun TabsContent(
-    groupedFiles : Map<String , List<File>> , imageLoader : ImageLoader , viewModel : HomeViewModel , view : View , coroutineScope : CoroutineScope , data : UiHomeModel
+    groupedFiles : Map<String , List<File>> , viewModel : HomeViewModel , view : View , coroutineScope : CoroutineScope , data : UiHomeModel
 ) {
     val tabs : List<String> = groupedFiles.keys.toList()
     val pagerState : PagerState = rememberPagerState(pageCount = { tabs.size })
+    val imageLoader = LocalContext.current.imageLoader
 
     Row(
         modifier = Modifier.fillMaxWidth() , verticalAlignment = Alignment.CenterVertically
@@ -125,7 +127,6 @@ fun TabsContent(
                 modifier = Modifier,
                 filesByDate = filesByDate,
                 fileSelectionStates = data.analyzeState.fileSelectionMap,
-                imageLoader = imageLoader,
                 onFileSelectionChange = viewModel::onFileSelectionChange,
                 onDateSelectionChange = { files, checked -> viewModel.onEvent(HomeEvent.ToggleSelectFilesForDate(files, checked)) },
                 originals = data.analyzeState.duplicateOriginals,
@@ -136,7 +137,6 @@ fun TabsContent(
                 modifier = Modifier,
                 filesByDate = filesByDateRaw,
                 fileSelectionStates = data.analyzeState.fileSelectionMap,
-                imageLoader = imageLoader,
                 onFileSelectionChange = viewModel::onFileSelectionChange,
                 onDateSelectionChange = { files, checked -> viewModel.onEvent(HomeEvent.ToggleSelectFilesForDate(files, checked)) },
                 originals = data.analyzeState.duplicateOriginals,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -14,7 +14,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import coil3.ImageLoader
+import androidx.compose.ui.platform.LocalContext
+import coil3.imageLoader
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
@@ -32,12 +33,12 @@ import java.io.File
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun AnalyzeScreen(
-    imageLoader: ImageLoader,
     view: View,
     viewModel: HomeViewModel,
     data: UiHomeModel,
 ) {
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
+    val imageLoader = LocalContext.current.imageLoader
     val hasSelectedFiles: Boolean = data.analyzeState.selectedFilesCount > 0
     val groupedFiles: Map<String, List<File>> = data.analyzeState.groupedFiles
 
@@ -62,7 +63,6 @@ fun AnalyzeScreen(
                     if (groupedFiles.isNotEmpty()) {
                         TabsContent(
                             groupedFiles = groupedFiles,
-                            imageLoader = imageLoader,
                             viewModel = viewModel,
                             view = view,
                             coroutineScope = coroutineScope,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
@@ -18,16 +18,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
-import coil3.disk.DiskCache
-import coil3.disk.directory
-import coil3.memory.MemoryCache
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -46,16 +41,6 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
     val view: View = LocalView.current
     val viewModel: HomeViewModel = koinViewModel()
     val uiState: UiStateScreen<UiHomeModel> by viewModel.uiState.collectAsState()
-
-    val imageLoader: ImageLoader = remember {
-        ImageLoader.Builder(context = context).memoryCache {
-            MemoryCache.Builder().maxSizePercent(context = context, percent = 0.24).build()
-        }.diskCache {
-            DiskCache.Builder()
-                .directory(directory = context.cacheDir.resolve(relative = "image_cache"))
-                .maxSizePercent(percent = 0.02).build()
-        }.build()
-    }
 
     LaunchedEffect(key1 = true) {
         if (!PermissionsHelper.hasStoragePermissions(context)) {
@@ -104,7 +89,6 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
                     uiState.data?.let { data ->
                         key(data.analyzeState.fileTypesData) {
                             AnalyzeScreen(
-                                imageLoader = imageLoader,
                                 view = view,
                                 viewModel = viewModel,
                                 data = data

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
@@ -18,10 +18,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
-import coil3.ImageLoader
-import coil3.disk.DiskCache
-import coil3.disk.directory
-import coil3.memory.MemoryCache
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
@@ -49,14 +45,6 @@ fun TrashScreen(activity : TrashActivity) {
     val context = LocalContext.current
     val uiStateScreen : UiStateScreen<UiTrashModel> by viewModel.uiState.collectAsState()
 
-    val imageLoader : ImageLoader = remember {
-        ImageLoader.Builder(context).memoryCache {
-            MemoryCache.Builder().maxSizePercent(context = context , percent = 0.24).build()
-        }.diskCache {
-            DiskCache.Builder().directory(context.cacheDir.resolve(relative = "image_cache")).maxSizePercent(percent = 0.02).build()
-        }.build()
-    }
-
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.trash) , onBackClicked = { activity.finish() }) { paddingValues ->
         ScreenStateHandler(screenState = uiStateScreen , onLoading = {
@@ -82,7 +70,6 @@ fun TrashScreen(activity : TrashActivity) {
                         height = Dimension.fillToConstraints
                     } ,
                     trashFiles = trashModel.trashFiles ,
-                    imageLoader = imageLoader ,
                     uiState = trashModel ,
                     viewModel = viewModel ,
                     view = view ,
@@ -119,7 +106,6 @@ fun TrashScreen(activity : TrashActivity) {
 fun TrashItemsList(
     modifier : Modifier ,
     trashFiles : List<File> ,
-    imageLoader : ImageLoader ,
     uiState : UiTrashModel ,
     viewModel : TrashViewModel ,
     view : View ,
@@ -134,7 +120,6 @@ fun TrashItemsList(
         modifier = modifier ,
         filesByDate = filesByDate ,
         fileSelectionStates = uiState.fileSelectionStates ,
-        imageLoader = imageLoader ,
         onFileSelectionChange = { file , isChecked ->
             viewModel.onEvent(TrashEvent.OnFileSelectionChange(file , isChecked))
         } ,


### PR DESCRIPTION
## Summary
- configure a singleton `ImageLoader` in `Cleaner`
- remove screen-specific loaders and use the shared instance
- wire `imageLoader` via `LocalContext` in all image-related components

## Testing
- `./gradlew help` *(fails: Starting a Gradle Daemon)*
- `./gradlew test` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f34e368832d810bb5a587e7e3fe