### PR TITLE
Implement weekly clean streak card

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
@@ -15,8 +15,10 @@ import coil3.memory.MemoryCache
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.cleaner.app.notifications.work.CleanupReminderScheduler
+import com.d4rk.cleaner.app.notifications.work.StreakReminderScheduler
 import com.d4rk.cleaner.core.di.initializeKoin
 import com.d4rk.cleaner.core.utils.constants.ads.AdsConstants
+import com.d4rk.cleaner.core.utils.helpers.StreakTracker
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
@@ -29,9 +31,11 @@ class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory {
 
     override fun onCreate() {
         initializeKoin(context = this)
+        StreakTracker.initialize()
         SingletonImageLoader.setSafe { newImageLoader(this) }
         super.onCreate()
         CleanupReminderScheduler.schedule(this)
+        StreakReminderScheduler.schedule(this)
         registerActivityLifecycleCallbacks(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(observer = this)
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -45,6 +45,7 @@ import com.d4rk.cleaner.app.clean.scanner.ui.components.ClipboardCleanerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.ImageOptimizerCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.PromotedAppCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.QuickScanSummaryCard
+import com.d4rk.cleaner.app.clean.scanner.ui.components.WeeklyCleanStreakCard
 import com.d4rk.cleaner.app.clean.scanner.ui.components.WhatsAppCleanerCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsAppCleanerActivity
 import com.d4rk.cleaner.app.images.picker.ui.ImagePickerActivity
@@ -63,6 +64,7 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
     val appManagerState: UiStateScreen<UiAppManagerModel> by appManagerViewModel.uiState.collectAsState()
     val whatsappSummary by viewModel.whatsAppMediaSummary.collectAsState()
     val clipboardText by viewModel.clipboardPreview.collectAsState()
+    val streakDays by viewModel.cleanStreak.collectAsState()
     val promotedApp = uiState.data?.promotedApp
     val mediumRectAdsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
     val largeBannerAdsConfig: AdsConfig = koinInject(qualifier = named(name = "large_banner"))
@@ -120,6 +122,8 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
                             progress = uiState.data?.storageInfo?.storageUsageProgress ?: 0f,
                             onQuickScanClick = { viewModel.onEvent(event = ScannerEvent.ToggleAnalyzeScreen(visible = true)) }
                         )
+
+                        WeeklyCleanStreakCard(streakDays = streakDays)
 
                         if (showWhatsAppCard) {
                             AnimatedVisibility(visible = showWhatsAppCard) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -83,6 +83,9 @@ class ScannerViewModel(
     private val _clipboardDetectedSensitive = MutableStateFlow(false)
     val clipboardDetectedSensitive: StateFlow<Boolean> = _clipboardDetectedSensitive
 
+    private val _cleanStreak = MutableStateFlow(0)
+    val cleanStreak: StateFlow<Int> = _cleanStreak
+
     init {
         clipboardManager.addPrimaryClipChangedListener(clipboardListener)
         onEvent(ScannerEvent.LoadInitialData)
@@ -90,6 +93,7 @@ class ScannerViewModel(
         loadWhatsAppMedia()
         loadClipboardData()
         loadPromotedApp()
+        loadCleanStreak()
         launch(dispatchers.io) {
             CleaningEventBus.events.collectLatest {
                 onEvent(ScannerEvent.RefreshData)
@@ -883,6 +887,14 @@ class ScannerViewModel(
                 _uiState.updateData(ScreenState.Success()) { current ->
                     current.copy(promotedApp = promoted)
                 }
+            }
+        }
+    }
+
+    private fun loadCleanStreak() {
+        launch(dispatchers.io) {
+            dataStore.streakCount.collect { streak ->
+                _cleanStreak.value = streak
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -1,0 +1,63 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+
+@Composable
+fun WeeklyCleanStreakCard(
+    streakDays: Int,
+    modifier: Modifier = Modifier,
+) {
+    val reward = when (streakDays) {
+        1 -> stringResource(id = R.string.streak_reward_day1)
+        3 -> stringResource(id = R.string.streak_reward_day3)
+        5 -> stringResource(id = R.string.streak_reward_day5)
+        7 -> stringResource(id = R.string.streak_reward_day7)
+        else -> null
+    }
+
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = stringResource(id = R.string.clean_streak_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = stringResource(id = R.string.clean_streak_days_format, streakDays),
+                style = MaterialTheme.typography.bodySmall
+            )
+            if (streakDays >= 7) {
+                Text(
+                    text = stringResource(id = R.string.clean_streak_perfect_week),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            } else if (reward != null) {
+                Text(
+                    text = reward,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/StreakNotifier.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/notifications/StreakNotifier.kt
@@ -1,0 +1,61 @@
+package com.d4rk.cleaner.app.notifications.notifications
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.annotation.RequiresPermission
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.main.ui.MainActivity
+import com.google.android.material.color.MaterialColors
+
+class StreakNotifier(private val context: Context) {
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    fun sendNotification(title: String, message: String) {
+        createChannelIfNeeded()
+        val intent = Intent(context, MainActivity::class.java).apply {
+            putExtra("open_scan", true)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        val notification = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL)
+            .setSmallIcon(R.drawable.ic_cleaner_notify)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setContentIntent(pendingIntent)
+            .setColor(
+                MaterialColors.getColor(context, com.google.android.material.R.attr.colorPrimary, 0)
+            )
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun createChannelIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                NOTIFICATION_CHANNEL,
+                context.getString(R.string.streak_notification_title),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            NotificationManagerCompat.from(context).createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val NOTIFICATION_CHANNEL = "streak_reminder"
+        const val NOTIFICATION_ID = 2001
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderScheduler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderScheduler.kt
@@ -1,0 +1,21 @@
+package com.d4rk.cleaner.app.notifications.work
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+object StreakReminderScheduler {
+    private const val WORK_NAME = "streak_reminder_work"
+
+    fun schedule(context: Context) {
+        val request = PeriodicWorkRequestBuilder<StreakReminderWorker>(1, TimeUnit.DAYS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderWorker.kt
@@ -1,0 +1,60 @@
+package com.d4rk.cleaner.app.notifications.work
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.notifications.notifications.StreakNotifier
+import com.d4rk.cleaner.core.data.datastore.DataStore
+import kotlinx.coroutines.flow.first
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class StreakReminderWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    private val dataStore: DataStore by inject()
+    private val notifier: StreakNotifier by inject()
+
+    override suspend fun doWork(): Result {
+        val enabled = dataStore.streakReminderEnabled.first()
+        if (!enabled) return Result.success()
+
+        val lastClean = dataStore.lastCleanDay.first()
+        val streak = dataStore.streakCount.first()
+        val today = System.currentTimeMillis() / DAY_MS
+        val lastDay = lastClean / DAY_MS
+        val diff = today - lastDay
+
+        val message = when {
+            diff >= 1 -> applicationContext.getString(R.string.streak_notification_missed)
+            streak >= 3 && streak <= 7 -> applicationContext.getString(
+                R.string.streak_notification_milestone_format,
+                streak
+            )
+            else -> applicationContext.getString(R.string.streak_notification_daily)
+        }
+
+        if (
+            ContextCompat.checkSelfPermission(
+                applicationContext,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            notifier.sendNotification(
+                applicationContext.getString(R.string.streak_notification_title),
+                message
+            )
+        }
+        return Result.success()
+    }
+
+    companion object {
+        private const val DAY_MS = 86_400_000L
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/settings/cleaning/ui/CleaningSettingsList.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/settings/cleaning/ui/CleaningSettingsList.kt
@@ -42,6 +42,7 @@ fun CleaningSettingsList(paddingValues : PaddingValues) {
     val deleteImageFiles : Boolean by dataStore.deleteImageFiles.collectAsState(initial = false)
     val deleteDuplicateFiles: Boolean by dataStore.deleteDuplicateFiles.collectAsState(initial = false)
     val clipboardClean : Boolean by dataStore.clipboardClean.collectAsState(initial = false)
+    val streakReminderEnabled: Boolean by dataStore.streakReminderEnabled.collectAsState(initial = false)
 
     LazyColumn(
         modifier = Modifier
@@ -248,6 +249,17 @@ fun CleaningSettingsList(paddingValues : PaddingValues) {
                 ) { isChecked ->
                     CoroutineScope(Dispatchers.IO).launch {
                         dataStore.saveClipboardClean(isChecked)
+                    }
+                }
+
+                ExtraTinyVerticalSpacer()
+
+                SwitchPreferenceItem(
+                    title = stringResource(id = R.string.preference_streak_reminder),
+                    checked = streakReminderEnabled,
+                ) { isChecked ->
+                    CoroutineScope(Dispatchers.IO).launch {
+                        dataStore.saveStreakReminderEnabled(isChecked)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -317,4 +317,37 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val streakCountKey = intPreferencesKey(name = AppDataStoreConstants.DATA_STORE_STREAK_COUNT)
+    val streakCount: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[streakCountKey] ?: 0
+    }
+
+    suspend fun saveStreakCount(count: Int) {
+        dataStore.edit { prefs ->
+            prefs[streakCountKey] = count
+        }
+    }
+
+    private val lastCleanDayKey = longPreferencesKey(name = AppDataStoreConstants.DATA_STORE_LAST_CLEAN_DAY)
+    val lastCleanDay: Flow<Long> = dataStore.data.map { prefs ->
+        prefs[lastCleanDayKey] ?: 0L
+    }
+
+    suspend fun saveLastCleanDay(timestamp: Long) {
+        dataStore.edit { prefs ->
+            prefs[lastCleanDayKey] = timestamp
+        }
+    }
+
+    private val streakReminderEnabledKey = booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_STREAK_REMINDER_ENABLED)
+    val streakReminderEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[streakReminderEnabledKey] ?: false
+    }
+
+    suspend fun saveStreakReminderEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[streakReminderEnabledKey] = enabled
+        }
+    }
+
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/NotificationModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/NotificationModule.kt
@@ -2,11 +2,13 @@ package com.d4rk.cleaner.core.di.modules
 
 import com.d4rk.cleaner.app.notifications.domain.usecases.ShouldShowCleanupNotificationUseCase
 import com.d4rk.cleaner.app.notifications.notifications.CleanupNotifier
+import com.d4rk.cleaner.app.notifications.notifications.StreakNotifier
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val notificationModule: Module = module {
     single { CleanupNotifier(context = androidContext()) }
+    single { StreakNotifier(context = androidContext()) }
     single { ShouldShowCleanupNotificationUseCase(memoryRepository = get(), dataStore = get()) }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -31,4 +31,7 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_OTHER_EXTENSIONS = "other_extensions"
     const val DATA_STORE_CLIPBOARD_CLEAN = "clipboard_clean"
     const val DATA_STORE_WHATSAPP_GRID_VIEW = "whatsapp_grid_view"
+    const val DATA_STORE_STREAK_COUNT = "streak_count"
+    const val DATA_STORE_LAST_CLEAN_DAY = "last_clean_day"
+    const val DATA_STORE_STREAK_REMINDER_ENABLED = "streak_reminder_enabled"
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/StreakTracker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/StreakTracker.kt
@@ -1,0 +1,40 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import com.d4rk.cleaner.core.data.datastore.DataStore
+
+object StreakTracker : KoinComponent {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val dataStore: DataStore by inject()
+
+    private const val DAY_MS = 86_400_000L
+
+    fun initialize() {
+        scope.launch {
+            CleaningEventBus.events.collect {
+                updateStreak()
+            }
+        }
+    }
+
+    private suspend fun updateStreak() {
+        val lastClean = dataStore.lastCleanDay.first()
+        val streak = dataStore.streakCount.first()
+        val today = System.currentTimeMillis() / DAY_MS
+        val lastDay = lastClean / DAY_MS
+        val newStreak = when {
+            lastClean == 0L -> 1
+            today - lastDay >= 2L -> 1
+            today - lastDay == 1L -> streak + 1
+            else -> streak
+        }
+        dataStore.saveStreakCount(newStreak)
+        dataStore.saveLastCleanDay(System.currentTimeMillis())
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,4 +320,16 @@
     <string name="no_files_selected_to_clean">No files selected to clean.</string>
     <string name="failed_to_update_trash_size">Failed to update trash size: %1$s</string>
     <string name="no_cleaning_options_selected">Please choose your cleaning preferences in settings to proceed.</string>
+    <string name="clean_streak_title">🔥 Weekly Clean Streak</string>
+    <string name="clean_streak_days_format">You've cleaned for %1$d day(s) in a row!</string>
+    <string name="clean_streak_perfect_week">🏆 Perfect Week! Keep it going!</string>
+    <string name="streak_reward_day1">Nice start!</string>
+    <string name="streak_reward_day3">Did you know you can sort by size?</string>
+    <string name="streak_reward_day5">Estimate system junk!</string>
+    <string name="streak_reward_day7">Perfect Week 🏅</string>
+    <string name="streak_notification_title">Keep your Clean Streak going!</string>
+    <string name="streak_notification_daily">Time to clean up your device and keep your streak going.</string>
+    <string name="streak_notification_missed">You didn’t clean yesterday — clean now to keep the 🔥 alive!</string>
+    <string name="streak_notification_milestone_format">🔥 You're on a %1$d-day streak! Great job!</string>
+    <string name="preference_streak_reminder">Remind me to clean daily (helps maintain streak)</string>
 </resources>


### PR DESCRIPTION
## Summary
- add streak keys to DataStore constants
- track clean streak updates in DataStore
- create `StreakTracker` to update streak on cleaning events
- add `WeeklyCleanStreakCard` component
- integrate streak card into `ScannerScreen`
- initialize streak tracking from `Cleaner`
- add streak UI strings
- add smart reminder notifications for cleaning streak

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869744ab3c4832db5b49de590bbf60b