### PR TITLE
Filter empty WhatsApp media items

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsAppCleanerScreen.kt
@@ -202,7 +202,7 @@ private fun SuccessContent(
                 count = summary.profilePhotos.files.size,
                 size = summary.profilePhotos.formattedSize
             ),
-        )
+        ).filter { it.size != "0 B" }
     }
     val total = remember(directoryList) { directoryList.sumOf { it.count } }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryCard.kt
@@ -3,6 +3,7 @@ package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,7 +54,11 @@ fun DirectoryCard(item: DirectoryItem, onOpenDetails: (String) -> Unit, modifier
                 )
             }
             Column(modifier = Modifier.weight(1f)) {
-                Text(text = item.name, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.basicMarquee()
+                )
                 Text(text = item.size, style = MaterialTheme.typography.bodySmall)
             }
         }


### PR DESCRIPTION
## Summary
- filter out empty media categories in `WhatsAppCleanerScreen`
- apply a marquee effect to grid item titles

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e1cb5884832da64296b39f42f64a