### PR TITLE
Add summary card on home screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
@@ -30,8 +30,7 @@ import com.d4rk.cleaner.app.apps.manager.domain.actions.AppManagerEvent
 import com.d4rk.cleaner.app.clean.analyze.ui.AnalyzeScreen
 import com.d4rk.cleaner.app.clean.home.domain.actions.HomeEvent
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
-import com.d4rk.cleaner.app.clean.home.ui.components.ExtraStorageInfo
-import com.d4rk.cleaner.app.clean.home.ui.components.StorageProgressButton
+import com.d4rk.cleaner.app.clean.home.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -58,34 +57,12 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
                 .weight(4f)
                 .fillMaxWidth()
         ) {
-            if (uiState.data?.analyzeState?.isAnalyzeScreenVisible == false) {
-                StorageProgressButton(
-                    progress = uiState.data?.storageInfo?.storageUsageProgress ?: 0f,
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .offset(y = 98.dp),
-                    onClick = {
-                        viewModel.onEvent(HomeEvent.ToggleAnalyzeScreen(true))
-                    }
-                )
-
-                ExtraStorageInfo(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = SizeConstants.LargeSize),
-                    cleanedSpace = uiState.data?.storageInfo?.cleanedSpace ?: "",
-                    freeSpace = "${uiState.data?.storageInfo?.freeSpacePercentage ?: 0} %",
-                    isCleanedSpaceLoading = uiState.data?.storageInfo?.isCleanedSpaceLoading == true,
-                    isFreeSpaceLoading = uiState.data?.storageInfo?.isFreeSpaceLoading == true
-                )
-            }
-
             Crossfade(
                 targetState = uiState.data?.analyzeState?.isAnalyzeScreenVisible,
                 animationSpec = tween(durationMillis = 300),
                 label = ""
-            ) { showCleaningComposable ->
-                if (showCleaningComposable == true) {
+            ) { showAnalyze ->
+                if (showAnalyze == true) {
                     uiState.data?.let { data ->
                         key(data.analyzeState.fileTypesData) {
                             AnalyzeScreen(
@@ -95,6 +72,15 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
                             )
                         }
                     }
+                } else {
+                    QuickScanSummaryCard(
+                        cleanedSize = uiState.data?.storageInfo?.cleanedSpace ?: "",
+                        freePercent = uiState.data?.storageInfo?.freeSpacePercentage ?: 0,
+                        usedPercent = ((uiState.data?.storageInfo?.storageUsageProgress ?: 0f) * 100).toInt(),
+                        progress = uiState.data?.storageInfo?.storageUsageProgress ?: 0f,
+                        modifier = Modifier.align(Alignment.Center),
+                        onQuickScanClick = { viewModel.onEvent(HomeEvent.ToggleAnalyzeScreen(true)) }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ProgressBar.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ProgressBar.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -50,7 +51,10 @@ import com.d4rk.cleaner.app.clean.memory.domain.data.model.StorageInfo
  */
 @Composable
 fun StorageProgressButton(
-    progress : Float , modifier : Modifier = Modifier , onClick : () -> Unit = {}
+    progress: Float,
+    modifier: Modifier = Modifier,
+    size: Dp = 240.dp,
+    onClick: () -> Unit = {}
 ) {
     val view : View = LocalView.current
     val isVisible = remember { mutableStateOf(true) }
@@ -60,7 +64,8 @@ fun StorageProgressButton(
     )
 
     Box(
-        contentAlignment = Alignment.Center , modifier = modifier.size(240.dp)
+        contentAlignment = Alignment.Center,
+        modifier = modifier.size(size)
     ) {
         CircularProgressIndicator(
             progress = { 1f } ,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
@@ -1,0 +1,70 @@
+package com.d4rk.cleaner.app.clean.home.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.d4rk.cleaner.R
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
+@Composable
+fun QuickScanSummaryCard(
+    cleanedSize: String,
+    freePercent: Int,
+    usedPercent: Int,
+    progress: Float,
+    modifier: Modifier = Modifier,
+    buttonSize: Dp = 96.dp,
+    onQuickScanClick: () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(id = R.string.quick_scan_cleaned_format, cleanedSize),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                SmallVerticalSpacer()
+                Text(
+                    text = stringResource(id = R.string.quick_scan_free_format, freePercent, usedPercent),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                SmallVerticalSpacer()
+                Text(
+                    text = stringResource(id = R.string.quick_scan_summary_tip),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+            Box(contentAlignment = Alignment.Center) {
+                StorageProgressButton(
+                    progress = progress,
+                    modifier = Modifier,
+                    size = buttonSize,
+                    onClick = onQuickScanClick
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,10 @@
     <string name="move_to_trash_title">Move to Trash</string>
     <string name="move_to_trash_message">Are you sure you want to move these files to the trash?</string>
     <string name="quick_scan">Quick Scan</string>
+    <string name="rescan">Rescan</string>
+    <string name="quick_scan_cleaned_format">%1$s cleaned this week</string>
+    <string name="quick_scan_free_format">%1$d%% free • %2$d%% used</string>
+    <string name="quick_scan_summary_tip">Regular cleaning keeps your phone fast</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>
     <string name="fonts">Fonts</string>


### PR DESCRIPTION
## Summary
- replace home screen's top stats with new `QuickScanSummaryCard`
- add `QuickScanSummaryCard` component
- allow customizing size in `StorageProgressButton`
- update strings with card text

## Testing
- `./gradlew lint -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864da0295a4832d82ce0200d5785051