### PR TITLE
Add cross-promo use case

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/PromotedApp.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/PromotedApp.kt
@@ -1,0 +1,7 @@
+package com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui
+
+data class PromotedApp(
+    val name: String,
+    val packageName: String,
+    val iconLogo: String,
+)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/UiScannerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/data/model/ui/UiScannerModel.kt
@@ -3,12 +3,14 @@ package com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui
 /** State of the cleaning process. */
 
 import com.d4rk.cleaner.app.clean.memory.domain.data.model.StorageInfo
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.PromotedApp
 import java.io.File
 
 data class UiScannerModel(
     val storageInfo : StorageInfo = StorageInfo() ,
     var analyzeState : UiAnalyzeModel = UiAnalyzeModel() ,
     var daysFromLastScan : Int = 0 ,
+    var promotedApp : PromotedApp? = null ,
     var isRescanDialogVisible : Boolean = false ,
 )
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetPromotedAppUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetPromotedAppUseCase.kt
@@ -1,0 +1,37 @@
+package com.d4rk.cleaner.app.clean.scanner.domain.usecases
+
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.PromotedApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.net.URL
+
+class GetPromotedAppUseCase {
+    suspend operator fun invoke(currentPackage: String): PromotedApp? = withContext(Dispatchers.IO) {
+        runCatching {
+            val apiUrl = "https://raw.githubusercontent.com/D4rK7355608/apps/main/apps.json"
+            val response = URL(apiUrl).readText()
+            val appsJson = JSONObject(response)
+                .getJSONObject("data")
+                .getJSONArray("apps")
+            val filtered = mutableListOf<PromotedApp>()
+            for (i in 0 until appsJson.length()) {
+                val item = appsJson.getJSONObject(i)
+                val category = item.optString("category")
+                if (category.equals("tools", true) || category.equals("utilities", true)) {
+                    val pkg = item.getString("packageName")
+                    if (pkg != currentPackage) {
+                        filtered.add(
+                            PromotedApp(
+                                name = item.getString("name"),
+                                packageName = pkg,
+                                iconLogo = item.getString("iconLogo")
+                            )
+                        )
+                    }
+                }
+            }
+            filtered.randomOrNull()
+        }.getOrNull()
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -45,6 +45,7 @@ import com.d4rk.cleaner.app.clean.scanner.ui.components.CacheCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ImageOptimizerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WhatsAppCleanerCard
+import com.d4rk.cleaner.app.clean.scanner.ui.components.PromotedAppCard
 import com.d4rk.cleaner.app.images.picker.ui.ImagePickerActivity
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 import org.koin.compose.viewmodel.koinViewModel
@@ -61,6 +62,7 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
     val appManagerState: UiStateScreen<UiAppManagerModel> by appManagerViewModel.uiState.collectAsState()
     val whatsappSummary by viewModel.whatsAppMediaSummary.collectAsState()
     val clipboardText by viewModel.clipboardPreview.collectAsState()
+    val promotedApp = uiState.data?.promotedApp
     val mediumRectAdsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 
     val showApkCard = appManagerState.data?.apkFiles?.isNotEmpty() == true
@@ -70,7 +72,8 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
     val visibleCardsCount = 3 +
         (if (showApkCard) 1 else 0) +
         (if (showWhatsAppCard) 1 else 0) +
-        (if (showClipboardCard) 1 else 0)
+        (if (showClipboardCard) 1 else 0) +
+        (if (promotedApp != null) 1 else 0)
 
     LaunchedEffect(key1 = true) {
         if (!PermissionsHelper.hasStoragePermissions(context)) {
@@ -214,6 +217,19 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                                     onCleanClick = { viewModel.onClipboardClear() }
                                 )
                             }
+                            itemIndex++
+                            if (visibleCardsCount > 3 && itemIndex % 4 == 0) {
+                                key("ad_$itemIndex") {
+                                    AdBanner(
+                                        modifier = Modifier.padding(bottom = SizeConstants.MediumSize),
+                                        adsConfig = mediumRectAdsConfig
+                                    )
+                                }
+                            }
+                        }
+
+                        promotedApp?.let { app ->
+                            PromotedAppCard(app = app)
                             itemIndex++
                             if (visibleCardsCount > 3 && itemIndex % 4 == 0) {
                                 key("ad_$itemIndex") {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -39,6 +39,7 @@ import com.d4rk.cleaner.app.clean.scanner.utils.helpers.getWhatsAppMediaSummary
 import com.d4rk.cleaner.app.settings.cleaning.utils.constants.ExtensionsConstants
 import com.d4rk.cleaner.core.data.datastore.DataStore
 import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetPromotedAppUseCase
 import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,6 +63,7 @@ class ScannerViewModel(
     private val deleteFilesUseCase: DeleteFilesUseCase,
     private val moveToTrashUseCase: MoveToTrashUseCase,
     private val updateTrashSizeUseCase: UpdateTrashSizeUseCase,
+    private val getPromotedAppUseCase: GetPromotedAppUseCase,
     private val dispatchers: DispatcherProvider,
     private val dataStore: DataStore
 ) : ScreenViewModel<UiScannerModel, ScannerEvent, ScannerAction>(
@@ -88,6 +90,7 @@ class ScannerViewModel(
         loadCleanedSpace()
         loadWhatsAppMedia()
         loadClipboardData()
+        loadPromotedApp()
         launch(dispatchers.io) {
             CleaningEventBus.events.collectLatest {
                 onEvent(ScannerEvent.RefreshData)
@@ -871,6 +874,17 @@ class ScannerViewModel(
                 videos = videos,
                 documents = docs
             )
+        }
+    }
+
+    private fun loadPromotedApp() {
+        launch(dispatchers.io) {
+            val promoted = getPromotedAppUseCase(application.packageName)
+            promoted?.let {
+                _uiState.updateData(ScreenState.Success()) { current ->
+                    current.copy(promotedApp = promoted)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/PromotedAppCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/PromotedAppCard.kt
@@ -1,0 +1,72 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.PromotedApp
+
+@Composable
+fun PromotedAppCard(app: PromotedApp, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(all = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+        ) {
+            Text(
+                text = stringResource(id = R.string.cleaner_recommends),
+                style = MaterialTheme.typography.labelMedium
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+            ) {
+                AsyncImage(
+                    model = app.iconLogo,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = SizeConstants.MediumSize).size(48.dp)
+                )
+                Text(
+                    text = app.name,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                FilledTonalButton(
+                    onClick = {
+                        IntentsHelper.openUrl(
+                            context = context,
+                            url = "https://play.google.com/store/apps/details?id=${app.packageName}"
+                        )
+                    },
+                    modifier = Modifier.bounceClick()
+                ) {
+                    Text(text = stringResource(id = R.string.install))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -93,6 +93,7 @@ val appModule : Module = module {
     single<DeleteFilesUseCase> { DeleteFilesUseCase(homeRepository = get()) }
     single<MoveToTrashUseCase> { MoveToTrashUseCase(homeRepository = get()) }
     single<UpdateTrashSizeUseCase> { UpdateTrashSizeUseCase(homeRepository = get()) }
+    single<GetPromotedAppUseCase> { GetPromotedAppUseCase() }
     single<GetTrashSizeUseCase> { GetTrashSizeUseCase(dataStore = get()) }
 
     viewModel<ScannerViewModel> {
@@ -104,6 +105,7 @@ val appModule : Module = module {
             deleteFilesUseCase = get(),
             moveToTrashUseCase = get(),
             updateTrashSizeUseCase = get(),
+            getPromotedAppUseCase = get(),
             dispatchers = get(),
             dataStore = get()
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="clean_clipboard">Clear Clipboard</string>
     <string name="see_more">View Details</string>
     <string name="learn_more">How It Works</string>
+    <string name="cleaner_recommends">Cleaner Recommends</string>
     <string name="image_optimizer_card_title">Image Optimizer</string>
     <string name="image_optimizer_card_subtitle">Compress photos without losing quality.&#10;Save space with one tap.</string>
     <string name="image_optimizer_last_format">Last optimization: %1$s</string>


### PR DESCRIPTION
## Summary
- move promoted-app logic into `GetPromotedAppUseCase`
- inject and use this use case inside `ScannerViewModel`
- display title text in `PromotedAppCard`
- provide the new use case in `AppModule`

## Testing
- `./gradlew tasks --all`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a08be084832db01f5b70dc93a039