### PR TITLE
Add confirmation dialog to WhatsApp cleaner

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -15,11 +15,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,6 +59,8 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
     val scrollBehavior: TopAppBarScrollBehavior =
         TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
+    var showCleanDialog by remember { mutableStateOf(false) }
+
     val state: UiStateScreen<UiWhatsAppCleanerModel> by viewModel.uiState.collectAsState()
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -76,7 +82,7 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
         scrollBehavior = scrollBehavior,
         floatingActionButton = {
             AnimatedExtendedFloatingActionButton(
-                onClick = { viewModel.onEvent(WhatsAppCleanerEvent.CleanAll) },
+                onClick = { showCleanDialog = true },
                 icon = {
                     Icon(
                         modifier = Modifier.size(SizeConstants.ButtonIconSize),
@@ -113,6 +119,27 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
                     }
                 )
             }
+        )
+    }
+
+    if (showCleanDialog) {
+        AlertDialog(
+            onDismissRequest = { showCleanDialog = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    showCleanDialog = false
+                    viewModel.onEvent(WhatsAppCleanerEvent.CleanAll)
+                }) {
+                    Text(text = stringResource(id = R.string.clean_whatsapp))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCleanDialog = false }) {
+                    Text(text = stringResource(id = R.string.cancel))
+                }
+            },
+            title = { Text(text = stringResource(id = R.string.clean_whatsapp_warning_title)) },
+            text = { Text(text = stringResource(id = R.string.clean_whatsapp_warning_message)) }
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="whatsapp_card_title">WhatsApp Files</string>
     <string name="whatsapp_card_subtitle">Clear out media you no longer need.</string>
     <string name="clean_whatsapp">Clean WhatsApp Media</string>
+    <string name="clean_whatsapp_warning_title">Clean WhatsApp Media</string>
+    <string name="clean_whatsapp_warning_message">This will delete all WhatsApp media files. Continue?</string>
+    <string name="cancel">Cancel</string>
     <string name="whatsapp_cleaner">WhatsApp Cleaner</string>
     <string name="free_up_format">You can free up %1$s</string>
     <string name="total_files_format">%1$s files</string>


### PR DESCRIPTION
## Summary
- show a confirmation dialog before deleting WhatsApp media
- add strings for the new dialog

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683ba24620832dada7ff192bf74c80