### PR TITLE
Add navigation for WhatsApp cleaner

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
@@ -1,4 +1,4 @@
-package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/navigation/WhatsAppRoutes.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/navigation/WhatsAppRoutes.kt
@@ -1,0 +1,12 @@
+package com.d4rk.cleaner.app.clean.whatsapp.navigation
+
+sealed class WhatsAppRoute(val route: String) {
+    data object Permission : WhatsAppRoute("permission")
+    data object Summary : WhatsAppRoute("summary")
+    data class Details(val type: String) : WhatsAppRoute("details/{type}") {
+        companion object {
+            const val TYPE = "type"
+            fun create(type: String) = "details/$type"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/permission/ui/PermissionScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/permission/ui/PermissionScreen.kt
@@ -1,4 +1,4 @@
-package com.d4rk.cleaner.app.clean.whatsappcleaner.ui
+package com.d4rk.cleaner.app.clean.whatsapp.permission.ui
 
 import android.app.Activity
 import androidx.compose.foundation.layout.Arrangement
@@ -8,17 +8,35 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
 
 @Composable
-fun PermissionScreen() {
+fun PermissionScreen(onPermissionGranted: () -> Unit) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME &&
+                PermissionsHelper.hasStoragePermissions(context)
+            ) {
+                onPermissionGranted()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     Column(
         modifier = Modifier.fillMaxSize().padding(16.dp),
         verticalArrangement = Arrangement.Center,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -13,11 +15,22 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navArgument
+import androidx.navigation.compose.rememberNavController
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailsScreen
+import com.d4rk.cleaner.app.clean.whatsapp.navigation.WhatsAppRoute
+import com.d4rk.cleaner.app.clean.whatsapp.permission.ui.PermissionScreen
+import com.d4rk.cleaner.core.utils.helpers.PermissionsHelper
+import org.koin.compose.viewmodel.koinViewModel
 
 class WhatsAppCleanerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,6 +54,12 @@ class WhatsAppCleanerActivity : AppCompatActivity() {
 private fun ScreenContent(activity: Activity) {
     val scrollBehavior: TopAppBarScrollBehavior =
         TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+    val navController = rememberNavController()
+    val startDestination = if (PermissionsHelper.hasStoragePermissions(activity)) {
+        WhatsAppRoute.Summary.route
+    } else {
+        WhatsAppRoute.Permission.route
+    }
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.image_optimizer),
@@ -49,6 +68,44 @@ private fun ScreenContent(activity: Activity) {
         },
         scrollBehavior = scrollBehavior,
     ) { paddingValues ->
-        WhatsAppCleanerScreen(paddingValues = paddingValues)
+        NavHost(
+            navController = navController,
+            startDestination = startDestination,
+            modifier = Modifier.padding(paddingValues)
+        ) {
+            composable(WhatsAppRoute.Permission.route) {
+                PermissionScreen(onPermissionGranted = {
+                    navController.navigate(WhatsAppRoute.Summary.route) {
+                        popUpTo(WhatsAppRoute.Permission.route) { inclusive = true }
+                    }
+                })
+            }
+            composable(WhatsAppRoute.Summary.route) {
+                WhatsAppCleanerScreen(navController = navController, paddingValues = PaddingValues())
+            }
+            composable(
+                route = WhatsAppRoute.Details("").route,
+                arguments = listOf(navArgument(WhatsAppRoute.Details.TYPE) { type = NavType.StringType })
+            ) { backStackEntry ->
+                val type = backStackEntry.arguments?.getString(WhatsAppRoute.Details.TYPE) ?: ""
+                DetailsScreenNav(type = type)
+            }
+        }
     }
+}
+
+@Composable
+private fun DetailsScreenNav(
+    type: String,
+    viewModel: WhatsAppCleanerViewModel = koinViewModel()
+) {
+    val state = viewModel.uiState.collectAsState().value
+    val summary = state.data?.mediaSummary ?: com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary()
+    val files = when (type) {
+        "images" -> summary.images
+        "videos" -> summary.videos
+        "documents" -> summary.documents
+        else -> emptyList()
+    }
+    DetailsScreen(title = type, files = files)
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsappcleaner/ui/WhatsAppCleanerScreen.kt
@@ -14,15 +14,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.whatsapp.navigation.WhatsAppRoute
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun WhatsAppCleanerScreen(viewModel: WhatsAppCleanerViewModel = koinViewModel(), paddingValues: PaddingValues) {
+fun WhatsAppCleanerScreen(
+    navController: NavHostController,
+    viewModel: WhatsAppCleanerViewModel = koinViewModel(),
+    paddingValues: PaddingValues
+) {
     val state: UiStateScreen<UiWhatsAppCleanerModel> by viewModel.uiState.collectAsState()
     ScreenStateHandler(
         screenState = state,
@@ -32,22 +38,36 @@ fun WhatsAppCleanerScreen(viewModel: WhatsAppCleanerViewModel = koinViewModel(),
             Content(
                 paddingValues = paddingValues,
                 summary = data.mediaSummary,
-                onClean = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) }
+                onClean = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) },
+                onOpenDetails = { type ->
+                    navController.navigate(WhatsAppRoute.Details.create(type))
+                }
             )
         }
     )
 }
 
 @Composable
-private fun Content(summary: com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary, onClean: () -> Unit, paddingValues: PaddingValues) {
+private fun Content(
+    summary: com.d4rk.cleaner.app.clean.whatsappcleaner.domain.model.WhatsAppMediaSummary,
+    onClean: () -> Unit,
+    paddingValues: PaddingValues,
+    onOpenDetails: (String) -> Unit
+) {
     Column(
         modifier = Modifier.fillMaxSize().padding(paddingValues = paddingValues),
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(text = stringResource(id = R.string.images) + ": ${summary.images.size}")
-        Text(text = stringResource(id = R.string.videos) + ": ${summary.videos.size}")
-        Text(text = stringResource(id = R.string.documents) + ": ${summary.documents.size}")
+        Button(onClick = { onOpenDetails("images") }) {
+            Text(text = stringResource(id = R.string.images) + ": ${summary.images.size}")
+        }
+        Button(onClick = { onOpenDetails("videos") }) {
+            Text(text = stringResource(id = R.string.videos) + ": ${summary.videos.size}")
+        }
+        Button(onClick = { onOpenDetails("documents") }) {
+            Text(text = stringResource(id = R.string.documents) + ": ${summary.documents.size}")
+        }
         Button(onClick = onClean) {
             Text(text = stringResource(id = R.string.clean_whatsapp))
         }


### PR DESCRIPTION
## Summary
- move permission and details screens into dedicated whatsapp modules
- add navigation routes
- wire up navigation in WhatsAppCleanerActivity
- link UI to open details for each media type

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662609fa24832dafe8bf6d540b46e4