### PR TITLE
Add APK cleaner card

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.view.View
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,7 +30,9 @@ import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.d4rk.cleaner.app.apps.manager.domain.actions.AppManagerEvent
+import com.d4rk.cleaner.app.apps.manager.domain.data.model.ui.UiAppManagerModel
+import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
+import com.d4rk.cleaner.app.clean.home.ui.components.ApkCleanerCard
 import com.d4rk.cleaner.app.clean.analyze.ui.AnalyzeScreen
 import com.d4rk.cleaner.app.clean.home.domain.actions.HomeEvent
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
@@ -39,7 +45,9 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
     val context: Context = LocalContext.current
     val view: View = LocalView.current
     val viewModel: HomeViewModel = koinViewModel()
+    val appManagerViewModel: AppManagerViewModel = koinViewModel()
     val uiState: UiStateScreen<UiHomeModel> by viewModel.uiState.collectAsState()
+    val appManagerState: UiStateScreen<UiAppManagerModel> by appManagerViewModel.uiState.collectAsState()
 
     LaunchedEffect(key1 = true) {
         if (!PermissionsHelper.hasStoragePermissions(context)) {
@@ -73,14 +81,30 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
                         }
                     }
                 } else {
-                    QuickScanSummaryCard(
-                        cleanedSize = uiState.data?.storageInfo?.cleanedSpace ?: "",
-                        freePercent = uiState.data?.storageInfo?.freeSpacePercentage ?: 0,
-                        usedPercent = ((uiState.data?.storageInfo?.storageUsageProgress ?: 0f) * 100).toInt(),
-                        progress = uiState.data?.storageInfo?.storageUsageProgress ?: 0f,
-                        modifier = Modifier.align(Alignment.Center),
-                        onQuickScanClick = { viewModel.onEvent(HomeEvent.ToggleAnalyzeScreen(true)) }
-                    )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        QuickScanSummaryCard(
+                            cleanedSize = uiState.data?.storageInfo?.cleanedSpace ?: "",
+                            freePercent = uiState.data?.storageInfo?.freeSpacePercentage ?: 0,
+                            usedPercent = ((uiState.data?.storageInfo?.storageUsageProgress ?: 0f) * 100).toInt(),
+                            progress = uiState.data?.storageInfo?.storageUsageProgress ?: 0f,
+                            onQuickScanClick = { viewModel.onEvent(HomeEvent.ToggleAnalyzeScreen(true)) }
+                        )
+                        AnimatedVisibility(visible = appManagerState.data?.apkFiles?.isNotEmpty() == true) {
+                            ApkCleanerCard(
+                                apkFiles = appManagerState.data?.apkFiles ?: emptyList(),
+                                onCleanClick = {
+                                    val files = appManagerState.data?.apkFiles?.map { java.io.File(it.path) } ?: emptyList()
+                                    viewModel.onCleanApks(files)
+                                }
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -901,6 +901,10 @@ class HomeViewModel(
         }
     }
 
+    fun onCleanApks(apkFiles: List<File>) {
+        deleteFiles(apkFiles.toSet())
+    }
+
     private fun postSnackbar(message : UiTextHelper , isError : Boolean) {
         screenState.showSnackbar(snackbar = UiSnackbar(message = message , isError = isError , timeStamp = System.currentTimeMillis() , type = ScreenMessageType.SNACKBAR))
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ApkCleanerCard.kt
@@ -1,0 +1,85 @@
+package com.d4rk.cleaner.app.clean.home.ui.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Android
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.apps.manager.domain.data.model.ApkInfo
+import java.io.File
+
+@Composable
+fun ApkCleanerCard(
+    apkFiles: List<ApkInfo>,
+    modifier: Modifier = Modifier,
+    onCleanClick: () -> Unit
+) {
+    val preview = apkFiles.take(3)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = Icons.Outlined.Android, contentDescription = null)
+                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
+                    Text(
+                        text = stringResource(id = R.string.apk_card_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    SmallVerticalSpacer()
+                    Text(
+                        text = stringResource(id = R.string.apk_card_subtitle),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                preview.forEach { apk ->
+                    Text(
+                        text = File(apk.path).name,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                if (apkFiles.size > preview.size) {
+                    Text(
+                        text = stringResource(id = R.string.apk_card_more_format, apkFiles.size - preview.size),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            Button(modifier = Modifier.align(Alignment.End), onClick = onCleanClick) {
+                Text(text = stringResource(id = R.string.clean_apks))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="quick_scan_cleaned_format">%1$s cleaned this week</string>
     <string name="quick_scan_free_format">%1$d%% free • %2$d%% used</string>
     <string name="quick_scan_summary_tip">Regular cleaning keeps your phone fast</string>
+    <string name="apk_card_title">Installers Found</string>
+    <string name="apk_card_subtitle">Old APK files can take up a lot of space.</string>
+    <string name="apk_card_more_format">+%1$d more</string>
+    <string name="clean_apks">Clean APKs</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>
     <string name="fonts">Fonts</string>


### PR DESCRIPTION
## Summary
- show list of APK installers under Quick Scan
- allow cleaning APK files directly
- add supporting strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864dcaff748832d8cacbf7b78e20202