### PR TITLE
Add Clipboard Cleaner summary card

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeScreen.kt
@@ -38,6 +38,7 @@ import com.d4rk.cleaner.app.clean.home.domain.actions.HomeEvent
 import com.d4rk.cleaner.app.clean.home.domain.data.model.ui.UiHomeModel
 import com.d4rk.cleaner.app.clean.home.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.app.clean.home.ui.components.WhatsAppCleanerCard
+import com.d4rk.cleaner.app.clean.home.ui.components.ClipboardCleanerCard
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -50,6 +51,8 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
     val uiState: UiStateScreen<UiHomeModel> by viewModel.uiState.collectAsState()
     val appManagerState: UiStateScreen<UiAppManagerModel> by appManagerViewModel.uiState.collectAsState()
     val whatsappSummary by viewModel.whatsAppMediaSummary.collectAsState()
+    val clipboardText by viewModel.clipboardPreview.collectAsState()
+    val clipboardSensitive by viewModel.clipboardDetectedSensitive.collectAsState()
 
     LaunchedEffect(key1 = true) {
         if (!PermissionsHelper.hasStoragePermissions(context)) {
@@ -110,6 +113,13 @@ fun HomeScreen(paddingValues: PaddingValues, snackbarHostState: SnackbarHostStat
                             WhatsAppCleanerCard(
                                 mediaSummary = whatsappSummary,
                                 onCleanClick = { viewModel.onEvent(HomeEvent.CleanWhatsAppFiles) }
+                            )
+                        }
+                        AnimatedVisibility(visible = clipboardText != null || clipboardSensitive) {
+                            ClipboardCleanerCard(
+                                clipboardText = clipboardText,
+                                onCleanClick = { viewModel.onClipboardClear() },
+                                onSeeMoreClick = {}
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ClipboardCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ClipboardCleanerCard.kt
@@ -1,0 +1,86 @@
+package com.d4rk.cleaner.app.clean.home.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentPaste
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+
+@Composable
+fun ClipboardCleanerCard(
+    clipboardText: String?,
+    modifier: Modifier = Modifier,
+    onCleanClick: () -> Unit,
+    onSeeMoreClick: () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = Icons.Outlined.ContentPaste, contentDescription = null)
+                Column(modifier = Modifier.padding(start = SizeConstants.MediumSize)) {
+                    Text(
+                        text = stringResource(id = R.string.clipboard_card_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    SmallVerticalSpacer()
+                    Text(
+                        text = stringResource(id = R.string.clipboard_card_subtitle),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            if (!clipboardText.isNullOrBlank()) {
+                Text(
+                    text = stringResource(id = R.string.clipboard_current_format, clipboardText),
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+            ) {
+                FilledTonalButton(onClick = onCleanClick, modifier = Modifier.weight(1f)) {
+                    Icon(imageVector = Icons.Outlined.Delete, contentDescription = null)
+                    ButtonIconSpacer()
+                    Text(text = stringResource(id = R.string.clean_clipboard))
+                }
+                FilledTonalButton(onClick = onSeeMoreClick, modifier = Modifier.weight(1f)) {
+                    Icon(imageVector = Icons.Outlined.Visibility, contentDescription = null)
+                    ButtonIconSpacer()
+                    Text(text = stringResource(id = R.string.see_more))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -91,7 +91,17 @@ val appModule : Module = module {
     single<UpdateTrashSizeUseCase> { UpdateTrashSizeUseCase(homeRepository = get()) }
 
     viewModel<HomeViewModel> {
-        HomeViewModel(getStorageInfoUseCase = get() , getFileTypesUseCase = get() , analyzeFilesUseCase = get() , deleteFilesUseCase = get() , moveToTrashUseCase = get() , updateTrashSizeUseCase = get() , dispatchers = get() , dataStore = get())
+        HomeViewModel(
+            application = get(),
+            getStorageInfoUseCase = get(),
+            getFileTypesUseCase = get(),
+            analyzeFilesUseCase = get(),
+            deleteFilesUseCase = get(),
+            moveToTrashUseCase = get(),
+            updateTrashSizeUseCase = get(),
+            dispatchers = get(),
+            dataStore = get()
+        )
     }
 
     single<PackageManagerFacade> { PackageManagerFacadeImpl(application = get()) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,11 @@
     <string name="whatsapp_card_title">WhatsApp Cleanup</string>
     <string name="whatsapp_card_subtitle">Free up space by removing old WhatsApp files.</string>
     <string name="clean_whatsapp">Clean WhatsApp</string>
+    <string name="clipboard_card_title">Clipboard Cleanup</string>
+    <string name="clipboard_card_subtitle">Sensitive data can stay copied longer than needed.</string>
+    <string name="clipboard_current_format">Current: %1$s</string>
+    <string name="clean_clipboard">Clean</string>
+    <string name="see_more">See More</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>
     <string name="fonts">Fonts</string>


### PR DESCRIPTION
## Summary
- add clipboard cleaner card UI for home screen
- load clipboard preview in `HomeViewModel`
- show/hide the card on home screen
- wire up DI for new `application` param
- add strings for clipboard card

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e3aca974832d9010442a94b32c12