### PR TITLE
Refactor Cleaner Cards: sync & UI updates

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -126,10 +126,9 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                             )
                         }
                         CacheCleanerCard(
-                            onClick = {
+                            onScanClick = {
                                 viewModel.onEvent(ScannerEvent.CleanCache)
-                            },
-                            onInfoClick = {}
+                            }
                         )
                         ImageOptimizerCard(
                             onOptimizeClick = {
@@ -137,14 +136,12 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                                     context = context,
                                     activityClass = ImagePickerActivity::class.java
                                 )
-                            },
-                            onInfoClick = {}
+                            }
                         )
                         AnimatedVisibility(visible = clipboardText != null || clipboardSensitive) {
                             ClipboardCleanerCard(
                                 clipboardText = clipboardText,
-                                onCleanClick = { viewModel.onClipboardClear() },
-                                onSeeMoreClick = {}
+                                onCleanClick = { viewModel.onClipboardClear() }
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -88,6 +88,11 @@ class ScannerViewModel(
         loadCleanedSpace()
         loadWhatsAppMedia()
         loadClipboardData()
+        launch(dispatchers.io) {
+            CleaningEventBus.events.collectLatest {
+                onEvent(ScannerEvent.RefreshData)
+            }
+        }
     }
 
     override fun onEvent(event: ScannerEvent) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/CacheCleanerCard.kt
@@ -8,9 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
-import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -18,14 +17,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 
 @Composable
 fun CacheCleanerCard(
     modifier: Modifier = Modifier,
-    onClick: () -> Unit, // FIXME: Parameter "onClick" is never used
-    onInfoClick: () -> Unit = {}
+    onScanClick: () -> Unit,
 ) {
     OutlinedCard(
         modifier = modifier.fillMaxWidth(),
@@ -56,13 +56,19 @@ fun CacheCleanerCard(
                         style = MaterialTheme.typography.bodySmall
                     )
                 }
-                IconButton(onClick = onInfoClick) {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            }
+
+            FilledTonalButton(
+                onClick = onScanClick,
+                modifier = Modifier.align(Alignment.End).bounceClick()
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.DeleteSweep,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                ButtonIconSpacer()
+                Text(text = stringResource(id = R.string.scan_cache))
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ClipboardCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ClipboardCleanerCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentPaste
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -32,7 +31,6 @@ fun ClipboardCleanerCard(
     clipboardText: String?,
     modifier: Modifier = Modifier,
     onCleanClick: () -> Unit,
-    onSeeMoreClick: () -> Unit,
 ) {
     OutlinedCard(
         modifier = modifier.fillMaxWidth() ,
@@ -85,15 +83,6 @@ fun ClipboardCleanerCard(
                     )
                     ButtonIconSpacer()
                     Text(text = stringResource(id = R.string.clean_clipboard))
-                }
-                FilledTonalButton(onClick = onSeeMoreClick, modifier = Modifier.weight(1f).bounceClick()) {
-                    Icon(
-                        imageVector = Icons.Outlined.Visibility,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                    ButtonIconSpacer()
-                    Text(text = stringResource(id = R.string.see_more))
                 }
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ImageOptimizerCard.kt
@@ -10,11 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Image
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.PhotoSizeSelectLarge
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -33,7 +31,6 @@ fun ImageOptimizerCard(
     modifier: Modifier = Modifier,
     lastOptimized: String? = null,
     onOptimizeClick: () -> Unit,
-    onInfoClick: () -> Unit = {},
 ) {
     OutlinedCard(
         modifier = modifier.fillMaxWidth() ,
@@ -63,13 +60,6 @@ fun ImageOptimizerCard(
                     Text(
                         text = stringResource(id = R.string.image_optimizer_card_subtitle),
                         style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-                IconButton(onClick = onInfoClick) {
-                    Icon(
-                        imageVector = Icons.Outlined.Info,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="image_optimizer_card_footer">Supports JPEG • Custom quality &amp; size</string>
     <string name="cache_cleaner_card_title">Cache Cleaner</string>
     <string name="cache_cleaner_card_subtitle">Free up space from app cache</string>
+    <string name="scan_cache">Scan Cache</string>
     <string name="cache_cleaner">Cache Cleaner</string>
     <string name="apks">APKs</string>
     <string name="archives">Archives</string>


### PR DESCRIPTION
## Summary
- refresh scanner cards when cleanup events occur
- clean up ImageOptimizerCard and ClipboardCleanerCard
- replace CacheCleanerCard icon button with a `Scan Cache` action
- add missing string resource

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659119bf1c832da43e8c0eaa855710