### PR TITLE
Refactor dialogs to BasicAlertDialog

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.FolderOff
-import androidx.compose.material3.AlertDialog
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
@@ -37,7 +37,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
@@ -276,22 +275,16 @@ fun DetailsScreen(
     }
 
     if (showConfirm) {
-        AlertDialog(
-            onDismissRequest = { showConfirm = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    showConfirm = false
-                    onDelete(selected.toList())
-                    selected.clear()
-                }) {
-                    Text(text = stringResource(id = R.string.delete))
-                }
+        BasicAlertDialog(
+            onDismiss = { showConfirm = false },
+            onConfirm = {
+                showConfirm = false
+                onDelete(selected.toList())
+                selected.clear()
             },
-            dismissButton = {
-                TextButton(onClick = { showConfirm = false }) { Text("Cancel") }
-            },
-            title = { Text(text = stringResource(id = R.string.delete_confirmation_title)) },
-            text = {
+            onCancel = { showConfirm = false },
+            title = stringResource(id = R.string.delete_confirmation_title),
+            content = {
                 Text(
                     text = pluralStringResource(
                         id = R.plurals.delete_confirmation_message,
@@ -299,7 +292,9 @@ fun DetailsScreen(
                         selected.size
                     )
                 )
-            }
+            },
+            confirmButtonText = stringResource(id = R.string.delete),
+            dismissButtonText = "Cancel"
         )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/SortDialog.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/components/SortDialog.kt
@@ -3,14 +3,12 @@ package com.d4rk.cleaner.app.clean.whatsapp.details.ui.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DateRangePicker
 import androidx.compose.material3.DateRangePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDateRangePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -18,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.d4rk.cleaner.app.clean.whatsapp.details.ui.SortType
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,23 +36,21 @@ fun SortDialog(
         initialSelectedEndDateMillis = endDate
     )
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(onClick = {
-                onApply(
-                    selected.value,
-                    isDescending.value,
-                    dateState.selectedStartDateMillis,
-                    dateState.selectedEndDateMillis
-                ); onDismiss()
-            }) {
-                Text("OK")
-            }
+    BasicAlertDialog(
+        onDismiss = onDismiss,
+        onConfirm = {
+            onApply(
+                selected.value,
+                isDescending.value,
+                dateState.selectedStartDateMillis,
+                dateState.selectedEndDateMillis
+            ); onDismiss()
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
-        title = { Text("Sort options") },
-        text = {
+        onCancel = onDismiss,
+        confirmButtonText = "OK",
+        dismissButtonText = "Cancel",
+        title = "Sort options",
+        content = {
             Column {
                 options.forEach { type ->
                     Row(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -10,11 +10,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material.icons.outlined.FolderOff
-import androidx.compose.material3.AlertDialog
+import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberTopAppBarState
@@ -123,23 +122,17 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
     }
 
     if (showCleanDialog) {
-        AlertDialog(
-            onDismissRequest = { showCleanDialog = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    showCleanDialog = false
-                    viewModel.onEvent(WhatsAppCleanerEvent.CleanAll)
-                }) {
-                    Text(text = stringResource(id = R.string.clean_whatsapp))
-                }
+        BasicAlertDialog(
+            onDismiss = { showCleanDialog = false },
+            onConfirm = {
+                showCleanDialog = false
+                viewModel.onEvent(WhatsAppCleanerEvent.CleanAll)
             },
-            dismissButton = {
-                TextButton(onClick = { showCleanDialog = false }) {
-                    Text(text = stringResource(id = R.string.cancel))
-                }
-            },
-            title = { Text(text = stringResource(id = R.string.clean_whatsapp_warning_title)) },
-            text = { Text(text = stringResource(id = R.string.clean_whatsapp_warning_message)) }
+            onCancel = { showCleanDialog = false },
+            title = stringResource(id = R.string.clean_whatsapp_warning_title),
+            content = { Text(text = stringResource(id = R.string.clean_whatsapp_warning_message)) },
+            confirmButtonText = stringResource(id = R.string.clean_whatsapp),
+            dismissButtonText = stringResource(id = R.string.cancel)
         )
     }
 }


### PR DESCRIPTION
## Summary
- replace `AlertDialog` with `BasicAlertDialog` in WhatsApp feature dialogs
- remove unused material imports

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a2c63340832d8332a6b75aba25f2