### PR TITLE
Fix ad sizing race in ScannerDashboardScreen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -72,16 +72,23 @@ fun ScannerDashboardScreen(
 
     val appManagerState: UiStateScreen<UiAppManagerModel> by appManagerViewModel.uiState.collectAsState()
     val whatsappSummary by viewModel.whatsAppMediaSummary.collectAsState()
+    val whatsappLoaded by viewModel.whatsAppMediaLoaded.collectAsState()
+    val whatsappInstalled by viewModel.isWhatsAppInstalled.collectAsState()
     val clipboardText by viewModel.clipboardPreview.collectAsState()
     val streakDays by viewModel.cleanStreak.collectAsState()
     val showStreakCard by viewModel.showStreakCard.collectAsState()
     val streakHideUntil by viewModel.streakHideUntil.collectAsState()
 
-    val showApkCard = appManagerState.data?.apkFiles?.isNotEmpty() == true
-    val showWhatsAppCard = whatsappSummary.hasData
+    val showApkCard =
+        appManagerState.data?.apkFilesLoading == false &&
+            appManagerState.data?.apkFiles?.isNotEmpty() == true
+    val showWhatsAppCard = whatsappLoaded && whatsappInstalled
     val showClipboardCard = !clipboardText.isNullOrBlank()
 
-    val cleanerCardsCount = listOf(showWhatsAppCard, showApkCard, showClipboardCard).count { it }
+    val dataLoaded = appManagerState.data?.apkFilesLoading == false && whatsappLoaded
+    val cleanerCardsCount = if (dataLoaded) {
+        listOf(showWhatsAppCard, showApkCard, showClipboardCard).count { it }
+    } else 0
 
     val listState: LazyListState = rememberLazyListState()
 
@@ -96,9 +103,9 @@ fun ScannerDashboardScreen(
         if (promotedApp == null) bannerAdsConfig else leaderboard
     }
 
-    val showAdTop = cleanerCardsCount > 0
-    val showAdMid = cleanerCardsCount > 0
-    val showAdEnd = promotedApp == null || cleanerCardsCount >= 1
+    val showAdTop = dataLoaded && cleanerCardsCount > 0
+    val showAdMid = dataLoaded && cleanerCardsCount > 0
+    val showAdEnd = dataLoaded && (promotedApp == null || cleanerCardsCount >= 1)
 
     val itemsSize: Int = remember(
         showAdTop,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
@@ -48,8 +48,6 @@ fun WhatsAppCleanerCard(
     modifier: Modifier = Modifier,
     onCleanClick: () -> Unit
 ) {
-    if (!mediaSummary.hasData) return
-
     OutlinedCard(
         modifier = modifier.fillMaxWidth() ,
         shape = RoundedCornerShape(SizeConstants.ExtraLargeSize) ,


### PR DESCRIPTION
## Summary
- wait for Whatsapp and APK data load before showing ads on scanner dashboard
- track whatsapp summary load state in `ScannerViewModel`
- only show WhatsApp card when app is installed
- use `ContentResolver` with `runCatching` to detect WhatsApp installation

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*
- `./gradlew assembleDebug --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d73ab3858832d813bb00e883bc0af