### PR TITLE
Fix localized titles on WhatsApp details screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
@@ -70,6 +70,20 @@ fun DetailsScreen(
 
     val state = viewModel.uiState.collectAsState().value
     val summary = state.data?.mediaSummary ?: WhatsAppMediaSummary()
+    val localizedTitle = when (title) {
+        "images" -> stringResource(id = R.string.images)
+        "videos" -> stringResource(id = R.string.videos)
+        "documents" -> stringResource(id = R.string.documents)
+        "audios" -> stringResource(id = R.string.audios)
+        "statuses" -> stringResource(id = R.string.statuses)
+        "voice_notes" -> stringResource(id = R.string.voice_notes)
+        "video_notes" -> stringResource(id = R.string.video_notes)
+        "gifs" -> stringResource(id = R.string.gifs)
+        "wallpapers" -> stringResource(id = R.string.wallpapers)
+        "stickers" -> stringResource(id = R.string.stickers)
+        "profile_photos" -> stringResource(id = R.string.profile_photos)
+        else -> title
+    }
     val files = when (title) {
         "images" -> summary.images.files
         "videos" -> summary.videos.files
@@ -109,7 +123,7 @@ fun DetailsScreen(
                 Icon(imageVector = Icons.AutoMirrored.Filled.Sort, contentDescription = null)
             }
         },
-        title = title,
+        title = localizedTitle,
         onBackClicked = {
             activity.finish()
         },


### PR DESCRIPTION
## Summary
- show localized directory names on top bar of WhatsApp details screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678e3c10b0832db1dfe673b071fe9e