### PR TITLE
Fix WhatsApp previews on home screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/HomeViewModel.kt
@@ -34,6 +34,7 @@ import com.d4rk.cleaner.app.clean.home.domain.usecases.GetStorageInfoUseCase
 import com.d4rk.cleaner.app.clean.home.domain.usecases.MoveToTrashUseCase
 import com.d4rk.cleaner.app.clean.home.domain.usecases.UpdateTrashSizeUseCase
 import com.d4rk.cleaner.app.clean.home.utils.helpers.StorageUtils
+import com.d4rk.cleaner.app.clean.home.utils.helpers.getWhatsAppMediaSummary
 import com.d4rk.cleaner.app.clean.memory.domain.data.model.StorageInfo
 import com.d4rk.cleaner.app.settings.cleaning.utils.constants.ExtensionsConstants
 import com.d4rk.cleaner.core.data.datastore.DataStore
@@ -838,15 +839,14 @@ class HomeViewModel(
     }
 
     private fun loadWhatsAppMedia() {
-        // TODO: Replace with real scan logic
-        val images = listOf(
-            File("IMG_2024.jpg"),
-            File("IMG_2023.jpg"),
-            File("Screenshot.png")
-        )
-        val videos = listOf(File("VID_001.mp4"))
-        val docs = listOf(File("doc.pdf"))
-        _whatsAppMediaSummary.value = WhatsAppMediaSummary(images = images, videos = videos, documents = docs)
+        launch(context = dispatchers.io) {
+            val (images, videos, docs) = getWhatsAppMediaSummary()
+            _whatsAppMediaSummary.value = WhatsAppMediaSummary(
+                images = images,
+                videos = videos,
+                documents = docs
+            )
+        }
     }
 
     private fun toggleAnalyzeScreen(visible: Boolean) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/utils/helpers/WhatsAppUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/utils/helpers/WhatsAppUtils.kt
@@ -1,0 +1,23 @@
+package com.d4rk.cleaner.app.clean.home.utils.helpers
+
+import android.os.Environment
+import java.io.File
+
+fun getWhatsAppMediaDirs(): File? {
+    val legacy = File(Environment.getExternalStorageDirectory(), "WhatsApp/Media")
+    if (legacy.exists()) return legacy
+    val scoped = File(Environment.getExternalStorageDirectory(), "Android/media/com.whatsapp/WhatsApp/Media")
+    return scoped.takeIf { it.exists() }
+}
+
+fun getWhatsAppMediaSummary(): Triple<List<File>, List<File>, List<File>> {
+    val mediaDir = getWhatsAppMediaDirs() ?: return Triple(emptyList(), emptyList(), emptyList())
+    fun list(dirName: String): List<File> {
+        val dir = File(mediaDir, dirName)
+        return dir.listFiles()?.filter { it.isFile && !it.name.startsWith(".") }?.sortedByDescending { it.lastModified() } ?: emptyList()
+    }
+    val images = list("WhatsApp Images")
+    val videos = list("WhatsApp Video")
+    val docs = list("WhatsApp Documents")
+    return Triple(images, videos, docs)
+}


### PR DESCRIPTION
## Summary
- implement basic filesystem scan for WhatsApp media
- load real files in HomeViewModel for previews

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fef83350832dbe21bf77bdb425c7