### PR TITLE
Refactor WhatsApp details tab layout

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/CustomTabLayout.kt
@@ -19,35 +19,22 @@
 
 package com.d4rk.cleaner.app.clean.whatsapp.details.ui.components
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import java.io.File
 
@@ -61,107 +48,40 @@ fun CustomTabLayout(
     onTabSelected: (index: Int) -> Unit,
     onTabCheckedChange: (index: Int, checked: Boolean) -> Unit,
 ) {
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val tabWidth = (screenWidth - 32.dp) / items.size
-
-    val indicatorOffset: Dp by animateDpAsState(
-        targetValue = tabWidth * selectedItemIndex,
-        animationSpec = tween(easing = LinearEasing),
-        label = "indicator-offset"
-    )
-
-    Box(
-        modifier = modifier
-            .clip(CircleShape)
-            .height(intrinsicSize = IntrinsicSize.Min),
+    ScrollableTabRow(
+        modifier = modifier.fillMaxWidth(),
+        selectedTabIndex = selectedItemIndex,
+        edgePadding = 0.dp,
+        indicator = { tabPositions ->
+            TabRowDefaults.PrimaryIndicator(
+                modifier = Modifier.tabIndicatorOffset(tabPositions[selectedItemIndex]),
+                shape = RoundedCornerShape(topStart = 3.dp, topEnd = 3.dp)
+            )
+        }
     ) {
-        TabIndicator(
-            indicatorWidth = tabWidth,
-            indicatorOffset = indicatorOffset,
-            indicatorColor = MaterialTheme.colorScheme.primary,
-        )
-        Row(
-            modifier = Modifier.clip(CircleShape),
-            horizontalArrangement = Arrangement.Center,
-        ) {
-            items.mapIndexed { index, text ->
-                val isSelected = index == selectedItemIndex
-                val files = filesPerTab.getOrNull(index) ?: emptyList()
-                val isChecked = files.isNotEmpty() && files.all { it in selectedFiles }
+        items.forEachIndexed { index, text ->
+            val files = filesPerTab.getOrNull(index) ?: emptyList()
+            val isChecked = files.isNotEmpty() && files.all { it in selectedFiles }
 
-                TabItem(
-                    isSelected = isSelected,
-                    checked = isChecked,
-                    onTabClick = { onTabSelected(index) },
-                    onCheckedChange = { onTabCheckedChange(index, it) },
-                    tabWidth = tabWidth,
-                    text = text,
-                )
-            }
+            Tab(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50)),
+                selected = selectedItemIndex == index,
+                onClick = { onTabSelected(index) },
+                text = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start
+                    ) {
+                        Checkbox(
+                            checked = isChecked,
+                            onCheckedChange = { onTabCheckedChange(index, it) },
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(text)
+                    }
+                }
+            )
         }
     }
-}
-
-@Composable
-private fun TabItem(
-    isSelected: Boolean,
-    checked: Boolean,
-    onTabClick: () -> Unit,
-    onCheckedChange: (Boolean) -> Unit,
-    tabWidth: Dp,
-    text: String,
-) {
-    val tabTextColor: Color by animateColorAsState(
-        targetValue = if (isSelected) {
-            MaterialTheme.colorScheme.onPrimary
-        } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
-        },
-        animationSpec = tween(easing = LinearEasing),
-    )
-
-    Row(
-        modifier = Modifier
-            .clip(CircleShape)
-            .clickable { onTabClick() }
-            .width(tabWidth)
-            .padding(12.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Checkbox(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-        )
-        Spacer(modifier = Modifier.width(4.dp))
-        Text(
-            text = text,
-            color = tabTextColor,
-            textAlign = TextAlign.Center,
-        )
-    }
-}
-
-@Composable
-private fun TabIndicator(
-    indicatorWidth: Dp,
-    indicatorOffset: Dp,
-    indicatorColor: Color,
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxHeight()
-            .width(
-                width = indicatorWidth,
-            )
-            .offset(
-                x = indicatorOffset,
-            )
-            .clip(
-                shape = CircleShape,
-            )
-            .background(
-                color = indicatorColor,
-            ),
-    )
 }


### PR DESCRIPTION
## Summary
- refactor `CustomTabLayout` to use `ScrollableTabRow` and `Tab`
- this design matches the analyze screen's tabs

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686835ff095c832d9f4620e0da767edc