### PR TITLE
Add full WhatsApp media categories

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -38,31 +38,35 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) : What
             return DirectorySummary(files, size, formatted)
         }
 
-        val images = collect("WhatsApp Images")
-        val videos = collect("WhatsApp Video")
-        val docs = collect("WhatsApp Documents")
-        val audios = collect("WhatsApp Audio")
-        val statuses = collect(".Statuses")
-        val voiceNotes = collect("WhatsApp Voice Notes")
-        val videoNotes = collect("WhatsApp Video Notes")
-        val gifs = collect("WhatsApp Animated Gifs")
-        val wallpapers = collect("WallPaper")
-        val stickers = collect("WhatsApp Stickers")
-        val profile = collect("WhatsApp Profile Photos")
+        val directories = mapOf(
+            "images" to "WhatsApp Images",
+            "videos" to "WhatsApp Video",
+            "documents" to "WhatsApp Documents",
+            "audios" to "WhatsApp Audio",
+            "statuses" to ".Statuses",
+            "voice_notes" to "WhatsApp Voice Notes",
+            "video_notes" to "WhatsApp Video Notes",
+            "gifs" to "WhatsApp Animated Gifs",
+            "wallpapers" to "WallPaper",
+            "stickers" to "WhatsApp Stickers",
+            "profile_photos" to "WhatsApp Profile Photos",
+        )
 
-        val totalSize = listOf(
-            images,
-            videos,
-            docs,
-            audios,
-            statuses,
-            voiceNotes,
-            videoNotes,
-            gifs,
-            wallpapers,
-            stickers,
-            profile,
-        ).sumOf { it.totalBytes }
+        val collected = directories.mapValues { (_, dirName) -> collect(dirName) }
+
+        val images = collected.getValue("images")
+        val videos = collected.getValue("videos")
+        val docs = collected.getValue("documents")
+        val audios = collected.getValue("audios")
+        val statuses = collected.getValue("statuses")
+        val voiceNotes = collected.getValue("voice_notes")
+        val videoNotes = collected.getValue("video_notes")
+        val gifs = collected.getValue("gifs")
+        val wallpapers = collected.getValue("wallpapers")
+        val stickers = collected.getValue("stickers")
+        val profile = collected.getValue("profile_photos")
+
+        val totalSize = collected.values.sumOf { it.totalBytes }
         val totalFormatted = Formatter.formatFileSize(application, totalSize)
 
         WhatsAppMediaSummary(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerScreen.kt
@@ -132,6 +132,14 @@ private fun SuccessContent(
     val videos = stringResource(id = R.string.videos)
     val docs = stringResource(id = R.string.documents)
     val images = stringResource(id = R.string.images)
+    val audios = stringResource(id = R.string.audios)
+    val statuses = stringResource(id = R.string.statuses)
+    val voiceNotes = stringResource(id = R.string.voice_notes)
+    val videoNotes = stringResource(id = R.string.video_notes)
+    val gifs = stringResource(id = R.string.gifs)
+    val wallpapers = stringResource(id = R.string.wallpapers)
+    val stickers = stringResource(id = R.string.stickers)
+    val profiles = stringResource(id = R.string.profile_photos)
 
     val freeUp = uiModel.totalSize
 
@@ -157,7 +165,63 @@ private fun SuccessContent(
                 icon = R.drawable.ic_apk_document,
                 count = summary.documents.files.size,
                 size = summary.documents.formattedSize
-            )
+            ),
+            DirectoryItem(
+                type = "audios",
+                name = audios,
+                icon = R.drawable.ic_audio_file,
+                count = summary.audios.files.size,
+                size = summary.audios.formattedSize
+            ),
+            DirectoryItem(
+                type = "statuses",
+                name = statuses,
+                icon = R.drawable.ic_image,
+                count = summary.statuses.files.size,
+                size = summary.statuses.formattedSize
+            ),
+            DirectoryItem(
+                type = "voice_notes",
+                name = voiceNotes,
+                icon = R.drawable.ic_audio_file,
+                count = summary.voiceNotes.files.size,
+                size = summary.voiceNotes.formattedSize
+            ),
+            DirectoryItem(
+                type = "video_notes",
+                name = videoNotes,
+                icon = R.drawable.ic_video_file,
+                count = summary.videoNotes.files.size,
+                size = summary.videoNotes.formattedSize
+            ),
+            DirectoryItem(
+                type = "gifs",
+                name = gifs,
+                icon = R.drawable.ic_image,
+                count = summary.gifs.files.size,
+                size = summary.gifs.formattedSize
+            ),
+            DirectoryItem(
+                type = "wallpapers",
+                name = wallpapers,
+                icon = R.drawable.ic_image,
+                count = summary.wallpapers.files.size,
+                size = summary.wallpapers.formattedSize
+            ),
+            DirectoryItem(
+                type = "stickers",
+                name = stickers,
+                icon = R.drawable.ic_image,
+                count = summary.stickers.files.size,
+                size = summary.stickers.formattedSize
+            ),
+            DirectoryItem(
+                type = "profile_photos",
+                name = profiles,
+                icon = R.drawable.ic_image,
+                count = summary.profilePhotos.files.size,
+                size = summary.profilePhotos.formattedSize
+            ),
         )
     }
     val total = remember(directoryList) { directoryList.sumOf { it.count } }
@@ -249,6 +313,62 @@ private fun LoadingContent(
                         type = "documents",
                         name = docs,
                         icon = R.drawable.ic_apk_document,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "audios",
+                        name = audios,
+                        icon = R.drawable.ic_audio_file,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "statuses",
+                        name = statuses,
+                        icon = R.drawable.ic_image,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "voice_notes",
+                        name = voiceNotes,
+                        icon = R.drawable.ic_audio_file,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "video_notes",
+                        name = videoNotes,
+                        icon = R.drawable.ic_video_file,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "gifs",
+                        name = gifs,
+                        icon = R.drawable.ic_image,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "wallpapers",
+                        name = wallpapers,
+                        icon = R.drawable.ic_image,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "stickers",
+                        name = stickers,
+                        icon = R.drawable.ic_image,
+                        count = 0,
+                        size = "0 B"
+                    ),
+                    DirectoryItem(
+                        type = "profile_photos",
+                        name = profiles,
+                        icon = R.drawable.ic_image,
                         count = 0,
                         size = "0 B"
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,13 @@
     <string name="windows_files">Windows Files</string>
     <string name="videos">Videos</string>
     <string name="audios">Audios</string>
+    <string name="statuses">Statuses</string>
+    <string name="voice_notes">Voice Notes</string>
+    <string name="video_notes">Video Notes</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">Wallpapers</string>
+    <string name="stickers">Stickers</string>
+    <string name="profile_photos">Profile Photos</string>
     <string name="empty_folders">Empty Folders</string>
     <string name="duplicates">Duplicates</string>
     <plurals name="status_selected_files">


### PR DESCRIPTION
## Summary
- compute summary for all WhatsApp media folders
- expose each directory's size on screen
- list more categories (audios, statuses, notes, etc.)
- provide strings for the new categories

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ce0448ac832d85c6a20883a94f53