### PR TITLE
Add trash size badge

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/usecases/GetTrashSizeUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/domain/usecases/GetTrashSizeUseCase.kt
@@ -1,0 +1,10 @@
+package com.d4rk.cleaner.app.clean.trash.domain.usecases
+
+import com.d4rk.cleaner.core.data.datastore.DataStore
+import kotlinx.coroutines.flow.first
+
+class GetTrashSizeUseCase(private val dataStore: DataStore) {
+    suspend operator fun invoke(): Long {
+        return dataStore.trashSize.first()
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainViewModel.kt
@@ -18,8 +18,13 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.cleaner.app.main.domain.actions.MainAction
 import com.d4rk.cleaner.app.main.domain.actions.MainEvent
 import com.d4rk.cleaner.app.main.domain.model.UiMainScreen
+import com.d4rk.cleaner.app.clean.trash.domain.usecases.GetTrashSizeUseCase
+import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils
 
-class MainViewModel(private val performInAppUpdateUseCase : PerformInAppUpdateUseCase) : ScreenViewModel<UiMainScreen , MainEvent , MainAction>(initialState = UiStateScreen(data = UiMainScreen())) {
+class MainViewModel(
+    private val performInAppUpdateUseCase : PerformInAppUpdateUseCase,
+    private val getTrashSizeUseCase: GetTrashSizeUseCase,
+) : ScreenViewModel<UiMainScreen , MainEvent , MainAction>(initialState = UiStateScreen(data = UiMainScreen())) {
 
     init {
         onEvent(event = MainEvent.LoadNavigation)
@@ -40,6 +45,9 @@ class MainViewModel(private val performInAppUpdateUseCase : PerformInAppUpdateUs
 
     private fun loadNavigationItems() {
         launch {
+            val trashSize = getTrashSizeUseCase()
+            val trashBadge = if (trashSize > 0) StorageUtils.formatSizeReadable(trashSize) else ""
+
             screenState.successData {
                 copy(
                     navigationDrawerItems = listOf(
@@ -49,6 +57,7 @@ class MainViewModel(private val performInAppUpdateUseCase : PerformInAppUpdateUs
                         ) , NavigationDrawerItem(
                             title = com.d4rk.cleaner.R.string.trash ,
                             selectedIcon = Icons.Outlined.Delete ,
+                            badgeText = trashBadge ,
                         ) , NavigationDrawerItem(
                             title = R.string.settings ,
                             selectedIcon = Icons.Outlined.Settings ,

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -38,6 +38,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.usecases.DeleteFilesUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetFileTypesUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.MoveToTrashUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.UpdateTrashSizeUseCase
+import com.d4rk.cleaner.app.clean.trash.domain.usecases.GetTrashSizeUseCase
 import com.d4rk.cleaner.app.clean.scanner.ui.ScannerViewModel
 import com.d4rk.cleaner.app.clean.trash.domain.usecases.GetTrashFilesUseCase
 import com.d4rk.cleaner.app.clean.trash.domain.usecases.RestoreFromTrashUseCase
@@ -79,7 +80,10 @@ val appModule : Module = module {
     }
 
     viewModel<MainViewModel> { (launcher : ActivityResultLauncher<IntentSenderRequest>) ->
-        MainViewModel(performInAppUpdateUseCase = get { parametersOf(launcher) })
+        MainViewModel(
+            performInAppUpdateUseCase = get { parametersOf(launcher) },
+            getTrashSizeUseCase = get(),
+        )
     }
 
     single<ScannerRepositoryInterface> { ScannerRepositoryImpl(application = get() , dataStore = get()) }
@@ -89,6 +93,7 @@ val appModule : Module = module {
     single<DeleteFilesUseCase> { DeleteFilesUseCase(homeRepository = get()) }
     single<MoveToTrashUseCase> { MoveToTrashUseCase(homeRepository = get()) }
     single<UpdateTrashSizeUseCase> { UpdateTrashSizeUseCase(homeRepository = get()) }
+    single<GetTrashSizeUseCase> { GetTrashSizeUseCase(dataStore = get()) }
 
     viewModel<ScannerViewModel> {
         ScannerViewModel(


### PR DESCRIPTION
## Summary
- show trash size as badge in Main navigation drawer
- wire up GetTrashSizeUseCase in MainViewModel
- provide GetTrashSizeUseCase via DI

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865967e688c832d96301f32ae9c8778