### PR TITLE
Use ScreenViewModel in WhatsApp details

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/actions/WhatsAppDetailsAction.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/actions/WhatsAppDetailsAction.kt
@@ -1,0 +1,8 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface WhatsAppDetailsAction : ActionEvent {
+    data class ShowSnackbar(val message: UiSnackbar) : WhatsAppDetailsAction
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/actions/WhatsAppDetailsEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/actions/WhatsAppDetailsEvent.kt
@@ -1,0 +1,16 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.SortType
+import java.io.File
+
+sealed interface WhatsAppDetailsEvent : UiEvent {
+    data class SetFiles(val files: List<File>) : WhatsAppDetailsEvent
+    data object ToggleView : WhatsAppDetailsEvent
+    data class ApplySort(
+        val type: SortType,
+        val descending: Boolean,
+        val startDate: Long?,
+        val endDate: Long?,
+    ) : WhatsAppDetailsEvent
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/model/UiWhatsAppDetailsModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/domain/model/UiWhatsAppDetailsModel.kt
@@ -1,0 +1,14 @@
+package com.d4rk.cleaner.app.clean.whatsapp.details.domain.model
+
+import com.d4rk.cleaner.app.clean.whatsapp.details.ui.SortType
+import java.io.File
+
+data class UiWhatsAppDetailsModel(
+    val isGridView: Boolean = true,
+    val descending: Boolean = false,
+    val startDate: Long? = null,
+    val endDate: Long? = null,
+    val sortType: SortType = SortType.DATE,
+    val files: List<File> = emptyList(),
+    val suggested: List<File> = emptyList(),
+)

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/whatsappCleanerModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/whatsappCleanerModule.kt
@@ -16,5 +16,5 @@ val whatsappCleanerModule: Module = module {
     single { GetWhatsAppMediaSummaryUseCase(repository = get()) }
     single { DeleteWhatsAppMediaUseCase(repository = get()) }
     viewModel { WhatsappCleanerSummaryViewModel(getSummaryUseCase = get(), deleteUseCase = get(), dispatchers = get()) }
-    viewModel { DetailsViewModel(dataStore = get()) }
+    viewModel { DetailsViewModel(dataStore = get(), dispatchers = get()) }
 }


### PR DESCRIPTION
## Summary
- introduce `WhatsAppDetailsEvent`/`WhatsAppDetailsAction`
- manage details UI state via `UiWhatsAppDetailsModel`
- refactor `WhatsAppDetailsViewModel` to `ScreenViewModel`
- adapt `WhatsAppDetailsScreen` to new events
- inject dispatchers into `DetailsViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683fa9c5b0832db632151b518e2642