### PR TITLE
Improve audio listing layout

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FileListItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FileListItem.kt
@@ -1,0 +1,59 @@
+package com.d4rk.cleaner.app.clean.scanner.ui.components
+
+import android.content.Context
+import android.text.format.Formatter
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.scanner.utils.helpers.getFileIcon
+import com.google.common.io.Files.getFileExtension
+import java.io.File
+
+@Composable
+fun FileListItem(file: File, modifier: Modifier = Modifier) {
+    val context: Context = LocalContext.current
+    val fileExtension = remember(file.name) { getFileExtension(file.name) }
+    val size = remember(file.length()) { Formatter.formatShortFileSize(context, file.length()) }
+    val audioExtensions = remember { context.resources.getStringArray(R.array.audio_extensions).toList() }
+    val isAudio = remember(fileExtension) { audioExtensions.any { it.equals(fileExtension, ignoreCase = true) } }
+    val fileIcon = if (isAudio) R.drawable.ic_audio_file else remember(fileExtension) { getFileIcon(fileExtension, context) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(SizeConstants.SmallSize),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(id = fileIcon),
+            contentDescription = null,
+            modifier = Modifier.size(40.dp)
+        )
+        Column(modifier = Modifier.padding(start = 8.dp).weight(1f)) {
+            Text(
+                text = file.name,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(text = size, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -65,6 +65,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.scanner.ui.components.FilePreviewCard
+import com.d4rk.cleaner.app.clean.scanner.ui.components.FileListItem
 import com.d4rk.cleaner.app.clean.whatsapp.details.domain.actions.WhatsAppDetailsEvent
 import com.d4rk.cleaner.app.clean.whatsapp.details.domain.model.UiWhatsAppDetailsModel
 import com.d4rk.cleaner.app.clean.whatsapp.details.ui.components.CustomTabLayout
@@ -74,6 +75,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleane
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.WhatsappCleanerSummaryViewModel
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import com.d4rk.cleaner.app.clean.whatsapp.utils.helpers.openFile
+import com.google.common.io.Files.getFileExtension
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -355,6 +357,9 @@ fun DetailsScreenContent(
                 LazyColumn(modifier = Modifier.weight(1f)) {
                     items(files) { file ->
                         val checked = file in selected
+                        val fileExtension = remember(file.name) { getFileExtension(file.name) }
+                        val audioExt = remember { context.resources.getStringArray(R.array.audio_extensions).toList() }
+                        val isAudio = remember(fileExtension) { audioExt.any { it.equals(fileExtension, ignoreCase = true) } }
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -368,7 +373,11 @@ fun DetailsScreenContent(
                                     )
                                 }
                         ) {
-                            FilePreviewCard(file = file, modifier = Modifier.weight(1f))
+                            if (isAudio) {
+                                FileListItem(file = file, modifier = Modifier.weight(1f))
+                            } else {
+                                FilePreviewCard(file = file, modifier = Modifier.weight(1f))
+                            }
                             Checkbox(
                                 checked = checked,
                                 onCheckedChange = {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/AudioDirectoryCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/AudioDirectoryCard.kt
@@ -1,0 +1,76 @@
+package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
+
+@Composable
+fun AudioDirectoryCard(
+    item: DirectoryItem,
+    onOpenDetails: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .padding(all = SizeConstants.ExtraSmallSize)
+            .animateContentSize()
+            .bounceClick(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+        onClick = { onOpenDetails(item.type) }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .animateContentSize()
+                .padding(all = SizeConstants.LargeSize),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(end = 16.dp)
+                    .size(48.dp)
+                    .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = item.icon),
+                    contentDescription = null,
+                    tint = Color.Unspecified
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = stringResource(id = R.string.total_files_format, item.count),
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Text(text = item.size, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/DirectoryGrid.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
+import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.AudioDirectoryCard
+import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 
 @Composable
 fun DirectoryGrid(items: List<DirectoryItem>, onOpenDetails: (String) -> Unit) {
@@ -25,7 +27,12 @@ fun DirectoryGrid(items: List<DirectoryItem>, onOpenDetails: (String) -> Unit) {
                     .animateContentSize()
             ) {
                 for (item in chunk) {
-                    DirectoryCard(item = item, onOpenDetails = onOpenDetails, modifier = Modifier.weight(1f))
+                    val isAudio = item.type == WhatsAppMediaConstants.AUDIOS || item.type == WhatsAppMediaConstants.VOICE_NOTES
+                    if (isAudio) {
+                        AudioDirectoryCard(item = item, onOpenDetails = onOpenDetails, modifier = Modifier.weight(1f))
+                    } else {
+                        DirectoryCard(item = item, onOpenDetails = onOpenDetails, modifier = Modifier.weight(1f))
+                    }
                 }
                 if (chunk.size == 1) {
                     androidx.compose.foundation.layout.Spacer(modifier = Modifier.weight(1f))


### PR DESCRIPTION
## Summary
- add special directory card for audio content
- display audio files with a dedicated list item
- use the specialized card for audio types

## Testing
- `./gradlew -p app assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d872aaa00832db45133e8622da855