### PR TITLE
Improve clean streak card UX

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -2,11 +2,17 @@ package com.d4rk.cleaner.app.clean.scanner.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocalFireDepartment
+import androidx.compose.material.icons.rounded.LocalFireDepartment
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedCardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,9 +34,27 @@ fun WeeklyCleanStreakCard(
         else -> null
     }
 
+    val message = when {
+        streakDays == 0 -> stringResource(id = R.string.clean_streak_start)
+        streakDays == 1 -> stringResource(id = R.string.clean_streak_day1)
+        streakDays in 2..3 -> stringResource(id = R.string.clean_streak_day2_3, streakDays)
+        streakDays == 6 -> stringResource(id = R.string.clean_streak_almost_week)
+        streakDays >= 7 && streakDays < 10 -> stringResource(id = R.string.clean_streak_week)
+        streakDays >= 10 -> stringResource(id = R.string.clean_streak_long_format, streakDays)
+        else -> stringResource(id = R.string.clean_streak_day2_3, streakDays)
+    }
+
     OutlinedCard(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+        colors = OutlinedCardDefaults.outlinedCardColors(
+            containerColor = when (streakDays) {
+                0 -> MaterialTheme.colorScheme.secondaryContainer
+                in 1..3 -> MaterialTheme.colorScheme.primaryContainer
+                in 4..6 -> MaterialTheme.colorScheme.tertiaryContainer
+                else -> MaterialTheme.colorScheme.surfaceVariant
+            }
+        )
     ) {
         Column(
             modifier = Modifier
@@ -44,9 +68,19 @@ fun WeeklyCleanStreakCard(
                 style = MaterialTheme.typography.titleMedium
             )
             Text(
-                text = stringResource(id = R.string.clean_streak_days_format, streakDays),
-                style = MaterialTheme.typography.bodySmall
+                text = message,
+                style = MaterialTheme.typography.bodyMedium
             )
+            Row(horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
+                for (i in 1..7) {
+                    val filled = streakDays >= i
+                    Icon(
+                        imageVector = if (filled) Icons.Rounded.LocalFireDepartment else Icons.Outlined.LocalFireDepartment,
+                        contentDescription = null,
+                        tint = if (filled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+                    )
+                }
+            }
             if (streakDays >= 7) {
                 Text(
                     text = stringResource(id = R.string.clean_streak_perfect_week),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,12 @@
     <string name="move_to_trash_icon_description">Move to trash icon</string>
     <string name="delete_forever_icon_description">Delete forever icon</string>
     <string name="clean_streak_title">🔥 Weekly Clean Streak</string>
-    <string name="clean_streak_days_format">You\'ve cleaned for %1$d day(s) in a row!</string>
+    <string name="clean_streak_start">Start your clean streak today!</string>
+    <string name="clean_streak_day1">You’ve started a streak! 🔥 Keep going!</string>
+    <string name="clean_streak_day2_3">Nice! You’re on a %1$d-day streak.</string>
+    <string name="clean_streak_almost_week">Almost there… One more clean for a perfect week!</string>
+    <string name="clean_streak_week">🏆 7-Day Streak! You're on fire!</string>
+    <string name="clean_streak_long_format">🔥 %1$d-Day Streak! You’re unstoppable.</string>
     <string name="clean_streak_perfect_week">🏆 Perfect Week! Keep it going!</string>
     <string name="streak_reward_day1">Nice start!</string>
     <string name="streak_reward_day3">Did you know you can sort by size?</string>


### PR DESCRIPTION
## Summary
- add motivational text resources for clean streaks
- redesign `WeeklyCleanStreakCard` with progress icons, dynamic message, and color

## Testing
- `./gradlew tasks --all`
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697b78e8b4832da7b8f97187617e23