### PR TITLE
Add Cache Cleaner card

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,7 @@
             android:label="@string/trash"
             android:parentActivityName=".app.main.ui.MainActivity" />
 
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/actions/ScannerEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/actions/ScannerEvent.kt
@@ -16,6 +16,7 @@ sealed class ScannerEvent : UiEvent {
     data class ToggleSelectFilesForDate(val files: List<File>, val isChecked: Boolean) : ScannerEvent()
     object CleanFiles : ScannerEvent()
     object CleanWhatsAppFiles : ScannerEvent()
+    object CleanCache : ScannerEvent()
     object MoveSelectedToTrash : ScannerEvent()
     data class SetDeleteForeverConfirmationDialogVisibility(val isVisible : Boolean) : ScannerEvent()
     data class SetMoveToTrashConfirmationDialogVisibility(val isVisible : Boolean) : ScannerEvent()

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -39,6 +39,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningType
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.UiScannerModel
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ApkCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ClipboardCleanerCard
+import com.d4rk.cleaner.app.clean.scanner.ui.components.CacheCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ImageOptimizerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WhatsAppCleanerCard
@@ -124,6 +125,12 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                                 onCleanClick = { viewModel.onEvent(ScannerEvent.CleanWhatsAppFiles) }
                             )
                         }
+                        CacheCleanerCard(
+                            onClick = {
+                                viewModel.onEvent(ScannerEvent.CleanCache)
+                            },
+                            onInfoClick = {}
+                        )
                         ImageOptimizerCard(
                             onOptimizeClick = {
                                 IntentsHelper.openActivity(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -101,6 +101,7 @@ class ScannerViewModel(
             is ScannerEvent.ToggleSelectFilesForDate -> toggleSelectFilesForDate(event.files , event.isChecked)
             is ScannerEvent.CleanFiles -> cleanFiles()
             is ScannerEvent.CleanWhatsAppFiles -> onCleanWhatsAppFiles()
+            is ScannerEvent.CleanCache -> onCleanCache()
             is ScannerEvent.MoveSelectedToTrash -> moveSelectedToTrash()
             is ScannerEvent.SetDeleteForeverConfirmationDialogVisibility -> setDeleteForeverConfirmationDialogVisibility(
                 isVisible = event.isVisible
@@ -939,6 +940,10 @@ class ScannerViewModel(
     }
 
     fun onCleanWhatsAppFiles() {
+        postSnackbar(UiTextHelper.StringResource(R.string.feature_not_available), isError = false)
+    }
+
+    fun onCleanCache() {
         postSnackbar(UiTextHelper.StringResource(R.string.feature_not_available), isError = false)
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
@@ -1,0 +1,73 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DeleteSweep
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+
+@Composable
+fun CacheCleanerCard(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onInfoClick: () -> Unit = {}
+) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth().bounceClick(onClick = onClick),
+        border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outline),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.DeleteSweep,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(id = R.string.cache_cleaner_card_title),
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = stringResource(id = R.string.cache_cleaner_card_subtitle),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+                IconButton(onClick = onInfoClick) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,11 @@
     <string name="image_optimizer_card_subtitle">Shrink image sizes without losing quality.&#10;Free up space with a single tap.</string>
     <string name="image_optimizer_last_format">Last optimized: %1$s</string>
     <string name="image_optimizer_card_footer">Supports JPEG • Adjustable quality &amp; size</string>
+
+    <!-- Cache Cleaner -->
+    <string name="cache_cleaner_card_title">Cache Cleaner</string>
+    <string name="cache_cleaner_card_subtitle">Free up space from app cache</string>
+    <string name="cache_cleaner">Cache Cleaner</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>
     <string name="fonts">Fonts</string>


### PR DESCRIPTION
## Summary
- remove unfinished CacheCleanerActivity and screen
- show Cache Cleaner card but just trigger not-available message
- handle card click via new `CleanCache` event
- style card like other home cards

## Testing
- `./gradlew tasks --all`


------
https://chatgpt.com/codex/tasks/task_e_686544808cf4832dabbdd70a2834097f