### PR TITLE
Fix WhatsApp card refresh after cleaning

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerScreen.kt
@@ -24,9 +24,13 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -91,6 +95,17 @@ fun ScannerScreen(paddingValues: PaddingValues , snackbarHostState: SnackbarHost
         if (!PermissionsHelper.hasStoragePermissions(context)) {
             PermissionsHelper.requestStoragePermissions(context as Activity)
         }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.onEvent(ScannerEvent.RefreshData)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     Column(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -223,6 +223,8 @@ class ScannerViewModel(
 
     private fun refreshData() {
         loadInitialData()
+        loadWhatsAppMedia()
+        loadClipboardData()
         if (screenData?.analyzeState?.isAnalyzeScreenVisible == true) {
             analyzeFiles()
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -12,6 +12,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.actions.WhatsAppCleane
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleanerModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaSummaryUseCase
+import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -92,6 +93,7 @@ class WhatsappCleanerSummaryViewModel(
                     )
                 }
                 onEvent(WhatsAppCleanerEvent.LoadMedia)
+                CleaningEventBus.notifyCleaned()
             }
         }
     }
@@ -113,6 +115,7 @@ class WhatsappCleanerSummaryViewModel(
                     )
                 }
                 onEvent(WhatsAppCleanerEvent.LoadMedia)
+                CleaningEventBus.notifyCleaned()
             }
         }
     }


### PR DESCRIPTION
## Summary
- trigger WhatsApp media rescan when refreshing data
- refresh data when returning to ScannerScreen
- notify home screen after WhatsApp cleaner deletions

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b62aa278832dabe9967e43a65532