### PR TITLE
Improve home cleanup previews

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/ApkCleanerCard.kt
@@ -32,6 +32,7 @@ import android.content.Context
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.ui.platform.LocalContext
+import com.d4rk.cleaner.app.clean.home.utils.helpers.StorageUtils
 import java.io.File
 
 @Composable
@@ -91,11 +92,16 @@ fun ApkCleanerCard(
                             contentDescription = null,
                             modifier = Modifier.size(24.dp)
                         )
-                        Text(
-                            text = appName,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.padding(start = SizeConstants.ExtraSmallSize)
-                        )
+                        Column(modifier = Modifier.padding(start = SizeConstants.ExtraSmallSize)) {
+                            Text(
+                                text = appName,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            Text(
+                                text = StorageUtils.formatSizeReadable(apk.size),
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
                     }
                 }
                 if (apkFiles.size > preview.size) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/FilePreviewCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/FilePreviewCard.kt
@@ -1,0 +1,147 @@
+package com.d4rk.cleaner.app.clean.home.ui.components
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.PictureAsPdf
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.video.VideoFrameDecoder
+import coil3.video.videoFramePercent
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.home.utils.helpers.getFileIcon
+import com.d4rk.cleaner.app.clean.home.utils.helpers.loadPdfThumbnail
+import com.google.common.io.Files.getFileExtension
+import java.io.File
+
+@Composable
+fun FilePreviewCard(file: File, modifier: Modifier = Modifier) {
+    val context: Context = LocalContext.current
+    val fileExtension: String = remember(file.name) { getFileExtension(file.name) }
+    val imageExtensions = remember { context.resources.getStringArray(R.array.image_extensions).toList() }
+    val videoExtensions = remember { context.resources.getStringArray(R.array.video_extensions).toList() }
+    val officeExtensions = remember { context.resources.getStringArray(R.array.microsoft_office_extensions).toList() }
+    val imageLoader = LocalContext.current.imageLoader
+
+    Card(modifier = modifier) {
+        Box(modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surfaceVariant)) {
+            if (file.isDirectory) {
+                Icon(
+                    imageVector = Icons.Outlined.Folder,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.Center)
+                )
+            } else {
+                when (fileExtension.lowercase()) {
+                    in imageExtensions -> {
+                        AsyncImage(
+                            model = remember(file) {
+                                ImageRequest.Builder(context).data(file).size(64).crossfade(true).build()
+                            },
+                            imageLoader = imageLoader,
+                            contentDescription = file.name,
+                            contentScale = ContentScale.FillWidth,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    in videoExtensions -> {
+                        AsyncImage(
+                            model = remember(file) {
+                                ImageRequest.Builder(context).data(file).decoderFactory { result, options, _ ->
+                                    VideoFrameDecoder(result.source, options)
+                                }.videoFramePercent(0.5).crossfade(true).build()
+                            },
+                            contentDescription = file.name,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                    in officeExtensions -> {
+                        if (fileExtension.lowercase() == "pdf") {
+                            val pdfBitmap = remember(file) { loadPdfThumbnail(file) }
+                            if (pdfBitmap != null) {
+                                Image(
+                                    bitmap = pdfBitmap.asImageBitmap(),
+                                    contentDescription = file.name,
+                                    contentScale = ContentScale.FillWidth,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Outlined.PictureAsPdf,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(24.dp)
+                                        .align(Alignment.Center)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.Outlined.Description,
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .align(Alignment.Center)
+                            )
+                        }
+                    }
+                    else -> {
+                        val fileIcon = remember(fileExtension) { getFileIcon(fileExtension, context) }
+                        Icon(
+                            painter = painterResource(id = fileIcon),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(24.dp)
+                                .align(Alignment.Center)
+                        )
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color.Black.copy(alpha = 0.4f))
+                    .align(Alignment.BottomCenter)
+            ) {
+                Text(
+                    text = file.name,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier
+                        .padding(all = SizeConstants.SmallSize)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/WhatsAppCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/WhatsAppCleanerCard.kt
@@ -1,14 +1,12 @@
 package com.d4rk.cleaner.app.clean.home.ui.components
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Chat
 import androidx.compose.material.icons.outlined.Delete
@@ -16,7 +14,6 @@ import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.PictureAsPdf
 import androidx.compose.material.icons.outlined.Videocam
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,16 +22,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
-import coil3.video.VideoFrameDecoder
-import coil3.video.videoFramePercent
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -110,47 +101,27 @@ fun WhatsAppCleanerCard(
 
 @Composable
 private fun CategoryRow(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, files: List<File>) {
-    val preview = files.take(3)
-    val context = LocalContext.current
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(imageVector = icon, contentDescription = null)
-        Row(
-            modifier = Modifier
-                .padding(start = SizeConstants.MediumSize)
-                .horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-            verticalAlignment = Alignment.CenterVertically
+    val preview = files.take(9)
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(imageVector = icon, contentDescription = null)
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(start = SizeConstants.MediumSize)
+            )
+        }
+        Column(
+            modifier = Modifier.padding(start = SizeConstants.MediumSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)
         ) {
-            preview.forEach { file ->
-                val ext = file.extension.lowercase()
-                if (icon == Icons.Outlined.Image || icon == Icons.Outlined.Videocam) {
-                    val request = remember(file) {
-                        if (icon == Icons.Outlined.Videocam) {
-                            ImageRequest.Builder(context)
-                                .data(file)
-                                .decoderFactory { result, options, _ ->
-                                    VideoFrameDecoder(result.source, options)
-                                }
-                                .videoFramePercent(0.5)
-                                .build()
-                        } else {
-                            ImageRequest.Builder(context).data(file).build()
-                        }
-                    }
-                    AsyncImage(
-                        model = request,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp)
-                    )
-                } else {
-                    if (ext == "pdf") {
-                        Icon(
-                            imageVector = Icons.Outlined.PictureAsPdf,
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp)
+            preview.chunked(3).forEach { rowFiles ->
+                Row(horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
+                    rowFiles.forEach { file ->
+                        FilePreviewCard(
+                            file = file,
+                            modifier = Modifier.size(64.dp)
                         )
-                    } else {
-                        AssistChip(onClick = {}, label = { Text(file.name) }, enabled = false)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show detailed previews in WhatsApp cleaner card using a new `FilePreviewCard`
- display APK size and icon in the APK cleaner card
- support grid-style previews without checkboxes

## Testing
- `./gradlew lintVitalRelease` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f2c56f24832dbd9a10f39ce58256