### PR TITLE
Enable streak reminders by default

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainActivity.kt
@@ -3,6 +3,9 @@ package com.d4rk.cleaner.app.main.ui
 import android.content.Intent
 import android.os.Bundle
 import android.os.Environment
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
@@ -14,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupActivity
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
@@ -73,6 +77,18 @@ class MainActivity : AppCompatActivity() {
     private fun handleStartup() {
         lifecycleScope.launch {
             val isFirstLaunch : Boolean = dataStore.startup.first()
+
+            if (!dataStore.isStreakReminderInitialized()) {
+                val hasPermission =
+                    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                        ContextCompat.checkSelfPermission(
+                            this@MainActivity,
+                            Manifest.permission.POST_NOTIFICATIONS
+                        ) == PackageManager.PERMISSION_GRANTED
+                if (hasPermission) {
+                    dataStore.saveStreakReminderEnabled(true)
+                }
+            }
 
             val trashDir = File(getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS) , "Trash")
             val actualTrashSize = withContext(Dispatchers.IO) { calculateDirectorySize(trashDir) }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.coroutines.flow.first
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.d4rk.cleaner.core.utils.constants.datastore.AppDataStoreConstants
 import kotlinx.coroutines.flow.Flow
@@ -348,6 +349,11 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         dataStore.edit { prefs ->
             prefs[streakReminderEnabledKey] = enabled
         }
+    }
+
+    suspend fun isStreakReminderInitialized(): Boolean {
+        val prefs = dataStore.data.first()
+        return prefs.contains(streakReminderEnabledKey)
     }
 
     private val showStreakCardKey = booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_SHOW_STREAK_CARD)


### PR DESCRIPTION
## Summary
- enable streak reminder toggle when user finishes onboarding (if POST_NOTIFICATIONS permission granted)
- ensure streak reminder is automatically enabled on startup if permission is granted
- expose helper to check if streak reminder preference exists

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e153c8d64832da50efb23ab5ee8a1