### PR TITLE
Add notification strings translations

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">آخر منظف أندرويد هتحتاجه لاستخدامك اليومي!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">قد يحتاج هاتفك إلى تنظيف</string>
+    <string name="cleanup_notification_default">اضغط للفحص وتفريغ المساحة.</string>
+    <string name="scan_now">افحص الآن</string>
+    <string name="cleanup_title_variant1">فحص سريع بس</string>
+    <string name="cleanup_title_variant2">حاسس المساحة ضيقة؟</string>
+    <string name="cleanup_title_variant3">المنظف هنا لو محتاجه</string>
+    <string name="cleanup_title_variant4">تليفونك مشغول اليومين دول</string>
+    <string name="cleanup_title_variant5">عايز انتعاشة خفيفة؟</string>
+    <string name="cleanup_storage_very_high">المساحة ضيقة جدًا. عايز تنظف شوية؟</string>
+    <string name="cleanup_storage_high">انت على %1$d%% — اضغط للفحص لو حبيت.</string>
+    <string name="cleanup_storage_medium">فيه حاجات كتير هنا. الفحص ممكن يفيد.</string>
+    <string name="cleanup_storage_ok">المساحة عندك تمام!</string>
+    <string name="cleanup_notification_last_scan_format">آخر فحص: من %1$d يوم. %2$s</string>
+    <string name="cleanup_notification_never_scanned">لسه ما فحصتش تليفونك. اضغط للبدء.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">أهلًا بيك في كلينر!</string>
     <string name="onboarding_welcome_description">يلا بينا نعمل إعداد سريع ونبدأ نفضي مساحة.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Последният Android Cleaner, от който ще се нуждаете за ежедневна употреба!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Вашият телефон може да има нужда от почистване</string>
+    <string name="cleanup_notification_default">Докоснете за сканиране и освобождаване на място.</string>
+    <string name="scan_now">Сканирай сега</string>
+    <string name="cleanup_title_variant1">Само една бърза проверка</string>
+    <string name="cleanup_title_variant2">Недостига ли място?</string>
+    <string name="cleanup_title_variant3">Cleaner е тук, ако имате нужда</string>
+    <string name="cleanup_title_variant4">Телефонът ви беше зает напоследък</string>
+    <string name="cleanup_title_variant5">Време за леко освежаване?</string>
+    <string name="cleanup_storage_very_high">Паметта е доста запълнена. Искате ли да почистите малко?</string>
+    <string name="cleanup_storage_high">Вие сте на %1$d%% — докоснете за сканиране при нужда.</string>
+    <string name="cleanup_storage_medium">Има доста неща тук. Сканиране може да помогне.</string>
+    <string name="cleanup_storage_ok">Паметта ви изглежда добре!</string>
+    <string name="cleanup_notification_last_scan_format">Последно сканиране: преди %1$d дни. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Все още не сте сканирали телефона си. Докоснете, за да започнете.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Добре дошли в Cleaner!</string>
     <string name="onboarding_welcome_description">Нека да преминем през бърза настройка и да започнем да освобождаваме място.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">দৈনন্দিন ব্যবহারের জন্য আপনার প্রয়োজনীয় শেষ অ্যান্ড্রয়েড ক্লিনার!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">আপনার ফোনে হয়তো পরিষ্কার করা দরকার</string>
+    <string name="cleanup_notification_default">স্পেস খালি করতে স্ক্যান করতে ট্যাপ করুন।</string>
+    <string name="scan_now">এখন স্ক্যান করুন</string>
+    <string name="cleanup_title_variant1">একটি দ্রুত চেক-ইন মাত্র</string>
+    <string name="cleanup_title_variant2">জায়গা টাইট লাগছে?</string>
+    <string name="cleanup_title_variant3">প্রয়োজন হলে ক্লিনার এখানে</string>
+    <string name="cleanup_title_variant4">আপনার ফোন সাম্প্রতিককালে ব্যস্ত ছিল</string>
+    <string name="cleanup_title_variant5">একটু হালকা রিফ্রেশ করবেন?</string>
+    <string name="cleanup_storage_very_high">স্টোরেজ খুব টাইট। একটু পরিষ্কার করতে চান?</string>
+    <string name="cleanup_storage_high">আপনি %1$d%% এ আছেন — প্রয়োজনে স্ক্যান করতে ট্যাপ করুন।</string>
+    <string name="cleanup_storage_medium">এখানে অনেক কিছু আছে। একটি স্ক্যান সাহায্য করতে পারে।</string>
+    <string name="cleanup_storage_ok">আপনার স্টোরেজ ঠিক আছে!</string>
+    <string name="cleanup_notification_last_scan_format">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</string>
+    <string name="cleanup_notification_never_scanned">আপনি এখনও ফোন স্ক্যান করেননি। শুরু করতে ট্যাপ করুন।</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">ক্লিনারে স্বাগতম!</string>
     <string name="onboarding_welcome_description">আসুন একটি দ্রুত সেটআপ সম্পন্ন করি এবং জায়গা খালি করা শুরু করি।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Der letzte Android-Cleaner, den Sie für den täglichen Gebrauch jemals brauchen werden!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Dein Handy braucht vielleicht eine Reinigung</string>
+    <string name="cleanup_notification_default">Tippe zum Scannen und Speicher freigeben.</string>
+    <string name="scan_now">Jetzt scannen</string>
+    <string name="cleanup_title_variant1">Nur ein kurzer Check</string>
+    <string name="cleanup_title_variant2">Wenig Platz übrig?</string>
+    <string name="cleanup_title_variant3">Cleaner ist da, falls du ihn brauchst</string>
+    <string name="cleanup_title_variant4">Dein Telefon war in letzter Zeit viel beschäftigt</string>
+    <string name="cleanup_title_variant5">Zeit für ein kleines Auffrischen?</string>
+    <string name="cleanup_storage_very_high">Speicher ist sehr knapp. Möchtest du ein bisschen aufräumen?</string>
+    <string name="cleanup_storage_high">Du bist bei %1$d%% — tippe zum Scannen, wenn nötig.</string>
+    <string name="cleanup_storage_medium">Hier gibt es einiges. Ein Scan könnte helfen.</string>
+    <string name="cleanup_storage_ok">Dein Speicher sieht gut aus!</string>
+    <string name="cleanup_notification_last_scan_format">Letzter Scan: vor %1$d Tagen. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Du hast dein Handy noch nicht gescannt. Tippe, um zu starten.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Willkommen bei Cleaner!</string>
     <string name="onboarding_welcome_description">Lassen Sie uns eine schnelle Einrichtung durchgehen und Speicherplatz freigeben.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">¡El último limpiador de Android que necesitarás para el uso diario!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Puede que tu teléfono necesite una limpieza</string>
+    <string name="cleanup_notification_default">Toca para escanear y liberar espacio.</string>
+    <string name="scan_now">Escanear ahora</string>
+    <string name="cleanup_title_variant1">Solo una rápida revisión</string>
+    <string name="cleanup_title_variant2">¿Falta espacio?</string>
+    <string name="cleanup_title_variant3">Cleaner está aquí si lo necesitas</string>
+    <string name="cleanup_title_variant4">Tu teléfono ha estado ocupado últimamente</string>
+    <string name="cleanup_title_variant5">¿Hora de una ligera renovación?</string>
+    <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
+    <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si lo necesitas.</string>
+    <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
+    <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
+    <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">¡Bienvenido a Cleaner!</string>
     <string name="onboarding_welcome_description">Vamos a realizar una configuración rápida y empezar a liberar espacio.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">¡El último Limpiador de Android que necesitarás para el uso diario!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Tal vez tu teléfono necesite una limpieza</string>
+    <string name="cleanup_notification_default">Toca para escanear y liberar espacio.</string>
+    <string name="scan_now">Escanear ahora</string>
+    <string name="cleanup_title_variant1">Solo un rápido chequeo</string>
+    <string name="cleanup_title_variant2">¿El espacio se siente reducido?</string>
+    <string name="cleanup_title_variant3">Cleaner está aquí si lo necesitas</string>
+    <string name="cleanup_title_variant4">Tu teléfono ha estado ocupado últimamente</string>
+    <string name="cleanup_title_variant5">¿Hora de un ligero refresco?</string>
+    <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
+    <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si es necesario.</string>
+    <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
+    <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
+    <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">¡Bienvenido/a a Cleaner!</string>
     <string name="onboarding_welcome_description">Vamos a realizar una configuración rápida y empezar a liberar espacio.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Ang huling Android Cleaner na kakailanganin mo para sa pang-araw-araw na paggamit!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Baka kailangan linisin ang iyong telepono</string>
+    <string name="cleanup_notification_default">Tapikin para i-scan at magpalaya ng espasyo.</string>
+    <string name="scan_now">I-scan ngayon</string>
+    <string name="cleanup_title_variant1">Mabilisang check lang</string>
+    <string name="cleanup_title_variant2">Mabigat ba ang espasyo?</string>
+    <string name="cleanup_title_variant3">Nandito ang Cleaner kung kailangan mo</string>
+    <string name="cleanup_title_variant4">Abala ang iyong telepono kamakailan</string>
+    <string name="cleanup_title_variant5">Panahon na ba para sa light refresh?</string>
+    <string name="cleanup_storage_very_high">Sobrang sikip ng storage. Gusto mo bang linisin ng kaunti?</string>
+    <string name="cleanup_storage_high">Nasa %1$d%% ka na — tapikin para mag-scan kung kailangan.</string>
+    <string name="cleanup_storage_medium">Maraming laman dito. Puwedeng makatulong ang scan.</string>
+    <string name="cleanup_storage_ok">Ayos naman ang storage mo!</string>
+    <string name="cleanup_notification_last_scan_format">Huling scan: %1$d araw na ang nakalipas. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Hindi mo pa na-scan ang iyong telepono. Tapikin para magsimula.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Maligayang pagdating sa Cleaner!</string>
     <string name="onboarding_welcome_description">Dumaan tayo sa mabilisang setup at simulan nang magbakante ng espasyo.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Le dernier nettoyeur Android dont vous aurez besoin au quotidien !</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Votre téléphone a peut-être besoin d’un nettoyage</string>
+    <string name="cleanup_notification_default">Appuyez pour analyser et libérer de l’espace.</string>
+    <string name="scan_now">Analyser maintenant</string>
+    <string name="cleanup_title_variant1">Juste une petite vérification</string>
+    <string name="cleanup_title_variant2">Manque de place ?</string>
+    <string name="cleanup_title_variant3">Cleaner est là si besoin</string>
+    <string name="cleanup_title_variant4">Votre téléphone a été bien occupé dernièrement</string>
+    <string name="cleanup_title_variant5">Envie d’un petit rafraîchissement ?</string>
+    <string name="cleanup_storage_very_high">Le stockage est vraiment plein. Un peu de ménage ?</string>
+    <string name="cleanup_storage_high">Vous êtes à %1$d%% — appuyez pour analyser si nécessaire.</string>
+    <string name="cleanup_storage_medium">Il y a pas mal de choses ici. Un scan pourrait aider.</string>
+    <string name="cleanup_storage_ok">Votre stockage est en bon état !</string>
+    <string name="cleanup_notification_last_scan_format">Dernière analyse : il y a %1$d jours. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Vous n’avez pas encore analysé votre téléphone. Appuyez pour commencer.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Bienvenue dans Cleaner !</string>
     <string name="onboarding_welcome_description">Procédons à une configuration rapide et commençons à libérer de l\'espace.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">आखिरी एंड्रॉइड क्लीनर जिसकी आपको रोज़मर्रा के इस्तेमाल के लिए कभी भी ज़रूरत पड़ेगी!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">आपके फ़ोन को शायद सफ़ाई की ज़रूरत है</string>
+    <string name="cleanup_notification_default">स्कैन करके जगह खाली करने के लिए टैप करें.</string>
+    <string name="scan_now">अभी स्कैन करें</string>
+    <string name="cleanup_title_variant1">बस एक त्वरित जाँच</string>
+    <string name="cleanup_title_variant2">जगह कम लग रही है?</string>
+    <string name="cleanup_title_variant3">जरूरत पड़े तो Cleaner यहीं है</string>
+    <string name="cleanup_title_variant4">आपका फ़ोन हाल में व्यस्त रहा है</string>
+    <string name="cleanup_title_variant5">थोड़ा रीफ़्रेश करने का समय?</string>
+    <string name="cleanup_storage_very_high">स्टोरेज बहुत कम है। थोड़ा साफ़ करना चाहेंगे?</string>
+    <string name="cleanup_storage_high">आप %1$d%% पर हैं — ज़रूरत हो तो स्कैन करने के लिए टैप करें.</string>
+    <string name="cleanup_storage_medium">यहाँ काफी चीजें हैं। स्कैन मदद कर सकता है.</string>
+    <string name="cleanup_storage_ok">आपका स्टोरेज ठीक दिख रहा है!</string>
+    <string name="cleanup_notification_last_scan_format">आख़िरी स्कैन: %1$d दिन पहले. %2$s</string>
+    <string name="cleanup_notification_never_scanned">आपने अभी तक फ़ोन स्कैन नहीं किया है। शुरू करने के लिए टैप करें.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">क्लीनर में आपका स्वागत है!</string>
     <string name="onboarding_welcome_description">चलिए एक त्वरित सेटअप से गुजरते हैं और जगह खाली करना शुरू करते हैं।</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Az utolsó Android Tisztító, amire valaha szükséged lesz a mindennapi használathoz!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Lehet, hogy a telefonodnak tisztításra van szüksége</string>
+    <string name="cleanup_notification_default">Érints rá a kereséshez és a hely felszabadításához.</string>
+    <string name="scan_now">Most keresés</string>
+    <string name="cleanup_title_variant1">Csak egy gyors ellenőrzés</string>
+    <string name="cleanup_title_variant2">Kevés a hely?</string>
+    <string name="cleanup_title_variant3">A Cleaner itt van, ha szükséged van rá</string>
+    <string name="cleanup_title_variant4">A telefonod mostanában elfoglalt volt</string>
+    <string name="cleanup_title_variant5">Ideje egy kis felfrissítésnek?</string>
+    <string name="cleanup_storage_very_high">Nagyon szűkös a tárhely. Szeretnél kicsit takarítani?</string>
+    <string name="cleanup_storage_high">Már %1$d%%-n állsz — érints rá a kereséshez, ha szükséges.</string>
+    <string name="cleanup_storage_medium">Elég sok minden van itt. Egy keresés segíthet.</string>
+    <string name="cleanup_storage_ok">A tárhelyed rendben van!</string>
+    <string name="cleanup_notification_last_scan_format">Utolsó keresés: %1$d napja. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Még nem vizsgáltad át a telefonod. Kezdéshez érints ide.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Üdvözlünk a Cleanerben!</string>
     <string name="onboarding_welcome_description">Vegyünk végig egy gyors beállítást, és kezdjünk el helyet felszabadítani.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Pembersih Android terakhir yang akan Anda perlukan untuk penggunaan sehari-hari!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Ponsel Anda mungkin perlu dibersihkan</string>
+    <string name="cleanup_notification_default">Ketuk untuk memindai dan mengosongkan ruang.</string>
+    <string name="scan_now">Pindai sekarang</string>
+    <string name="cleanup_title_variant1">Hanya cek cepat</string>
+    <string name="cleanup_title_variant2">Ruang terasa sempit?</string>
+    <string name="cleanup_title_variant3">Cleaner siap jika diperlukan</string>
+    <string name="cleanup_title_variant4">Ponsel Anda sibuk belakangan ini</string>
+    <string name="cleanup_title_variant5">Saatnya menyegarkan sedikit?</string>
+    <string name="cleanup_storage_very_high">Penyimpanan sangat penuh. Ingin bersih-bersih?</string>
+    <string name="cleanup_storage_high">Kamu di %1$d%% — ketuk untuk memindai jika perlu.</string>
+    <string name="cleanup_storage_medium">Banyak sekali di sini. Pindai mungkin membantu.</string>
+    <string name="cleanup_storage_ok">Penyimpanan Anda terlihat baik!</string>
+    <string name="cleanup_notification_last_scan_format">Pemindaian terakhir: %1$d hari lalu. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Anda belum pernah memindai ponsel. Ketuk untuk mulai.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Selamat datang di Cleaner!</string>
     <string name="onboarding_welcome_description">Mari kita lalui pengaturan cepat dan mulai mengosongkan ruang.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">L\'ultimo Cleaner per Android di cui avrai mai bisogno per l\'uso quotidiano!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Il tuo telefono potrebbe aver bisogno di una pulizia</string>
+    <string name="cleanup_notification_default">Tocca per eseguire la scansione e liberare spazio.</string>
+    <string name="scan_now">Scansiona ora</string>
+    <string name="cleanup_title_variant1">Solo un rapido controllo</string>
+    <string name="cleanup_title_variant2">Spazio un po’ ristretto?</string>
+    <string name="cleanup_title_variant3">Cleaner è qui se ti serve</string>
+    <string name="cleanup_title_variant4">Il tuo telefono è stato molto impegnato ultimamente</string>
+    <string name="cleanup_title_variant5">È ora di un leggero refresh?</string>
+    <string name="cleanup_storage_very_high">La memoria è davvero piena. Vuoi pulire un po’?</string>
+    <string name="cleanup_storage_high">Sei al %1$d%% — tocca per scansionare se necessario.</string>
+    <string name="cleanup_storage_medium">C’è un bel po’ di roba qui. Una scansione potrebbe aiutare.</string>
+    <string name="cleanup_storage_ok">La tua memoria sembra a posto!</string>
+    <string name="cleanup_notification_last_scan_format">Ultima scansione: %1$d giorni fa. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Non hai ancora scansionato il telefono. Tocca per iniziare.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Benvenuto in Cleaner!</string>
     <string name="onboarding_welcome_description">Eseguiamo una configurazione rapida e iniziamo a liberare spazio.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">毎日の使用に最適な、究極のAndroidクリーナー！</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">お使いのスマートフォンはクリーニングが必要かもしれません</string>
+    <string name="cleanup_notification_default">タップしてスキャンし、空き容量を確保しましょう。</string>
+    <string name="scan_now">今すぐスキャン</string>
+    <string name="cleanup_title_variant1">ちょっとしたチェックです</string>
+    <string name="cleanup_title_variant2">容量が足りないですか？</string>
+    <string name="cleanup_title_variant3">必要ならCleanerがサポートします</string>
+    <string name="cleanup_title_variant4">最近スマホがよく使われています</string>
+    <string name="cleanup_title_variant5">軽くリフレッシュしませんか？</string>
+    <string name="cleanup_storage_very_high">ストレージがかなり不足しています。少しクリーンアップしますか？</string>
+    <string name="cleanup_storage_high">現在%1$d%%です—必要に応じてタップしてスキャンしてください。</string>
+    <string name="cleanup_storage_medium">ここにはたくさんのものがあります。スキャンが役立つかもしれません。</string>
+    <string name="cleanup_storage_ok">ストレージは良好です！</string>
+    <string name="cleanup_notification_last_scan_format">最終スキャン: %1$d日前。%2$s</string>
+    <string name="cleanup_notification_never_scanned">まだスキャンしていません。タップして開始してください。</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">クリーナーへようこそ！</string>
     <string name="onboarding_welcome_description">簡単なセットアップを行い、空き容量を増やしましょう。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">일상적인 사용에 필요한 마지막 Android 클리너입니다!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">휴대폰을 정리해야 할 수도 있어요</string>
+    <string name="cleanup_notification_default">탭하여 스캔하고 공간을 확보하세요.</string>
+    <string name="scan_now">지금 스캔</string>
+    <string name="cleanup_title_variant1">간단한 점검이에요</string>
+    <string name="cleanup_title_variant2">공간이 부족한가요?</string>
+    <string name="cleanup_title_variant3">필요하면 클리너가 도와드려요</string>
+    <string name="cleanup_title_variant4">최근 휴대폰이 바빴네요</string>
+    <string name="cleanup_title_variant5">가볍게 새로고침할까요?</string>
+    <string name="cleanup_storage_very_high">저장공간이 매우 부족합니다. 조금 정리해볼까요?</string>
+    <string name="cleanup_storage_high">%1$d%% 사용 중 — 필요하면 탭해서 스캔하세요.</string>
+    <string name="cleanup_storage_medium">여기에 내용이 많네요. 스캔이 도움이 될 수 있어요.</string>
+    <string name="cleanup_storage_ok">저장공간은 괜찮아 보여요!</string>
+    <string name="cleanup_notification_last_scan_format">마지막 스캔: %1$d일 전. %2$s</string>
+    <string name="cleanup_notification_never_scanned">아직 휴대폰을 스캔하지 않았어요. 시작하려면 탭하세요.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">클리너에 오신 것을 환영합니다!</string>
     <string name="onboarding_welcome_description">빠른 설정을 진행하고 공간 확보를 시작해 보겠습니다.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Ostatni Android Cleaner, jakiego kiedykolwiek będziesz potrzebować do codziennego użytku!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Twój telefon może potrzebować czyszczenia</string>
+    <string name="cleanup_notification_default">Stuknij, aby przeskanować i zwolnić miejsce.</string>
+    <string name="scan_now">Skanuj teraz</string>
+    <string name="cleanup_title_variant1">Tylko szybka kontrola</string>
+    <string name="cleanup_title_variant2">Mało miejsca?</string>
+    <string name="cleanup_title_variant3">Cleaner jest tutaj, gdy potrzebujesz</string>
+    <string name="cleanup_title_variant4">Twój telefon ostatnio był zajęty</string>
+    <string name="cleanup_title_variant5">Czas na małe odświeżenie?</string>
+    <string name="cleanup_storage_very_high">Pamięć jest bardzo zapełniona. Chcesz trochę posprzątać?</string>
+    <string name="cleanup_storage_high">Masz %1$d%% — stuknij, aby przeskanować w razie potrzeby.</string>
+    <string name="cleanup_storage_medium">Jest tu całkiem sporo rzeczy. Skan może pomóc.</string>
+    <string name="cleanup_storage_ok">Twoja pamięć wygląda dobrze!</string>
+    <string name="cleanup_notification_last_scan_format">Ostatnie skanowanie: %1$d dni temu. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Nie przeskanowałeś jeszcze telefonu. Stuknij, aby zacząć.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Witaj w Cleaner!</string>
     <string name="onboarding_welcome_description">Przejdźmy przez szybką konfigurację i zacznijmy zwalniać miejsce.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">O último Limpador de Android que você precisará para o uso diário!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Seu telefone pode precisar de uma limpeza</string>
+    <string name="cleanup_notification_default">Toque para escanear e liberar espaço.</string>
+    <string name="scan_now">Escanear agora</string>
+    <string name="cleanup_title_variant1">Apenas uma checagem rápida</string>
+    <string name="cleanup_title_variant2">O espaço está apertado?</string>
+    <string name="cleanup_title_variant3">O Cleaner está aqui se precisar</string>
+    <string name="cleanup_title_variant4">Seu telefone esteve ocupado ultimamente</string>
+    <string name="cleanup_title_variant5">Hora de uma leve renovada?</string>
+    <string name="cleanup_storage_very_high">O armazenamento está bem cheio. Quer limpar um pouco?</string>
+    <string name="cleanup_storage_high">Você está em %1$d%% — toque para escanear se necessário.</string>
+    <string name="cleanup_storage_medium">Tem bastante coisa aqui. Um scan pode ajudar.</string>
+    <string name="cleanup_storage_ok">Seu armazenamento está ok!</string>
+    <string name="cleanup_notification_last_scan_format">Última varredura: há %1$d dias. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Você ainda não escaneou o telefone. Toque para começar.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Bem-vindo ao Cleaner!</string>
     <string name="onboarding_welcome_description">Vamos fazer uma configuração rápida e começar a liberar espaço.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Ultimul Cleaner Android de care veți avea vreodată nevoie pentru utilizarea de zi cu zi!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Telefonul tău ar putea avea nevoie de curățare</string>
+    <string name="cleanup_notification_default">Atinge pentru a scana și elibera spațiu.</string>
+    <string name="scan_now">Scanează acum</string>
+    <string name="cleanup_title_variant1">Doar o verificare rapidă</string>
+    <string name="cleanup_title_variant2">Spațiul e cam limitat?</string>
+    <string name="cleanup_title_variant3">Cleaner e aici dacă ai nevoie</string>
+    <string name="cleanup_title_variant4">Telefonul tău a fost ocupat în ultima vreme</string>
+    <string name="cleanup_title_variant5">E timpul pentru o mică reîmprospătare?</string>
+    <string name="cleanup_storage_very_high">Spațiul de stocare e foarte aglomerat. Vrei să cureți puțin?</string>
+    <string name="cleanup_storage_high">Ești la %1$d%% — atinge pentru scanare dacă e nevoie.</string>
+    <string name="cleanup_storage_medium">Sunt destule lucruri aici. Un scan ar putea ajuta.</string>
+    <string name="cleanup_storage_ok">Spațiul tău arată bine!</string>
+    <string name="cleanup_notification_last_scan_format">Ultimul scan: acum %1$d zile. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Nu ți-ai scanat încă telefonul. Atinge pentru a începe.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Bun venit la Cleaner!</string>
     <string name="onboarding_welcome_description">Să parcurgem o configurare rapidă și să începem eliberarea spațiului.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Последний Android Cleaner, который вам когда-либо понадобится для повседневного использования!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Возможно, вашему телефону требуется очистка</string>
+    <string name="cleanup_notification_default">Нажмите, чтобы просканировать и освободить место.</string>
+    <string name="scan_now">Сканировать сейчас</string>
+    <string name="cleanup_title_variant1">Быстрая проверка</string>
+    <string name="cleanup_title_variant2">Мало места?</string>
+    <string name="cleanup_title_variant3">Cleaner поможет, если нужно</string>
+    <string name="cleanup_title_variant4">Ваш телефон был занят в последнее время</string>
+    <string name="cleanup_title_variant5">Пора немного обновить?</string>
+    <string name="cleanup_storage_very_high">Хранилище почти заполнено. Хотите немного почистить?</string>
+    <string name="cleanup_storage_high">Вы используете %1$d%% — нажмите для сканирования при необходимости.</string>
+    <string name="cleanup_storage_medium">Здесь много всего. Сканирование может помочь.</string>
+    <string name="cleanup_storage_ok">Ваше хранилище в порядке!</string>
+    <string name="cleanup_notification_last_scan_format">Последнее сканирование: %1$d дней назад. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Вы ещё не сканировали телефон. Нажмите, чтобы начать.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Добро пожаловать в Cleaner!</string>
     <string name="onboarding_welcome_description">Давайте пройдем быструю настройку и начнем освобождать место.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Den sista Android-rensaren du någonsin kommer att behöva för dagligt bruk!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Din telefon kan behöva städas</string>
+    <string name="cleanup_notification_default">Tryck för att skanna och frigöra utrymme.</string>
+    <string name="scan_now">Skanna nu</string>
+    <string name="cleanup_title_variant1">Bara en snabb koll</string>
+    <string name="cleanup_title_variant2">Känns utrymmet trångt?</string>
+    <string name="cleanup_title_variant3">Cleaner finns här om du behöver</string>
+    <string name="cleanup_title_variant4">Din telefon har varit upptagen på sistone</string>
+    <string name="cleanup_title_variant5">Dags för en liten uppfräschning?</string>
+    <string name="cleanup_storage_very_high">Lagringen är riktigt full. Vill du städa lite?</string>
+    <string name="cleanup_storage_high">Du är på %1$d%% — tryck för att skanna vid behov.</string>
+    <string name="cleanup_storage_medium">Här finns mycket innehåll. En skanning kan hjälpa.</string>
+    <string name="cleanup_storage_ok">Ditt lagringsutrymme ser bra ut!</string>
+    <string name="cleanup_notification_last_scan_format">Senaste skanning: för %1$d dagar sedan. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Du har inte skannat din telefon än. Tryck för att börja.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Välkommen till Cleaner!</string>
     <string name="onboarding_welcome_description">Låt oss gå igenom en snabb installation och börja frigöra utrymme.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">แอปทำความสะอาด Android ตัวสุดท้ายที่คุณต้องการ สำหรับการใช้งานในทุกๆ วัน!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">โทรศัพท์ของคุณอาจต้องทำความสะอาด</string>
+    <string name="cleanup_notification_default">แตะเพื่อสแกนและเพิ่มพื้นที่ว่าง</string>
+    <string name="scan_now">สแกนตอนนี้</string>
+    <string name="cleanup_title_variant1">แค่ตรวจสอบด่วน</string>
+    <string name="cleanup_title_variant2">พื้นที่เหลือน้อย?</string>
+    <string name="cleanup_title_variant3">Cleaner พร้อมช่วยเมื่อคุณต้องการ</string>
+    <string name="cleanup_title_variant4">ช่วงนี้โทรศัพท์คุณทำงานหนัก</string>
+    <string name="cleanup_title_variant5">ได้เวลาล้างเครื่องเบา ๆ แล้วหรือยัง?</string>
+    <string name="cleanup_storage_very_high">พื้นที่จัดเก็บแน่นมาก ต้องการล้างหน่อยไหม?</string>
+    <string name="cleanup_storage_high">คุณใช้ไปแล้ว %1$d%% — แตะเพื่อสแกนหากจำเป็น</string>
+    <string name="cleanup_storage_medium">มีของเยอะมากที่นี่ การสแกนอาจช่วยได้</string>
+    <string name="cleanup_storage_ok">พื้นที่จัดเก็บของคุณดูโอเค!</string>
+    <string name="cleanup_notification_last_scan_format">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</string>
+    <string name="cleanup_notification_never_scanned">คุณยังไม่ได้สแกนโทรศัพท์ แตะเพื่อเริ่มต้น</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">ยินดีต้อนรับสู่ Cleaner!</string>
     <string name="onboarding_welcome_description">มาตั้งค่าอย่างรวดเร็วและเริ่มเพิ่มพื้นที่ว่างกันเถอะ</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Günlük kullanım için ihtiyaç duyacağınız son Android Temizleyici!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Telefonunuzun temizliğe ihtiyacı olabilir</string>
+    <string name="cleanup_notification_default">Tarayıp yer açmak için dokunun.</string>
+    <string name="scan_now">Şimdi tara</string>
+    <string name="cleanup_title_variant1">Sadece hızlı bir kontrol</string>
+    <string name="cleanup_title_variant2">Yer mi daralıyor?</string>
+    <string name="cleanup_title_variant3">İhtiyacın olursa Cleaner burada</string>
+    <string name="cleanup_title_variant4">Telefonun son zamanlarda meşguldü</string>
+    <string name="cleanup_title_variant5">Hafif bir yenileme zamanı mı?</string>
+    <string name="cleanup_storage_very_high">Depolama çok dolu. Biraz temizlemek ister misin?</string>
+    <string name="cleanup_storage_high">%1$d%% dolu — gerekirse taramak için dokun.</string>
+    <string name="cleanup_storage_medium">Burada epey şey var. Tarama yardımcı olabilir.</string>
+    <string name="cleanup_storage_ok">Depolaman gayet iyi!</string>
+    <string name="cleanup_notification_last_scan_format">Son tarama: %1$d gün önce. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Telefonunu henüz taramadın. Başlamak için dokun.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Cleaner\'a Hoş Geldiniz!</string>
     <string name="onboarding_welcome_description">Hızlı bir kurulum yapalım ve yer açmaya başlayalım.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Останній очищувач для Android, який вам знадобиться для щоденного використання!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Можливо, вашому телефону потрібне очищення</string>
+    <string name="cleanup_notification_default">Торкніться, щоб просканувати і звільнити місце.</string>
+    <string name="scan_now">Сканувати зараз</string>
+    <string name="cleanup_title_variant1">Просто швидка перевірка</string>
+    <string name="cleanup_title_variant2">Мало місця?</string>
+    <string name="cleanup_title_variant3">Cleaner поруч, якщо потрібно</string>
+    <string name="cleanup_title_variant4">Ваш телефон останнім часом був зайнятий</string>
+    <string name="cleanup_title_variant5">Час трохи оновити?</string>
+    <string name="cleanup_storage_very_high">Пам’ять майже заповнена. Хочете трохи почистити?</string>
+    <string name="cleanup_storage_high">У вас %1$d%% — торкніться для сканування за потреби.</string>
+    <string name="cleanup_storage_medium">Тут багато всього. Сканування може допомогти.</string>
+    <string name="cleanup_storage_ok">Пам’ять у хорошому стані!</string>
+    <string name="cleanup_notification_last_scan_format">Останнє сканування: %1$d днів тому. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Ви ще не сканували телефон. Торкніться, щоб почати.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Ласкаво просимо до Cleaner!</string>
     <string name="onboarding_welcome_description">Пройдімо швидке налаштування та почнімо звільняти місце.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">آخری اینڈرائیڈ کلینر جس کی آپ کو روزمرہ کے استعمال کے لیے ضرورت ہوگی!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">آپ کے فون کو صفائی کی ضرورت ہو سکتی ہے</string>
+    <string name="cleanup_notification_default">اسپیس خالی کرنے کے لیے اسکین پر ٹیپ کریں۔</string>
+    <string name="scan_now">ابھی اسکین کریں</string>
+    <string name="cleanup_title_variant1">بس ایک جلدی سے چیک</string>
+    <string name="cleanup_title_variant2">کیا جگہ کم محسوس ہو رہی ہے؟</string>
+    <string name="cleanup_title_variant3">ضرورت پڑنے پر Cleaner دستیاب ہے</string>
+    <string name="cleanup_title_variant4">آپ کا فون حال ہی میں مصروف رہا ہے</string>
+    <string name="cleanup_title_variant5">کیا ہلکی سی ریفریش کا وقت ہے؟</string>
+    <string name="cleanup_storage_very_high">اسٹوریج بہت تنگ ہے۔ تھوڑا صاف کرنا چاہیں گے؟</string>
+    <string name="cleanup_storage_high">آپ %1$d%% پر ہیں—ضرورت ہو تو اسکین کے لیے ٹیپ کریں۔</string>
+    <string name="cleanup_storage_medium">یہاں کافی چیزیں ہیں۔ اسکین مددگار ہو سکتا ہے۔</string>
+    <string name="cleanup_storage_ok">آپ کا اسٹوریج ٹھیک ہے!</string>
+    <string name="cleanup_notification_last_scan_format">آخری اسکین: %1$d دن پہلے۔ %2$s</string>
+    <string name="cleanup_notification_never_scanned">آپ نے ابھی تک فون اسکین نہیں کیا۔ شروع کرنے کے لیے ٹیپ کریں۔</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">کلینر میں خوش آمدید!</string>
     <string name="onboarding_welcome_description">آئیے ایک فوری سیٹ اپ سے گزریں اور جگہ خالی کرنا شروع کریں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">Trình dọn dẹp Android cuối cùng bạn cần cho việc sử dụng hàng ngày!</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">Điện thoại của bạn có thể cần dọn dẹp</string>
+    <string name="cleanup_notification_default">Nhấn để quét và giải phóng dung lượng.</string>
+    <string name="scan_now">Quét ngay</string>
+    <string name="cleanup_title_variant1">Chỉ kiểm tra nhanh thôi</string>
+    <string name="cleanup_title_variant2">Thiếu chỗ trống?</string>
+    <string name="cleanup_title_variant3">Cleaner sẵn sàng nếu bạn cần</string>
+    <string name="cleanup_title_variant4">Điện thoại của bạn gần đây bận rộn</string>
+    <string name="cleanup_title_variant5">Đến lúc làm mới nhẹ?</string>
+    <string name="cleanup_storage_very_high">Bộ nhớ rất chật. Bạn muốn dọn dẹp chút không?</string>
+    <string name="cleanup_storage_high">Bạn đã dùng %1$d%% — nhấn để quét nếu cần.</string>
+    <string name="cleanup_storage_medium">Có khá nhiều thứ ở đây. Quét có thể giúp.</string>
+    <string name="cleanup_storage_ok">Bộ nhớ của bạn vẫn ổn!</string>
+    <string name="cleanup_notification_last_scan_format">Lần quét cuối: %1$d ngày trước. %2$s</string>
+    <string name="cleanup_notification_never_scanned">Bạn chưa quét điện thoại. Nhấn để bắt đầu.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Chào mừng đến với Cleaner!</string>
     <string name="onboarding_welcome_description">Hãy cùng thực hiện một thiết lập nhanh và bắt đầu giải phóng dung lượng.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2,6 +2,22 @@
 <resources>
     <string name="app_short_description">您日常使用所需的最後一款 Android 清理工具！</string>
 
+    <!-- Notifications -->
+    <string name="cleanup_notification_title">您的手機可能需要清理</string>
+    <string name="cleanup_notification_default">點擊掃描並釋放空間。</string>
+    <string name="scan_now">立即掃描</string>
+    <string name="cleanup_title_variant1">只是快速檢查一下</string>
+    <string name="cleanup_title_variant2">空間不夠用了嗎？</string>
+    <string name="cleanup_title_variant3">需要時 Cleaner 在這裡</string>
+    <string name="cleanup_title_variant4">您的手機最近很忙碌</string>
+    <string name="cleanup_title_variant5">該輕鬆清理一下了嗎？</string>
+    <string name="cleanup_storage_very_high">儲存空間相當吃緊，要清一下嗎？</string>
+    <string name="cleanup_storage_high">您已使用 %1$d%% — 如有需要點擊掃描。</string>
+    <string name="cleanup_storage_medium">這裡有很多內容，掃描或許有幫助。</string>
+    <string name="cleanup_storage_ok">您的儲存空間狀況良好！</string>
+    <string name="cleanup_notification_last_scan_format">上次掃描：%1$d 天前。%2$s</string>
+    <string name="cleanup_notification_never_scanned">您尚未掃描手機，點擊即可開始.</string>
+
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">歡迎使用 Cleaner！</string>
     <string name="onboarding_welcome_description">讓我們進行快速設定，開始釋放空間。</string>


### PR DESCRIPTION
## Summary
- add notification strings translations for all languages

## Testing
- `./gradlew tasks --all`
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624ac99af8832d87219b054475f88e