### PR TITLE
Fix empty folder tab showing nothing

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/tabs/TabsContent.kt
@@ -50,6 +50,11 @@ fun TabsContent(
 ) {
     val tabs : List<String> = groupedFiles.keys.toList()
     val pagerState : PagerState = rememberPagerState(pageCount = { tabs.size })
+    // Title for the duplicates tab as defined in resources. Used to detect if
+    // a duplicates page exists in the provided map of tabs.
+    val duplicatesTabTitle =
+        data.analyzeState.fileTypesData.fileTypesTitles.getOrElse(10) { "Duplicates" }
+    val hasDuplicatesTab = groupedFiles.containsKey(duplicatesTabTitle)
     val imageLoader = LocalContext.current.imageLoader
 
     Row(
@@ -116,7 +121,7 @@ fun TabsContent(
             SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(file.lastModified()))
         }
 
-        if (tabs[page] == tabs.last()) {
+        if (hasDuplicatesTab && tabs[page] == duplicatesTabTitle) {
             val duplicateGroups = groupDuplicatesByOriginal(filesForCurrentPage)
             val filesByDate = duplicateGroups.groupBy { group ->
                 val firstFile = group.first()


### PR DESCRIPTION
## Summary
- detect duplicates tab by its localized title rather than assuming it's last
- avoid using duplicates layout for the empty folders page when duplicates are disabled

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c76a2a7b8832d8b54bd15b0ceff15