### PR TITLE
Improve clipboard clearing

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/data/ScannerRepositoryImpl.kt
@@ -2,11 +2,9 @@ package com.d4rk.cleaner.app.clean.scanner.data
 
 
 import android.app.Application
-import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.media.MediaScannerConnection
-import android.os.Build
 import android.os.Environment
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.memory.domain.data.model.StorageInfo
@@ -15,6 +13,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.UiScannerModel
 import com.d4rk.cleaner.app.clean.scanner.domain.`interface`.ScannerRepositoryInterface
 import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils
 import com.d4rk.cleaner.core.data.datastore.DataStore
+import com.d4rk.cleaner.core.utils.extensions.clearClipboardCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -160,12 +159,7 @@ class ScannerRepositoryImpl(
         val clipboardManager : ClipboardManager = application.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return
 
         runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                clipboardManager.clearPrimaryClip()
-            }
-            else {
-                clipboardManager.setPrimaryClip(ClipData.newPlainText("" , ""))
-            }
+            clipboardManager.clearClipboardCompat()
         }
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -1,10 +1,9 @@
 package com.d4rk.cleaner.app.clean.scanner.ui
 
 import android.app.Application
-import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.os.Build
+import com.d4rk.cleaner.core.utils.extensions.clearClipboardCompat
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
@@ -989,11 +988,7 @@ class ScannerViewModel(
 
     fun onClipboardClear() {
         runCatching {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                clipboardManager.clearPrimaryClip()
-            } else {
-                clipboardManager.setPrimaryClip(ClipData.newPlainText("", ""))
-            }
+            clipboardManager.clearClipboardCompat()
         }
         _clipboardPreview.value = null
         _clipboardDetectedSensitive.value = false

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/ClipboardExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/ClipboardExtensions.kt
@@ -1,0 +1,26 @@
+package com.d4rk.cleaner.core.utils.extensions
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.ClipboardManager
+import android.os.Build
+import android.os.PersistableBundle
+
+fun ClipboardManager.clearClipboardCompat() {
+    runCatching {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> {
+                clearPrimaryClip()
+            }
+            else -> {
+                val emptyClip = ClipData.newPlainText("", "")
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    emptyClip.description.extras = PersistableBundle().apply {
+                        putBoolean(ClipDescription.EXTRA_IS_SENSITIVE, true)
+                    }
+                }
+                setPrimaryClip(emptyClip)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `clearClipboardCompat` extension to handle pre and post-P Android versions
- use the extension in `ScannerViewModel` and `ScannerRepositoryImpl`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866284eef98832da207fa0485615ced