### PR TITLE
Centralize WhatsApp directory constants

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/WhatsAppUtils.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.app.clean.scanner.utils.helpers
 
 import android.os.Environment
+import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import java.io.File
 
 fun getWhatsAppMediaDirs(): File? {
@@ -16,8 +17,8 @@ fun getWhatsAppMediaSummary(): Triple<List<File>, List<File>, List<File>> {
         val dir = File(mediaDir, dirName)
         return dir.listFiles()?.filter { it.isFile && !it.name.startsWith(".") }?.sortedByDescending { it.lastModified() } ?: emptyList()
     }
-    val images = list("WhatsApp Images")
-    val videos = list("WhatsApp Video")
-    val docs = list("WhatsApp Documents")
+    val images = list(WhatsAppMediaConstants.DIRECTORIES[WhatsAppMediaConstants.IMAGES]!!)
+    val videos = list(WhatsAppMediaConstants.DIRECTORIES[WhatsAppMediaConstants.VIDEOS]!!)
+    val docs = list(WhatsAppMediaConstants.DIRECTORIES[WhatsAppMediaConstants.DOCUMENTS]!!)
     return Triple(images, videos, docs)
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/DetailsScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.cleaner.R
@@ -71,31 +72,31 @@ fun DetailsScreen(
     val state = viewModel.uiState.collectAsState().value
     val summary = state.data?.mediaSummary ?: WhatsAppMediaSummary()
     val localizedTitle = when (title) {
-        "images" -> stringResource(id = R.string.images)
-        "videos" -> stringResource(id = R.string.videos)
-        "documents" -> stringResource(id = R.string.documents)
-        "audios" -> stringResource(id = R.string.audios)
-        "statuses" -> stringResource(id = R.string.statuses)
-        "voice_notes" -> stringResource(id = R.string.voice_notes)
-        "video_notes" -> stringResource(id = R.string.video_notes)
-        "gifs" -> stringResource(id = R.string.gifs)
-        "wallpapers" -> stringResource(id = R.string.wallpapers)
-        "stickers" -> stringResource(id = R.string.stickers)
-        "profile_photos" -> stringResource(id = R.string.profile_photos)
+        WhatsAppMediaConstants.IMAGES -> stringResource(id = R.string.images)
+        WhatsAppMediaConstants.VIDEOS -> stringResource(id = R.string.videos)
+        WhatsAppMediaConstants.DOCUMENTS -> stringResource(id = R.string.documents)
+        WhatsAppMediaConstants.AUDIOS -> stringResource(id = R.string.audios)
+        WhatsAppMediaConstants.STATUSES -> stringResource(id = R.string.statuses)
+        WhatsAppMediaConstants.VOICE_NOTES -> stringResource(id = R.string.voice_notes)
+        WhatsAppMediaConstants.VIDEO_NOTES -> stringResource(id = R.string.video_notes)
+        WhatsAppMediaConstants.GIFS -> stringResource(id = R.string.gifs)
+        WhatsAppMediaConstants.WALLPAPERS -> stringResource(id = R.string.wallpapers)
+        WhatsAppMediaConstants.STICKERS -> stringResource(id = R.string.stickers)
+        WhatsAppMediaConstants.PROFILE_PHOTOS -> stringResource(id = R.string.profile_photos)
         else -> title
     }
     val files = when (title) {
-        "images" -> summary.images.files
-        "videos" -> summary.videos.files
-        "documents" -> summary.documents.files
-        "audios" -> summary.audios.files
-        "statuses" -> summary.statuses.files
-        "voice_notes" -> summary.voiceNotes.files
-        "video_notes" -> summary.videoNotes.files
-        "gifs" -> summary.gifs.files
-        "wallpapers" -> summary.wallpapers.files
-        "stickers" -> summary.stickers.files
-        "profile_photos" -> summary.profilePhotos.files
+        WhatsAppMediaConstants.IMAGES -> summary.images.files
+        WhatsAppMediaConstants.VIDEOS -> summary.videos.files
+        WhatsAppMediaConstants.DOCUMENTS -> summary.documents.files
+        WhatsAppMediaConstants.AUDIOS -> summary.audios.files
+        WhatsAppMediaConstants.STATUSES -> summary.statuses.files
+        WhatsAppMediaConstants.VOICE_NOTES -> summary.voiceNotes.files
+        WhatsAppMediaConstants.VIDEO_NOTES -> summary.videoNotes.files
+        WhatsAppMediaConstants.GIFS -> summary.gifs.files
+        WhatsAppMediaConstants.WALLPAPERS -> summary.wallpapers.files
+        WhatsAppMediaConstants.STICKERS -> summary.stickers.files
+        WhatsAppMediaConstants.PROFILE_PHOTOS -> summary.profilePhotos.files
         else -> emptyList()
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/data/WhatsAppCleanerRepositoryImpl.kt
@@ -6,6 +6,7 @@ import android.text.format.Formatter
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectorySummary
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.WhatsAppMediaSummary
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.repository.WhatsAppCleanerRepository
+import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -38,33 +39,21 @@ class WhatsAppCleanerRepositoryImpl(private val application: Application) : What
             return DirectorySummary(files, size, formatted)
         }
 
-        val directories = mapOf(
-            "images" to "WhatsApp Images",
-            "videos" to "WhatsApp Video",
-            "documents" to "WhatsApp Documents",
-            "audios" to "WhatsApp Audio",
-            "statuses" to ".Statuses",
-            "voice_notes" to "WhatsApp Voice Notes",
-            "video_notes" to "WhatsApp Video Notes",
-            "gifs" to "WhatsApp Animated Gifs",
-            "wallpapers" to "WallPaper",
-            "stickers" to "WhatsApp Stickers",
-            "profile_photos" to "WhatsApp Profile Photos",
-        )
+        val directories = WhatsAppMediaConstants.DIRECTORIES
 
         val collected = directories.mapValues { (_, dirName) -> collect(dirName) }
 
-        val images = collected.getValue("images")
-        val videos = collected.getValue("videos")
-        val docs = collected.getValue("documents")
-        val audios = collected.getValue("audios")
-        val statuses = collected.getValue("statuses")
-        val voiceNotes = collected.getValue("voice_notes")
-        val videoNotes = collected.getValue("video_notes")
-        val gifs = collected.getValue("gifs")
-        val wallpapers = collected.getValue("wallpapers")
-        val stickers = collected.getValue("stickers")
-        val profile = collected.getValue("profile_photos")
+        val images = collected.getValue(WhatsAppMediaConstants.IMAGES)
+        val videos = collected.getValue(WhatsAppMediaConstants.VIDEOS)
+        val docs = collected.getValue(WhatsAppMediaConstants.DOCUMENTS)
+        val audios = collected.getValue(WhatsAppMediaConstants.AUDIOS)
+        val statuses = collected.getValue(WhatsAppMediaConstants.STATUSES)
+        val voiceNotes = collected.getValue(WhatsAppMediaConstants.VOICE_NOTES)
+        val videoNotes = collected.getValue(WhatsAppMediaConstants.VIDEO_NOTES)
+        val gifs = collected.getValue(WhatsAppMediaConstants.GIFS)
+        val wallpapers = collected.getValue(WhatsAppMediaConstants.WALLPAPERS)
+        val stickers = collected.getValue(WhatsAppMediaConstants.STICKERS)
+        val profile = collected.getValue(WhatsAppMediaConstants.PROFILE_PHOTOS)
 
         val totalSize = collected.values.sumOf { it.totalBytes }
         val totalFormatted = Formatter.formatFileSize(application, totalSize)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -58,6 +58,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleanerModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.CleanerProgressIndicator
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.DirectoryGrid
+import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import org.koin.compose.viewmodel.koinViewModel
 
 
@@ -171,77 +172,77 @@ private fun WhatsappCleanerSummaryScreenSuccessContent(
     val directoryList = remember(summary) {
         listOf(
             DirectoryItem(
-                type = "images",
+                type = WhatsAppMediaConstants.IMAGES,
                 name = images,
                 icon = R.drawable.ic_image,
                 count = summary.images.files.size,
                 size = summary.images.formattedSize
             ),
             DirectoryItem(
-                type = "videos",
+                type = WhatsAppMediaConstants.VIDEOS,
                 name = videos,
                 icon = R.drawable.ic_video_file,
                 count = summary.videos.files.size,
                 size = summary.videos.formattedSize
             ),
             DirectoryItem(
-                type = "documents",
+                type = WhatsAppMediaConstants.DOCUMENTS,
                 name = docs,
                 icon = R.drawable.ic_description,
                 count = summary.documents.files.size,
                 size = summary.documents.formattedSize
             ),
             DirectoryItem(
-                type = "audios",
+                type = WhatsAppMediaConstants.AUDIOS,
                 name = audios,
                 icon = R.drawable.ic_audio_file,
                 count = summary.audios.files.size,
                 size = summary.audios.formattedSize
             ),
             DirectoryItem(
-                type = "statuses",
+                type = WhatsAppMediaConstants.STATUSES,
                 name = statuses,
                 icon = R.drawable.ic_web_stories,
                 count = summary.statuses.files.size,
                 size = summary.statuses.formattedSize
             ),
             DirectoryItem(
-                type = "voice_notes",
+                type = WhatsAppMediaConstants.VOICE_NOTES,
                 name = voiceNotes,
                 icon = R.drawable.ic_voice_selection,
                 count = summary.voiceNotes.files.size,
                 size = summary.voiceNotes.formattedSize
             ),
             DirectoryItem(
-                type = "video_notes",
+                type = WhatsAppMediaConstants.VIDEO_NOTES,
                 name = videoNotes,
                 icon = R.drawable.ic_video_file,
                 count = summary.videoNotes.files.size,
                 size = summary.videoNotes.formattedSize
             ),
             DirectoryItem(
-                type = "gifs",
+                type = WhatsAppMediaConstants.GIFS,
                 name = gifs,
                 icon = R.drawable.ic_gif,
                 count = summary.gifs.files.size,
                 size = summary.gifs.formattedSize
             ),
             DirectoryItem(
-                type = "wallpapers",
+                type = WhatsAppMediaConstants.WALLPAPERS,
                 name = wallpapers,
                 icon = R.drawable.ic_wallpaper,
                 count = summary.wallpapers.files.size,
                 size = summary.wallpapers.formattedSize
             ),
             DirectoryItem(
-                type = "stickers",
+                type = WhatsAppMediaConstants.STICKERS,
                 name = stickers,
                 icon = R.drawable.ic_ar_stickers,
                 count = summary.stickers.files.size,
                 size = summary.stickers.formattedSize
             ),
             DirectoryItem(
-                type = "profile_photos",
+                type = WhatsAppMediaConstants.PROFILE_PHOTOS,
                 name = profiles,
                 icon = R.drawable.ic_person_pin,
                 count = summary.profilePhotos.files.size,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/utils/constants/WhatsAppMediaConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/utils/constants/WhatsAppMediaConstants.kt
@@ -1,0 +1,29 @@
+package com.d4rk.cleaner.app.clean.whatsapp.utils.constants
+
+object WhatsAppMediaConstants {
+    const val IMAGES = "images"
+    const val VIDEOS = "videos"
+    const val DOCUMENTS = "documents"
+    const val AUDIOS = "audios"
+    const val STATUSES = "statuses"
+    const val VOICE_NOTES = "voice_notes"
+    const val VIDEO_NOTES = "video_notes"
+    const val GIFS = "gifs"
+    const val WALLPAPERS = "wallpapers"
+    const val STICKERS = "stickers"
+    const val PROFILE_PHOTOS = "profile_photos"
+
+    val DIRECTORIES = mapOf(
+        IMAGES to "WhatsApp Images",
+        VIDEOS to "WhatsApp Video",
+        DOCUMENTS to "WhatsApp Documents",
+        AUDIOS to "WhatsApp Audio",
+        STATUSES to ".Statuses",
+        VOICE_NOTES to "WhatsApp Voice Notes",
+        VIDEO_NOTES to "WhatsApp Video Notes",
+        GIFS to "WhatsApp Animated Gifs",
+        WALLPAPERS to "WallPaper",
+        STICKERS to "WhatsApp Stickers",
+        PROFILE_PHOTOS to "WhatsApp Profile Photos",
+    )
+}


### PR DESCRIPTION
## Summary
- add `WhatsAppMediaConstants` to hold WhatsApp media type keys and directory names
- use these constants in `DetailsScreen`, repository and summary screen
- update `WhatsAppUtils` to use new constants

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867906eefb4832dbf918c6c6accb04a