### PR TITLE
Add view toggle and sort options

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailScreenTopBar.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailScreenTopBar.kt
@@ -1,0 +1,41 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.filled.ViewList
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DetailScreenTopBar(
+    title: String,
+    isGridView: Boolean,
+    onToggleView: () -> Unit,
+    onSortClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = { Text(text = title) },
+        actions = {
+            IconButton(onClick = onToggleView) {
+                Icon(
+                    imageVector = if (isGridView) Icons.Filled.ViewList else Icons.Filled.GridView,
+                    contentDescription = null
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            IconButton(onClick = onSortClick) {
+                Icon(imageVector = Icons.Filled.Sort, contentDescription = null)
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
@@ -12,12 +12,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +31,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.scanner.ui.components.FilePreviewCard
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.SortDialog
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailScreenTopBar
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailsViewModel
 import java.io.File
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -32,46 +41,94 @@ fun DetailsScreen(
     title: String,
     files: List<File>,
     onDelete: (List<File>) -> Unit,
+    viewModel: DetailsViewModel,
     padding: PaddingValues = PaddingValues()
 ) {
     val selected = remember { mutableStateListOf<File>() }
     val context = LocalContext.current
+    val sortedFiles by viewModel.files.collectAsState()
+    val isGrid by viewModel.isGridView.collectAsState()
+    var showSort by remember { mutableStateOf(false) }
 
-    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
-        Text(text = title, style = MaterialTheme.typography.titleLarge)
-        if (files.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text(text = context.getString(R.string.no_files))
-            }
-        } else {
-            LazyVerticalGrid(columns = GridCells.Adaptive(96.dp), modifier = Modifier.weight(1f)) {
-                items(files) { file ->
-                    val checked = file in selected
-                    Box(modifier = Modifier.padding(4.dp)) {
-                        FilePreviewCard(file = file, modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                if (checked) selected.remove(file) else selected.add(file)
-                            })
-                        Checkbox(
-                            checked = checked,
-                            onCheckedChange = {
-                                if (checked) selected.remove(file) else selected.add(file)
-                            },
-                            modifier = Modifier.align(Alignment.TopEnd)
-                        )
+    LaunchedEffect(files) {
+        viewModel.setFiles(files)
+    }
+
+    Scaffold(topBar = {
+        DetailScreenTopBar(
+            title = title,
+            isGridView = isGrid,
+            onToggleView = { viewModel.toggleView() },
+            onSortClick = { showSort = true }
+        )
+    }) { inner ->
+        Column(modifier = Modifier.fillMaxSize().padding(inner).padding(padding)) {
+            if (sortedFiles.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(text = context.getString(R.string.no_files))
+                }
+            } else {
+                if (isGrid) {
+                    LazyVerticalGrid(columns = GridCells.Adaptive(96.dp), modifier = Modifier.weight(1f)) {
+                        items(sortedFiles) { file ->
+                            val checked = file in selected
+                            Box(modifier = Modifier.padding(4.dp)) {
+                                FilePreviewCard(file = file, modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        if (checked) selected.remove(file) else selected.add(file)
+                                    })
+                                Checkbox(
+                                    checked = checked,
+                                    onCheckedChange = {
+                                        if (checked) selected.remove(file) else selected.add(file)
+                                    },
+                                    modifier = Modifier.align(Alignment.TopEnd)
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    LazyColumn(modifier = Modifier.weight(1f)) {
+                        items(sortedFiles) { file ->
+                            val checked = file in selected
+                            Row(modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(4.dp)
+                                .clickable {
+                                    if (checked) selected.remove(file) else selected.add(file)
+                                }
+                            ) {
+                                FilePreviewCard(file = file, modifier = Modifier.weight(1f))
+                                Checkbox(
+                                    checked = checked,
+                                    onCheckedChange = {
+                                        if (checked) selected.remove(file) else selected.add(file)
+                                    },
+                                    modifier = Modifier.align(Alignment.CenterVertically)
+                                )
+                            }
+                        }
                     }
                 }
-            }
-            Button(
-                onClick = { onDelete(selected.toList()) },
-                enabled = selected.isNotEmpty(),
-                modifier = Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(8.dp)
-            ) {
-                Text(text = context.getString(R.string.delete_selected))
+                Button(
+                    onClick = { onDelete(selected.toList()) },
+                    enabled = selected.isNotEmpty(),
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(8.dp)
+                ) {
+                    Text(text = context.getString(R.string.delete_selected))
+                }
             }
         }
+    }
+
+    if (showSort) {
+        SortDialog(
+            current = viewModel.sortType.collectAsState().value,
+            onDismiss = { showSort = false },
+            onSortSelected = { viewModel.applySort(it) }
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsViewModel.kt
@@ -1,0 +1,43 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.io.File
+
+enum class SortType { NAME, DATE, SIZE }
+
+class DetailsViewModel : ViewModel() {
+
+    private val _isGridView = MutableStateFlow(true)
+    val isGridView: StateFlow<Boolean> = _isGridView
+
+    private val _sortType = MutableStateFlow(SortType.DATE)
+    val sortType: StateFlow<SortType> = _sortType
+
+    private val _files = MutableStateFlow<List<File>>(emptyList())
+    val files: StateFlow<List<File>> = _files
+
+    fun setFiles(list: List<File>) {
+        _files.value = sort(list)
+    }
+
+    fun toggleView() {
+        _isGridView.value = !_isGridView.value
+    }
+
+    fun applySort(type: SortType) {
+        _sortType.value = type
+        _files.update { sort(it) }
+    }
+
+    private fun sort(list: List<File>): List<File> {
+        val sorted = when (_sortType.value) {
+            SortType.NAME -> list.sortedBy { it.name.lowercase() }
+            SortType.DATE -> list.sortedBy { it.lastModified() }
+            SortType.SIZE -> list.sortedBy { it.length() }
+        }
+        return sorted
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/SortDialog.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/SortDialog.kt
@@ -1,0 +1,58 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SortDialog(
+    current: SortType,
+    onDismiss: () -> Unit,
+    onSortSelected: (SortType) -> Unit
+) {
+    val options = SortType.values().toList()
+    val selected = remember { mutableStateOf(current) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = { onSortSelected(selected.value); onDismiss() }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+        title = { Text("Sort by") },
+        text = {
+            Column {
+                options.forEach { type ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { selected.value = type }
+                    ) {
+                        RadioButton(
+                            selected = selected.value == type,
+                            onClick = { selected.value = type }
+                        )
+                        Text(
+                            text = type.name.lowercase().replaceFirstChar { it.uppercase() }
+                        )
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsActivity.kt
@@ -14,11 +14,13 @@ import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.actions.WhatsAppCleanerEvent
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.WhatsAppMediaSummary
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsAppCleanerViewModel
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailsViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class WhatsAppDetailsActivity : AppCompatActivity() {
 
     private val viewModel: WhatsAppCleanerViewModel by viewModel()
+    private val detailsViewModel: DetailsViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +32,11 @@ class WhatsAppDetailsActivity : AppCompatActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    DetailsScreenContent(type = type, viewModel = viewModel)
+                    DetailsScreenContent(
+                        type = type,
+                        viewModel = viewModel,
+                        detailsViewModel = detailsViewModel
+                    )
                 }
             }
         }
@@ -42,7 +48,11 @@ class WhatsAppDetailsActivity : AppCompatActivity() {
 }
 
 @Composable
-private fun DetailsScreenContent(type: String, viewModel: WhatsAppCleanerViewModel) {
+private fun DetailsScreenContent(
+    type: String,
+    viewModel: WhatsAppCleanerViewModel,
+    detailsViewModel: DetailsViewModel
+) {
     val state = viewModel.uiState.collectAsState().value
     val summary = state.data?.mediaSummary ?: WhatsAppMediaSummary()
     val files = when (type) {
@@ -62,7 +72,8 @@ private fun DetailsScreenContent(type: String, viewModel: WhatsAppCleanerViewMod
     DetailsScreen(
         title = type,
         files = files,
-        onDelete = { viewModel.onEvent(WhatsAppCleanerEvent.DeleteSelected(it)) }
+        onDelete = { viewModel.onEvent(WhatsAppCleanerEvent.DeleteSelected(it)) },
+        viewModel = detailsViewModel
     )
 }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/whatsappCleanerModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/whatsappCleanerModule.kt
@@ -5,6 +5,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository.WhatsAppCle
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaSummaryUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsAppCleanerViewModel
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.DetailsViewModel
 import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
@@ -15,4 +16,5 @@ val whatsappCleanerModule: Module = module {
     single { GetWhatsAppMediaSummaryUseCase(repository = get()) }
     single { DeleteWhatsAppMediaUseCase(repository = get()) }
     viewModel { WhatsAppCleanerViewModel(getSummaryUseCase = get(), deleteUseCase = get(), dispatchers = get()) }
+    viewModel { DetailsViewModel() }
 }


### PR DESCRIPTION
## Summary
- implement `DetailsViewModel` with view type toggle and sorting
- add `DetailScreenTopBar` and `SortDialog` composables
- update `DetailsScreen` to use new view model and display grid or list
- wire view model into `WhatsAppDetailsActivity`
- register `DetailsViewModel` in Koin

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669e1edf4c832d929bfef85de23b7c