### PR TITLE
Add tabs to WhatsApp details

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 Vishnu Sanal T
+ *
+ * This file is part of WhatsAppCleaner.
+ *
+ * Quotes Status Creator is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.cleaner.app.clean.whatsapp.details.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CustomTabLayout(
+    modifier: Modifier = Modifier,
+    selectedItemIndex: Int,
+    items: List<String>,
+    onTabSelected: (index: Int) -> Unit,
+) {
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val tabWidth = (screenWidth - 32.dp) / items.size
+
+    val indicatorOffset: Dp by animateDpAsState(
+        targetValue = tabWidth * selectedItemIndex,
+        animationSpec = tween(easing = LinearEasing),
+        label = "indicator-offset"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .height(intrinsicSize = IntrinsicSize.Min),
+    ) {
+        TabIndicator(
+            indicatorWidth = tabWidth,
+            indicatorOffset = indicatorOffset,
+            indicatorColor = MaterialTheme.colorScheme.primary,
+        )
+        Row(
+            modifier = Modifier.clip(CircleShape),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            items.mapIndexed { index, text ->
+                val isSelected = index == selectedItemIndex
+
+                TabItem(
+                    isSelected = isSelected,
+                    onClick = {
+                        onTabSelected(index)
+                    },
+                    tabWidth = tabWidth,
+                    text = text,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TabItem(
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    tabWidth: Dp,
+    text: String,
+) {
+    val tabTextColor: Color by animateColorAsState(
+        targetValue = if (isSelected) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = tween(easing = LinearEasing),
+    )
+
+    Text(
+        modifier = Modifier
+            .clip(CircleShape)
+            .clickable {
+                onClick()
+            }
+            .width(tabWidth)
+            .padding(12.dp),
+        text = text,
+        color = tabTextColor,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+private fun TabIndicator(
+    indicatorWidth: Dp,
+    indicatorOffset: Dp,
+    indicatorColor: Color,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(
+                width = indicatorWidth,
+            )
+            .offset(
+                x = indicatorOffset,
+            )
+            .clip(
+                shape = CircleShape,
+            )
+            .background(
+                color = indicatorColor,
+            ),
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,9 @@
     <string name="wallpapers">Wallpapers</string>
     <string name="stickers">Stickers</string>
     <string name="profile_photos">Profile Photos</string>
+    <string name="received">Received</string>
+    <string name="sent">Sent</string>
+    <string name="private_tab">Private</string>
     <string name="can_be_freed">Can be freed</string>
     <string name="empty_folders">Empty Folders</string>
     <string name="duplicates">Duplicates</string>


### PR DESCRIPTION
## Summary
- add Received/Sent/Private strings
- port `CustomTabLayout` from old module
- integrate tabbed pager into WhatsApp Details screen

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f5c6405c832d893b5f8f877fc319