### PR TITLE
Add WhatsApp cleaner feature screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,11 @@
             android:label="@string/trash"
             android:parentActivityName=".app.main.ui.MainActivity" />
 
+        <activity
+            android:name=".app.clean.whatsappcleaner.ui.WhatsAppCleanerActivity"
+            android:exported="false"
+            android:label="@string/clean_whatsapp"
+            android:parentActivityName=".app.main.ui.MainActivity" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -46,6 +46,7 @@ import com.d4rk.cleaner.app.clean.scanner.ui.components.ImageOptimizerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.PromotedAppCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.QuickScanSummaryCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WhatsAppCleanerCard
+import com.d4rk.cleaner.app.clean.whatsappcleaner.ui.WhatsAppCleanerActivity
 import com.d4rk.cleaner.app.images.picker.ui.ImagePickerActivity
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 import org.koin.compose.koinInject
@@ -163,7 +164,12 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                             AnimatedVisibility(visible = showWhatsAppCard) {
                                 WhatsAppCleanerCard(
                                     mediaSummary = whatsappSummary,
-                                    onCleanClick = { viewModel.onEvent(ScannerEvent.CleanWhatsAppFiles) }
+                                    onCleanClick = {
+                                        IntentsHelper.openActivity(
+                                            context = context,
+                                            activityClass = WhatsAppCleanerActivity::class.java
+                                        )
+                                    }
                                 )
                             }
                             itemIndex++

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/data/WhatsAppCleanerRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.data
+
+import android.app.Application
+import android.os.Environment
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interface.WhatsAppCleanerRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class WhatsAppCleanerRepositoryImpl(private val application: Application) : WhatsAppCleanerRepository {
+
+    private fun getWhatsAppMediaDir(): File {
+        val scoped = File(Environment.getExternalStorageDirectory(),
+            "Android/media/com.whatsapp/WhatsApp/Media")
+        val legacy = File(Environment.getExternalStorageDirectory(),
+            "WhatsApp/Media")
+        return when {
+            scoped.exists() -> scoped
+            legacy.exists() -> legacy
+            else -> scoped
+        }
+    }
+
+    override suspend fun getMediaSummary(): WhatsAppMediaSummary = withContext(Dispatchers.IO) {
+        val base = getWhatsAppMediaDir()
+        val images = File(base, "WhatsApp Images").listFiles()?.filter { it.isFile } ?: emptyList()
+        val videos = File(base, "WhatsApp Video").listFiles()?.filter { it.isFile } ?: emptyList()
+        val docs = File(base, "WhatsApp Documents").listFiles()?.filter { it.isFile } ?: emptyList()
+        WhatsAppMediaSummary(images = images, videos = videos, documents = docs)
+    }
+
+    override suspend fun deleteFiles(files: List<File>) = withContext(Dispatchers.IO) {
+        files.forEach { file ->
+            if (file.exists()) {
+                file.deleteRecursively()
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/di/WhatsAppCleanerModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/di/WhatsAppCleanerModule.kt
@@ -1,0 +1,18 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.di
+
+import com.d4rk.cleaner.app.clean.whatsappcleaner.data.WhatsAppCleanerRepositoryImpl
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interface.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.DeleteWhatsAppMediaUseCase
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.GetWhatsAppMediaSummaryUseCase
+import com.d4rk.cleaner.app.clean.whatsappcleaner.ui.WhatsAppCleanerViewModel
+import org.koin.android.ext.koin.androidApplication
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+val whatsAppCleanerModule: Module = module {
+    single<WhatsAppCleanerRepository> { WhatsAppCleanerRepositoryImpl(application = androidApplication()) }
+    single { GetWhatsAppMediaSummaryUseCase(repository = get()) }
+    single { DeleteWhatsAppMediaUseCase(repository = get()) }
+    viewModel { WhatsAppCleanerViewModel(getSummaryUseCase = get(), deleteUseCase = get(), dispatchers = get()) }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/data/model/ui/UiWhatsAppCleanerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/data/model/ui/UiWhatsAppCleanerModel.kt
@@ -1,0 +1,7 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.data.model.ui
+
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+
+data class UiWhatsAppCleanerModel(
+    val mediaSummary: WhatsAppMediaSummary = WhatsAppMediaSummary()
+)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/interface/WhatsAppCleanerRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/interface/WhatsAppCleanerRepository.kt
@@ -1,0 +1,9 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interface
+
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+import java.io.File
+
+interface WhatsAppCleanerRepository {
+    suspend fun getMediaSummary(): WhatsAppMediaSummary
+    suspend fun deleteFiles(files: List<File>)
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/DeleteWhatsAppMediaUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/DeleteWhatsAppMediaUseCase.kt
@@ -1,0 +1,17 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interface.WhatsAppCleanerRepository
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.io.File
+
+class DeleteWhatsAppMediaUseCase(private val repository: WhatsAppCleanerRepository) {
+    operator fun invoke(files: List<File>): Flow<DataState<Unit, Errors>> = flow {
+        runCatching { repository.deleteFiles(files) }
+            .onSuccess { emit(DataState.Success(Unit)) }
+            .onFailure { emit(DataState.Error(it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/GetWhatsAppMediaSummaryUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/GetWhatsAppMediaSummaryUseCase.kt
@@ -1,0 +1,18 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interface.WhatsAppCleanerRepository
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class GetWhatsAppMediaSummaryUseCase(private val repository: WhatsAppCleanerRepository) {
+    operator fun invoke(): Flow<DataState<WhatsAppMediaSummary, Errors>> = flow {
+        emit(DataState.Loading())
+        runCatching { repository.getMediaSummary() }
+            .onSuccess { emit(DataState.Success(it)) }
+            .onFailure { emit(DataState.Error(it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
@@ -1,0 +1,25 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+
+class WhatsAppCleanerActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AppTheme {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    WhatsAppCleanerScreen()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
@@ -1,0 +1,44 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun WhatsAppCleanerScreen(viewModel: WhatsAppCleanerViewModel = koinViewModel()) {
+    val state: UiStateScreen<UiWhatsAppCleanerModel> by viewModel.uiState.collectAsState()
+    ScreenStateHandler(state = state) { data ->
+        Content(summary = data.mediaSummary, onClean = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) })
+    }
+}
+
+@Composable
+private fun Content(summary: WhatsAppMediaSummary, onClean: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(all = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = stringResource(id = R.string.images) + ": ${summary.images.size}")
+        Text(text = stringResource(id = R.string.videos) + ": ${summary.videos.size}")
+        Text(text = stringResource(id = R.string.documents) + ": ${summary.documents.size}")
+        Button(onClick = onClean) {
+            Text(text = stringResource(id = R.string.clean_whatsapp))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerViewModel.kt
@@ -1,0 +1,75 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.data.model.ui.UiWhatsAppCleanerModel
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.DeleteWhatsAppMediaUseCase
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.GetWhatsAppMediaSummaryUseCase
+import kotlinx.coroutines.flow.collectLatest
+import java.io.File
+
+sealed interface WhatsAppCleanerEvent {
+    data object LoadMedia : WhatsAppCleanerEvent
+    data object CleanAll : WhatsAppCleanerEvent
+}
+
+sealed interface WhatsAppCleanerAction
+
+class WhatsAppCleanerViewModel(
+    private val getSummaryUseCase: GetWhatsAppMediaSummaryUseCase,
+    private val deleteUseCase: DeleteWhatsAppMediaUseCase,
+    private val dispatchers: DispatcherProvider
+) : ScreenViewModel<UiWhatsAppCleanerModel, WhatsAppCleanerEvent, WhatsAppCleanerAction>(
+    initialState = UiStateScreen(data = UiWhatsAppCleanerModel())
+) {
+
+    init { onEvent(WhatsAppCleanerEvent.LoadMedia) }
+
+    override fun onEvent(event: WhatsAppCleanerEvent) {
+        when (event) {
+            WhatsAppCleanerEvent.LoadMedia -> loadSummary()
+            WhatsAppCleanerEvent.CleanAll -> cleanAll()
+        }
+    }
+
+    private fun loadSummary() {
+        launch(context = dispatchers.io) {
+            getSummaryUseCase().collectLatest { result ->
+                _uiState.update { current ->
+                    when (result) {
+                        is DataState.Loading -> current.copy(screenState = ScreenState.IsLoading())
+                        is DataState.Success -> current.copy(
+                            screenState = ScreenState.Success(),
+                            data = current.data?.copy(mediaSummary = result.data)
+                                ?: UiWhatsAppCleanerModel(result.data)
+                        )
+                        is DataState.Error -> current.copy(
+                            screenState = ScreenState.Error(),
+                            errors = current.errors + UiSnackbar(
+                                message = UiTextHelper.DynamicString("${result.error}"),
+                                isError = true
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun cleanAll() {
+        val files = _uiState.value.data?.mediaSummary?.let { summary ->
+            summary.images + summary.videos + summary.documents
+        } ?: emptyList()
+        launch(context = dispatchers.io) {
+            deleteUseCase(files).collectLatest {
+                onEvent(WhatsAppCleanerEvent.LoadMedia)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/KoinModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/KoinModule.kt
@@ -7,12 +7,13 @@ import com.d4rk.cleaner.core.di.modules.appToolkitModule
 import com.d4rk.cleaner.core.di.modules.dispatchersModule
 import com.d4rk.cleaner.core.di.modules.notificationModule
 import com.d4rk.cleaner.core.di.modules.settingsModule
+import com.d4rk.cleaner.app.clean.whatsappcleaner.di.whatsAppCleanerModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
 fun initializeKoin(context : Context) {
     startKoin {
         androidContext(androidContext = context)
-        modules(modules = listOf(dispatchersModule , appModule , settingsModule , adsModule , appToolkitModule , notificationModule))
+        modules(modules = listOf(dispatchersModule , appModule , settingsModule , adsModule , appToolkitModule , notificationModule, whatsAppCleanerModule))
     }
 }


### PR DESCRIPTION
## Summary
- implement WhatsApp cleaner feature modules
- enable Koin module loading for WhatsApp cleaner
- add WhatsApp cleaner activity to manifest
- open WhatsApp cleaner screen from scanner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686618472dd4832d9cc500acb16087ae