### PR TITLE
Add checkbox tabs & uniform delete button

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
@@ -29,12 +29,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,15 +46,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import java.io.File
 
 @Composable
 fun CustomTabLayout(
     modifier: Modifier = Modifier,
     selectedItemIndex: Int,
     items: List<String>,
+    filesPerTab: List<List<File>>,
+    selectedFiles: List<File>,
     onTabSelected: (index: Int) -> Unit,
+    onTabCheckedChange: (index: Int, checked: Boolean) -> Unit,
 ) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val tabWidth = (screenWidth - 32.dp) / items.size
@@ -79,12 +86,14 @@ fun CustomTabLayout(
         ) {
             items.mapIndexed { index, text ->
                 val isSelected = index == selectedItemIndex
+                val files = filesPerTab.getOrNull(index) ?: emptyList()
+                val isChecked = files.isNotEmpty() && files.all { it in selectedFiles }
 
                 TabItem(
                     isSelected = isSelected,
-                    onClick = {
-                        onTabSelected(index)
-                    },
+                    checked = isChecked,
+                    onTabClick = { onTabSelected(index) },
+                    onCheckedChange = { onTabCheckedChange(index, it) },
                     tabWidth = tabWidth,
                     text = text,
                 )
@@ -96,7 +105,9 @@ fun CustomTabLayout(
 @Composable
 private fun TabItem(
     isSelected: Boolean,
-    onClick: () -> Unit,
+    checked: Boolean,
+    onTabClick: () -> Unit,
+    onCheckedChange: (Boolean) -> Unit,
     tabWidth: Dp,
     text: String,
 ) {
@@ -109,18 +120,26 @@ private fun TabItem(
         animationSpec = tween(easing = LinearEasing),
     )
 
-    Text(
+    Row(
         modifier = Modifier
             .clip(CircleShape)
-            .clickable {
-                onClick()
-            }
+            .clickable { onTabClick() }
             .width(tabWidth)
             .padding(12.dp),
-        text = text,
-        color = tabTextColor,
-        textAlign = TextAlign.Center,
-    )
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = text,
+            color = tabTextColor,
+            textAlign = TextAlign.Center,
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- add checkbox support to custom WhatsApp tabs
- keep selected files when switching pages
- add bottom delete button outside pager

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fada0e88832daa0142d5ea137666