### PR TITLE
Remove unused dismissal tracking

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/CleanupDismissReceiver.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/CleanupDismissReceiver.kt
@@ -13,8 +13,9 @@ class CleanupDismissReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         CoroutineScope(Dispatchers.IO).launch {
             val store = DataStore(context)
-            store.saveLastCleanupNotificationDismissed(System.currentTimeMillis())
-            store.saveCleanupNotificationSnoozedUntil(System.currentTimeMillis() + 3.days.inWholeMilliseconds)
+            store.saveCleanupNotificationSnoozedUntil(
+                System.currentTimeMillis() + 3.days.inWholeMilliseconds
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -59,16 +59,6 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
-    private val lastCleanupNotificationDismissedKey = longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_LAST_CLEANUP_NOTIFICATION_DISMISSED)
-    val lastCleanupNotificationDismissed: Flow<Long> = dataStore.data.map { prefs -> // FIXME: Property "lastCleanupNotificationDismissed" is never used
-        prefs[lastCleanupNotificationDismissedKey] ?: 0L
-    }
-
-    suspend fun saveLastCleanupNotificationDismissed(timestamp: Long) {
-        dataStore.edit { prefs ->
-            prefs[lastCleanupNotificationDismissedKey] = timestamp
-        }
-    }
 
     private val cleanupNotificationSnoozedUntilKey =
         longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_CLEANUP_NOTIFICATION_SNOOZED_UNTIL)
@@ -87,11 +77,6 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         prefs[reminderFrequencyKey] ?: 7
     }
 
-    suspend fun saveCleanupReminderFrequencyDays(days: Int) { // FIXME: Function "saveCleanupReminderFrequencyDays" is never used
-        dataStore.edit { prefs ->
-            prefs[reminderFrequencyKey] = days
-        }
-    }
 
     private val trashFileOriginalPathsKey = stringSetPreferencesKey(AppDataStoreConstants.DATA_STORE_TRASH_FILE_ORIGINAL_PATHS)
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -9,7 +9,6 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_TRASH_SIZE = "trash_size"
     const val DATA_STORE_LAST_CLEANUP_NOTIFICATION_SHOWN = "last_cleanup_notif_shown"
     const val DATA_STORE_LAST_CLEANUP_NOTIFICATION_CLICKED = "last_cleanup_notif_clicked"
-    const val DATA_STORE_LAST_CLEANUP_NOTIFICATION_DISMISSED = "last_cleanup_notif_dismissed"
     const val DATA_STORE_CLEANUP_NOTIFICATION_SNOOZED_UNTIL = "cleanup_notif_snoozed_until"
     const val DATA_STORE_CLEANUP_REMINDER_FREQUENCY_DAYS = "cleanup_reminder_frequency_days"
     const val DATA_STORE_PERMISSION_STORAGE_GRANTED = "permission_storage_granted"


### PR DESCRIPTION
## Summary
- clean up unused dismissal timestamp
- stop calling removed function in `CleanupDismissReceiver`

## Testing
- `./gradlew assembleDebug --no-daemon --max-workers=1 | tail -n 20` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686248b1befc832daf9429235d449db5