### PR TITLE
Integrate WhatsApp cleaner feature

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/data/WhatsAppCleanerRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.d4rk.cleaner.app.clean.whatsappcleaner.data
 
 import android.app.Application
 import android.os.Environment
-import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interfaces.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.repository.WhatsAppCleanerRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -32,9 +32,7 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) : What
 
     override suspend fun deleteFiles(files: List<File>) = withContext(Dispatchers.IO) {
         files.forEach { file ->
-            if (file.exists()) {
-                file.deleteRecursively()
-            }
+            if (file.exists()) file.deleteRecursively()
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/di/whatsappCleanerModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/di/whatsappCleanerModule.kt
@@ -1,7 +1,7 @@
 package com.d4rk.cleaner.app.clean.whatsappcleaner.di
 
 import com.d4rk.cleaner.app.clean.whatsappcleaner.data.WhatsAppCleanerRepositoryImpl
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interfaces.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.repository.WhatsAppCleanerRepository
 import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.GetWhatsAppMediaSummaryUseCase
 import com.d4rk.cleaner.app.clean.whatsappcleaner.ui.WhatsAppCleanerViewModel
@@ -10,8 +10,8 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
-val whatsAppCleanerModule: Module = module {
-    single<WhatsAppCleanerRepository> { WhatsAppCleanerRepositoryImpl(application = androidApplication()) }
+val whatsappCleanerModule: Module = module {
+    single<WhatsAppCleanerRepository> { WhatsAppCleanerRepositoryImpl(androidApplication()) }
     single { GetWhatsAppMediaSummaryUseCase(repository = get()) }
     single { DeleteWhatsAppMediaUseCase(repository = get()) }
     viewModel { WhatsAppCleanerViewModel(getSummaryUseCase = get(), deleteUseCase = get(), dispatchers = get()) }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/data/model/ui/UiWhatsAppCleanerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/data/model/ui/UiWhatsAppCleanerModel.kt
@@ -1,7 +1,0 @@
-package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.data.model.ui
-
-import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
-
-data class UiWhatsAppCleanerModel(
-    val mediaSummary: WhatsAppMediaSummary = WhatsAppMediaSummary()
-)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/model/WhatsAppMediaSummary.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/model/WhatsAppMediaSummary.kt
@@ -1,0 +1,12 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model
+
+import java.io.File
+
+data class WhatsAppMediaSummary(
+    val images: List<File> = emptyList(),
+    val videos: List<File> = emptyList(),
+    val documents: List<File> = emptyList()
+) {
+    val hasData: Boolean
+        get() = images.isNotEmpty() || videos.isNotEmpty() || documents.isNotEmpty()
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/repository/WhatsAppCleanerRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/repository/WhatsAppCleanerRepository.kt
@@ -1,6 +1,6 @@
-package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interfaces
+package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.repository
 
-import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary
 import java.io.File
 
 interface WhatsAppCleanerRepository {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/DeleteWhatsAppMediaUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/DeleteWhatsAppMediaUseCase.kt
@@ -1,7 +1,7 @@
 package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interfaces.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.repository.WhatsAppCleanerRepository
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.extensions.toError
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/GetWhatsAppMediaSummaryUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/domain/usecases/GetWhatsAppMediaSummaryUseCase.kt
@@ -1,8 +1,8 @@
 package com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.interfaces.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.repository.WhatsAppCleanerRepository
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.extensions.toError
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/CustomTabLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/CustomTabLayout.kt
@@ -1,0 +1,45 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CustomTabLayout(
+    items: List<String>,
+    selectedIndex: Int,
+    onTabSelected: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        items.forEachIndexed { index, text ->
+            val selected = index == selectedIndex
+            Box(
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .clickable { onTabSelected(index) }
+                    .background(if (selected) MaterialTheme.colorScheme.primary else Color.Transparent)
+                    .padding(vertical = 8.dp, horizontal = 16.dp)
+            ) {
+                Text(text = text, color = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/DetailsScreen.kt
@@ -1,0 +1,24 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.io.File
+
+@Composable
+fun DetailsScreen(title: String, files: List<File>) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = title)
+        LazyColumn {
+            items(files) { file ->
+                Text(text = file.name)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/PermissionScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/PermissionScreen.kt
@@ -1,0 +1,32 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import android.app.Activity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
+
+@Composable
+fun PermissionScreen() {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = stringResource(id = R.string.onboarding_permission_storage_description))
+        Button(onClick = { PermissionsHelper.requestStoragePermissions(context as Activity) }) {
+            Text(text = stringResource(id = R.string.button_grant_permission))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/UiWhatsAppCleanerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/UiWhatsAppCleanerModel.kt
@@ -1,0 +1,7 @@
+package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+
+import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary
+
+data class UiWhatsAppCleanerModel(
+    val mediaSummary: WhatsAppMediaSummary = WhatsAppMediaSummary()
+)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
@@ -7,6 +7,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 
@@ -17,9 +23,27 @@ class WhatsAppCleanerActivity : AppCompatActivity() {
         setContent {
             AppTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    WhatsAppCleanerScreen()
+                    ScreenContent(onBack = { finish() })
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun ScreenContent(onBack: () -> Unit) {
+    androidx.compose.material3.Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(imageVector = Icons.Outlined.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        WhatsAppCleanerScreen(modifier = Modifier.padding(padding))
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
@@ -9,40 +9,33 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.cleaner.R
-import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.WhatsAppMediaSummary
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.data.model.ui.UiWhatsAppCleanerModel
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun WhatsAppCleanerScreen(viewModel: WhatsAppCleanerViewModel = koinViewModel()) {
+fun WhatsAppCleanerScreen(modifier: Modifier = Modifier, viewModel: WhatsAppCleanerViewModel = koinViewModel()) {
     val state: UiStateScreen<UiWhatsAppCleanerModel> by viewModel.uiState.collectAsState()
     ScreenStateHandler(
         screenState = state,
-        onLoading = {
-            LoadingScreen()
-        },
-        onEmpty = {
-            NoDataScreen()
-        },
+        modifier = modifier.fillMaxSize(),
+        onLoading = { LoadingScreen() },
+        onEmpty = { NoDataScreen() },
         onSuccess = { data ->
-            Content(
-                summary = data.mediaSummary,
-                onClean = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) })
+            Content(summary = data.mediaSummary, onClean = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) })
         }
     )
 }
 
 @Composable
-private fun Content(summary: WhatsAppMediaSummary, onClean: () -> Unit) {
+private fun Content(summary: com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary, onClean: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxSize().padding(all = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerViewModel.kt
@@ -10,7 +10,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.data.model.ui.UiWhatsAppCleanerModel
 import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsappcleaner.domain.usecases.GetWhatsAppMediaSummaryUseCase
 import kotlinx.coroutines.flow.collectLatest

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/KoinModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/KoinModule.kt
@@ -7,13 +7,13 @@ import com.d4rk.cleaner.core.di.modules.appToolkitModule
 import com.d4rk.cleaner.core.di.modules.dispatchersModule
 import com.d4rk.cleaner.core.di.modules.notificationModule
 import com.d4rk.cleaner.core.di.modules.settingsModule
-import com.d4rk.cleaner.app.clean.whatsappcleaner.di.whatsAppCleanerModule
+import com.d4rk.cleaner.app.clean.whatsappcleaner.di.whatsappCleanerModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
 fun initializeKoin(context : Context) {
     startKoin {
         androidContext(androidContext = context)
-        modules(modules = listOf(dispatchersModule , appModule , settingsModule , adsModule , appToolkitModule , notificationModule, whatsAppCleanerModule))
+        modules(modules = listOf(dispatchersModule , appModule , settingsModule , adsModule , appToolkitModule , notificationModule, whatsappCleanerModule))
     }
 }


### PR DESCRIPTION
## Summary
- refactor WhatsApp cleaner classes back under `app.clean.whatsappcleaner`
- update imports and manifest entry for new package path
- wire DI module via Koin using the corrected package name

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661e43c70c832d816891ee0271dc9a