### PR TITLE
Use ScreenState from toolkit

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/model/ViewState.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/model/ViewState.kt
@@ -1,8 +1,0 @@
-package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.model
-
-// TODO: use the one from lib
-sealed class ViewState<out T> {
-    data object Loading : ViewState<Nothing>()
-    data class Success<T>(val data: T) : ViewState<T>()
-    data class Error(val message: String) : ViewState<Nothing>()
-}


### PR DESCRIPTION
## Summary
- replace custom `ViewState` with toolkit `ScreenStateHandler`
- refactor `WhatsAppCleanerScreen` to new pattern
- remove obsolete `ViewState` model

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664eebe8f0832d96a677fa561ebe06