### PR TITLE
Enhance WhatsApp item previews

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FileListItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FileListItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import coil3.compose.AsyncImage
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,7 +33,9 @@ fun FileListItem(file: File, modifier: Modifier = Modifier) {
     val fileExtension = remember(file.name) { getFileExtension(file.name) }
     val size = remember(file.length()) { Formatter.formatShortFileSize(context, file.length()) }
     val audioExtensions = remember { context.resources.getStringArray(R.array.audio_extensions).toList() }
+    val apkExtensions = remember { context.resources.getStringArray(R.array.apk_extensions).toList() }
     val isAudio = remember(fileExtension) { audioExtensions.any { it.equals(fileExtension, ignoreCase = true) } }
+    val isApk = remember(fileExtension) { apkExtensions.any { it.equals(fileExtension, ignoreCase = true) } }
     val fileIcon = if (isAudio) R.drawable.ic_audio_file else remember(fileExtension) { getFileIcon(fileExtension, context) }
 
     Row(
@@ -43,11 +46,29 @@ fun FileListItem(file: File, modifier: Modifier = Modifier) {
             .padding(SizeConstants.SmallSize),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Icon(
-            painter = painterResource(id = fileIcon),
-            contentDescription = null,
-            modifier = Modifier.size(40.dp)
-        )
+        if (isApk) {
+            val icon = remember(file.path) {
+                context.packageManager.getPackageArchiveInfo(file.path, 0)?.applicationInfo?.apply {
+                    sourceDir = file.path
+                    publicSourceDir = file.path
+                }?.loadIcon(context.packageManager)
+            }
+            if (icon != null) {
+                AsyncImage(model = icon, contentDescription = null, modifier = Modifier.size(40.dp))
+            } else {
+                Icon(
+                    painter = painterResource(id = fileIcon),
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp)
+                )
+            }
+        } else {
+            Icon(
+                painter = painterResource(id = fileIcon),
+                contentDescription = null,
+                modifier = Modifier.size(40.dp)
+            )
+        }
         Column(modifier = Modifier.padding(start = 8.dp).weight(1f)) {
             Text(
                 text = file.name,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FilePreviewCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/FilePreviewCard.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.PictureAsPdf
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -47,9 +49,13 @@ fun FilePreviewCard(file: File, modifier: Modifier = Modifier) {
     val imageExtensions = remember { context.resources.getStringArray(R.array.image_extensions).toList() }
     val videoExtensions = remember { context.resources.getStringArray(R.array.video_extensions).toList() }
     val officeExtensions = remember { context.resources.getStringArray(R.array.microsoft_office_extensions).toList() }
+    val apkExtensions = remember { context.resources.getStringArray(R.array.apk_extensions).toList() }
     val imageLoader = LocalContext.current.imageLoader
 
-    Card(modifier = modifier) {
+    Card(
+        modifier = modifier.aspectRatio(1f),
+        shape = RoundedCornerShape(SizeConstants.MediumSize)
+    ) {
         Box(modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surfaceVariant)) {
@@ -85,6 +91,31 @@ fun FilePreviewCard(file: File, modifier: Modifier = Modifier) {
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize()
                         )
+                    }
+                    in apkExtensions -> {
+                        val icon = remember(file.path) {
+                            context.packageManager.getPackageArchiveInfo(file.path, 0)?.applicationInfo?.apply {
+                                sourceDir = file.path
+                                publicSourceDir = file.path
+                            }?.loadIcon(context.packageManager)
+                        }
+                        if (icon != null) {
+                            AsyncImage(
+                                model = icon,
+                                contentDescription = file.name,
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .align(Alignment.Center)
+                            )
+                        } else {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_apk_document),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .align(Alignment.Center)
+                            )
+                        }
                     }
                     in officeExtensions -> {
                         if (fileExtension.lowercase() == "pdf") {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsScreen.kt
@@ -360,7 +360,6 @@ fun DetailsScreenContent(
                         val audioExt = remember { context.resources.getStringArray(R.array.audio_extensions).toList() }
                         val imageExt = remember { context.resources.getStringArray(R.array.image_extensions).toList() }
                         val videoExt = remember { context.resources.getStringArray(R.array.video_extensions).toList() }
-                        val isAudio = remember(fileExtension) { audioExt.any { it.equals(fileExtension, ignoreCase = true) } }
                         val isMedia = remember(fileExtension) {
                             imageExt.any { it.equals(fileExtension, ignoreCase = true) } ||
                                     videoExt.any { it.equals(fileExtension, ignoreCase = true) }
@@ -378,7 +377,7 @@ fun DetailsScreenContent(
                                     )
                                 }
                         ) {
-                            if (!isGrid) {
+                            if (isMedia) {
                                 FilePreviewCard(file = file, modifier = Modifier.weight(1f))
                             } else {
                                 FileListItem(file = file, modifier = Modifier.weight(1f))


### PR DESCRIPTION
## Summary
- load APK icons in preview and list item components
- keep grid previews square with rounded corners
- choose between preview or list item per media type

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*
- `./gradlew assembleDebug --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e286627c0832d8c43db8c3d0c7c3b