### PR TITLE
Refine storage colors

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -82,15 +81,18 @@ fun QuickScanSummaryCard(
                         tint = MaterialTheme.colorScheme.primary
                     )
                     SmallHorizontalSpacer()
+                    val freeColor = MaterialTheme.colorScheme.tertiary
+                    val usedColor = MaterialTheme.colorScheme.error
+
                     Text(
                         text = buildAnnotatedString {
                             append(stringResource(id = R.string.free) + " ")
-                            withStyle(SpanStyle(color = Color(0xFF4CAF50))) {
+                            withStyle(SpanStyle(color = freeColor)) {
                                 append("$freePercent%")
                             }
                             append(" • ")
                             append(stringResource(id = R.string.used) + " ")
-                            withStyle(SpanStyle(color = Color(0xFFFFA000))) {
+                            withStyle(SpanStyle(color = usedColor)) {
                                 append("$usedPercent%")
                             }
                         },

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/home/ui/components/QuickScanSummaryCard.kt
@@ -81,8 +81,16 @@ fun QuickScanSummaryCard(
                         tint = MaterialTheme.colorScheme.primary
                     )
                     SmallHorizontalSpacer()
-                    val freeColor = MaterialTheme.colorScheme.tertiary
-                    val usedColor = MaterialTheme.colorScheme.error
+                    val freeColor = when {
+                        freePercent >= 75 -> MaterialTheme.colorScheme.tertiary
+                        freePercent >= 50 -> MaterialTheme.colorScheme.primary
+                        else -> MaterialTheme.colorScheme.error
+                    }
+                    val usedColor = when {
+                        usedPercent >= 90 -> MaterialTheme.colorScheme.error
+                        usedPercent >= 75 -> MaterialTheme.colorScheme.tertiary
+                        else -> MaterialTheme.colorScheme.onSurfaceVariant
+                    }
 
                     Text(
                         text = buildAnnotatedString {


### PR DESCRIPTION
## Summary
- use MaterialTheme color scheme for storage percent colors

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686513450ce4832d8185bd884815dd50