### PR TITLE
Translate cleanup storage alerts

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">عايز انتعاشة خفيفة؟</string>
     <string name="cleanup_storage_very_high">المساحة ضيقة جدًا. عايز تنظف شوية؟</string>
     <string name="cleanup_storage_high">انت على %1$d%% — اضغط للفحص لو حبيت.</string>
+    <string name="cleanup_storage_high_2">انت مستخدم %1$d%% — فحص سريع ممكن يساعد.</string>
+    <string name="cleanup_storage_high_3">%1$d%% مليانة. المكان بيضيق شوي.</string>
+    <string name="cleanup_storage_high_4">المساحة بتتملي. دلوقتي %1$d%% مستخدم.</string>
+    <string name="cleanup_storage_high_5">%1$d%% مستخدم. ننضف؟</string>
+    <string name="cleanup_storage_high_6">قربت تتملي. %1$d%% مستخدم.</string>
     <string name="cleanup_storage_medium">فيه حاجات كتير هنا. الفحص ممكن يفيد.</string>
     <string name="cleanup_storage_ok">المساحة عندك تمام!</string>
     <string name="cleanup_notification_last_scan_format">آخر فحص: من %1$d يوم. %2$s</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">Време за леко освежаване?</string>
     <string name="cleanup_storage_very_high">Паметта е доста запълнена. Искате ли да почистите малко?</string>
     <string name="cleanup_storage_high">Вие сте на %1$d%% — докоснете за сканиране при нужда.</string>
+    <string name="cleanup_storage_high_2">Използвани са %1$d%% — бързо сканиране може да помогне.</string>
+    <string name="cleanup_storage_high_3">%1$d%% запълнени. Става малко тясно.</string>
+    <string name="cleanup_storage_high_4">Мястото се запълва. Сега са използвани %1$d%%.</string>
+    <string name="cleanup_storage_high_5">Използвани са %1$d%%. Време ли е за почистване?</string>
+    <string name="cleanup_storage_high_6">Приближавате се до пълно. %1$d%% заето.</string>
     <string name="cleanup_storage_medium">Има доста неща тук. Сканиране може да помогне.</string>
     <string name="cleanup_storage_ok">Паметта ви изглежда добре!</string>
     <string name="cleanup_notification_last_scan_format">Последно сканиране: преди %1$d дни. %2$s</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">একটু হালকা রিফ্রেশ করবেন?</string>
     <string name="cleanup_storage_very_high">স্টোরেজ খুব টাইট। একটু পরিষ্কার করতে চান?</string>
     <string name="cleanup_storage_high">আপনি %1$d%% এ আছেন — প্রয়োজনে স্ক্যান করতে ট্যাপ করুন।</string>
+    <string name="cleanup_storage_high_2">আপনি %1$d%% ব্যবহার করছেন — দ্রুত স্ক্যান সাহায্য করতে পারে।</string>
+    <string name="cleanup_storage_high_3">%1$d%% পূর্ণ হয়েছে। জায়গা একটু টাইট হয়ে যাচ্ছে।</string>
+    <string name="cleanup_storage_high_4">জায়গা ভর্তি হয়ে যাচ্ছে। এখন %1$d%% ব্যবহার হয়েছে।</string>
+    <string name="cleanup_storage_high_5">%1$d%% ব্যবহার হয়েছে। পরিষ্কার করবেন?</string>
+    <string name="cleanup_storage_high_6">প্রায় পুরো হয়ে যাচ্ছে। %1$d%% ব্যবহৃত।</string>
     <string name="cleanup_storage_medium">এখানে অনেক কিছু আছে। একটি স্ক্যান সাহায্য করতে পারে।</string>
     <string name="cleanup_storage_ok">আপনার স্টোরেজ ঠিক আছে!</string>
     <string name="cleanup_notification_last_scan_format">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Dein Handy verdient eine Auffrischung</string>
     <string name="cleanup_storage_very_high">Speicher ist sehr knapp. Möchtest du ein bisschen aufräumen?</string>
     <string name="cleanup_storage_high">Du bist bei %1$d%% — tippe zum Scannen, wenn nötig.</string>
+    <string name="cleanup_storage_high_2">Du bist bei %1$d%% Auslastung — ein schneller Scan könnte helfen.</string>
+    <string name="cleanup_storage_high_3">%1$d%% belegt. Hier wird es langsam eng.</string>
+    <string name="cleanup_storage_high_4">Der Speicher füllt sich. Jetzt sind %1$d%% belegt.</string>
+    <string name="cleanup_storage_high_5">%1$d%% belegt. Zeit zum Aufräumen?</string>
+    <string name="cleanup_storage_high_6">Du bist fast voll. %1$d%% in Benutzung.</string>
     <string name="cleanup_storage_medium">Hier gibt es einiges. Ein Scan könnte helfen.</string>
     <string name="cleanup_storage_ok">Dein Speicher sieht gut aus!</string>
     <string name="cleanup_notification_last_scan_format">Letzter Scan: vor %1$d Tagen. %2$s</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Tu teléfono merece un refresco</string>
     <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
     <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si lo necesitas.</string>
+    <string name="cleanup_storage_high_2">Estás con %1$d%% usado — un escaneo rápido podría ayudar.</string>
+    <string name="cleanup_storage_high_3">%1$d%% ocupado. Esto empieza a apretarse.</string>
+    <string name="cleanup_storage_high_4">Se está llenando el espacio. %1$d%% usado ahora.</string>
+    <string name="cleanup_storage_high_5">%1$d%% usado. ¿Hora de limpiar?</string>
+    <string name="cleanup_storage_high_6">Te estás acercando al límite. %1$d%% en uso.</string>
     <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
     <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
     <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Tu teléfono merece un refresco</string>
     <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
     <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si es necesario.</string>
+    <string name="cleanup_storage_high_2">Estás con %1$d%% usado — un escaneo rápido podría ayudar.</string>
+    <string name="cleanup_storage_high_3">%1$d%% ocupado. Esto empieza a apretarse.</string>
+    <string name="cleanup_storage_high_4">Se está llenando el espacio. %1$d%% usado ahora.</string>
+    <string name="cleanup_storage_high_5">%1$d%% usado. ¿Hora de limpiar?</string>
+    <string name="cleanup_storage_high_6">Te estás acercando al límite. %1$d%% en uso.</string>
     <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
     <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
     <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">Panahon na ba para sa light refresh?</string>
     <string name="cleanup_storage_very_high">Sobrang sikip ng storage. Gusto mo bang linisin ng kaunti?</string>
     <string name="cleanup_storage_high">Nasa %1$d%% ka na — tapikin para mag-scan kung kailangan.</string>
+    <string name="cleanup_storage_high_2">Nasa %1$d%% kang gamit — baka makatulong ang mabilisang scan.</string>
+    <string name="cleanup_storage_high_3">%1$d%% na ang puno. Medyo masikip na rito.</string>
+    <string name="cleanup_storage_high_4">Napupuno na ang espasyo. %1$d%% na ang nagagamit.</string>
+    <string name="cleanup_storage_high_5">%1$d%% na nagamit. Linisin na?</string>
+    <string name="cleanup_storage_high_6">Malapit nang mapuno. %1$d%% na ang gamit.</string>
     <string name="cleanup_storage_medium">Maraming laman dito. Puwedeng makatulong ang scan.</string>
     <string name="cleanup_storage_ok">Ayos naman ang storage mo!</string>
     <string name="cleanup_notification_last_scan_format">Huling scan: %1$d araw na ang nakalipas. %2$s</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Votre téléphone mérite un rafraîchissement</string>
     <string name="cleanup_storage_very_high">Le stockage est vraiment plein. Un peu de ménage ?</string>
     <string name="cleanup_storage_high">Vous êtes à %1$d%% — appuyez pour analyser si nécessaire.</string>
+    <string name="cleanup_storage_high_2">Vous en êtes à %1$d%% utilisé — un scan rapide pourrait aider.</string>
+    <string name="cleanup_storage_high_3">%1$d%% remplis. Ça commence à se serrer ici.</string>
+    <string name="cleanup_storage_high_4">L’espace se remplit. %1$d%% utilisé maintenant.</string>
+    <string name="cleanup_storage_high_5">%1$d%% utilisé. On nettoie ?</string>
+    <string name="cleanup_storage_high_6">Vous approchez de la limite. %1$d%% utilisés.</string>
     <string name="cleanup_storage_medium">Il y a pas mal de choses ici. Un scan pourrait aider.</string>
     <string name="cleanup_storage_ok">Votre stockage est en bon état !</string>
     <string name="cleanup_notification_last_scan_format">Dernière analyse : il y a %1$d jours. %2$s</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">थोड़ा रीफ़्रेश करने का समय?</string>
     <string name="cleanup_storage_very_high">स्टोरेज बहुत कम है। थोड़ा साफ़ करना चाहेंगे?</string>
     <string name="cleanup_storage_high">आप %1$d%% पर हैं — ज़रूरत हो तो स्कैन करने के लिए टैप करें.</string>
+    <string name="cleanup_storage_high_2">आप %1$d%% उपयोग कर चुके हैं — जल्दी से स्कैन कर लें तो मदद मिल सकती है।</string>
+    <string name="cleanup_storage_high_3">%1$d%% भर चुका है। यहाँ थोड़ी तंगी लग रही है।</string>
+    <string name="cleanup_storage_high_4">जगह भर रही है। अभी %1$d%% उपयोग में है।</string>
+    <string name="cleanup_storage_high_5">%1$d%% उपयोग में है। साफ़ करें?</string>
+    <string name="cleanup_storage_high_6">लगभग भरने वाला है। %1$d%% इस्तेमाल में है।</string>
     <string name="cleanup_storage_medium">यहाँ काफी चीजें हैं। स्कैन मदद कर सकता है.</string>
     <string name="cleanup_storage_ok">आपका स्टोरेज ठीक दिख रहा है!</string>
     <string name="cleanup_notification_last_scan_format">आख़िरी स्कैन: %1$d दिन पहले. %2$s</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">Ideje egy kis felfrissítésnek?</string>
     <string name="cleanup_storage_very_high">Nagyon szűkös a tárhely. Szeretnél kicsit takarítani?</string>
     <string name="cleanup_storage_high">Már %1$d%%-n állsz — érints rá a kereséshez, ha szükséges.</string>
+    <string name="cleanup_storage_high_2">Már %1$d%%-ot használsz — egy gyors keresés segíthet.</string>
+    <string name="cleanup_storage_high_3">%1$d%% betelt. Kezd szűkös lenni.</string>
+    <string name="cleanup_storage_high_4">Fogy a hely. Most %1$d%% foglalt.</string>
+    <string name="cleanup_storage_high_5">%1$d%% foglalt. Ideje tisztítani?</string>
+    <string name="cleanup_storage_high_6">Közel a megtelt állapothoz. %1$d%% használatban.</string>
     <string name="cleanup_storage_medium">Elég sok minden van itt. Egy keresés segíthet.</string>
     <string name="cleanup_storage_ok">A tárhelyed rendben van!</string>
     <string name="cleanup_notification_last_scan_format">Utolsó keresés: %1$d napja. %2$s</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Ponselmu pantas mendapatkan penyegaran</string>
     <string name="cleanup_storage_very_high">Penyimpanan sangat penuh. Ingin bersih-bersih?</string>
     <string name="cleanup_storage_high">Kamu di %1$d%% — ketuk untuk memindai jika perlu.</string>
+    <string name="cleanup_storage_high_2">Kamu sudah memakai %1$d%% — pemindaian cepat bisa membantu.</string>
+    <string name="cleanup_storage_high_3">%1$d%% terisi. Mulai terasa sempit.</string>
+    <string name="cleanup_storage_high_4">Ruang mulai penuh. %1$d%% sudah terpakai.</string>
+    <string name="cleanup_storage_high_5">%1$d%% terpakai. Saatnya bersih-bersih?</string>
+    <string name="cleanup_storage_high_6">Hampir penuh. %1$d%% terpakai.</string>
     <string name="cleanup_storage_medium">Banyak sekali di sini. Pindai mungkin membantu.</string>
     <string name="cleanup_storage_ok">Penyimpanan Anda terlihat baik!</string>
     <string name="cleanup_notification_last_scan_format">Pemindaian terakhir: %1$d hari lalu. %2$s</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Il tuo telefono merita un rinnovamento</string>
     <string name="cleanup_storage_very_high">La memoria è davvero piena. Vuoi pulire un po’?</string>
     <string name="cleanup_storage_high">Sei al %1$d%% — tocca per scansionare se necessario.</string>
+    <string name="cleanup_storage_high_2">Sei al %1$d%% di utilizzo — una scansione rapida potrebbe aiutare.</string>
+    <string name="cleanup_storage_high_3">%1$d%% pieno. Inizia a farsi stretto qui.</string>
+    <string name="cleanup_storage_high_4">Lo spazio si sta riempiendo. Ora %1$d%% usato.</string>
+    <string name="cleanup_storage_high_5">%1$d%% usato. È ora di pulire?</string>
+    <string name="cleanup_storage_high_6">Stai per esaurire lo spazio. %1$d%% in uso.</string>
     <string name="cleanup_storage_medium">C’è un bel po’ di roba qui. Una scansione potrebbe aiutare.</string>
     <string name="cleanup_storage_ok">La tua memoria sembra a posto!</string>
     <string name="cleanup_notification_last_scan_format">Ultima scansione: %1$d giorni fa. %2$s</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">あなたのスマホにリフレッシュを</string>
     <string name="cleanup_storage_very_high">ストレージがかなり不足しています。少しクリーンアップしますか？</string>
     <string name="cleanup_storage_high">現在%1$d%%です—必要に応じてタップしてスキャンしてください。</string>
+    <string name="cleanup_storage_high_2">%1$d%%使用中です — すばやくスキャンするとよいかもしれません。</string>
+    <string name="cleanup_storage_high_3">%1$d%%埋まっています。少し手狭になってきました。</string>
+    <string name="cleanup_storage_high_4">容量が埋まりつつあります。現在%1$d%%使用中です。</string>
+    <string name="cleanup_storage_high_5">%1$d%%使用中。掃除しますか？</string>
+    <string name="cleanup_storage_high_6">ほぼ満杯です。%1$d%%使用中。</string>
     <string name="cleanup_storage_medium">ここにはたくさんのものがあります。スキャンが役立つかもしれません。</string>
     <string name="cleanup_storage_ok">ストレージは良好です！</string>
     <string name="cleanup_notification_last_scan_format">最終スキャン: %1$d日前。%2$s</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">휴대폰도 새 단장을 할 자격이 있죠</string>
     <string name="cleanup_storage_very_high">저장공간이 매우 부족합니다. 조금 정리해볼까요?</string>
     <string name="cleanup_storage_high">%1$d%% 사용 중 — 필요하면 탭해서 스캔하세요.</string>
+    <string name="cleanup_storage_high_2">%1$d%% 사용 중 — 빠른 스캔이 도움이 될 수 있어요.</string>
+    <string name="cleanup_storage_high_3">%1$d%% 채워졌어요. 조금 비좁네요.</string>
+    <string name="cleanup_storage_high_4">공간이 차고 있어요. 지금 %1$d%% 사용 중입니다.</string>
+    <string name="cleanup_storage_high_5">%1$d%% 사용 중. 청소할까요?</string>
+    <string name="cleanup_storage_high_6">거의 가득 찼어요. %1$d%% 사용 중입니다.</string>
     <string name="cleanup_storage_medium">여기에 내용이 많네요. 스캔이 도움이 될 수 있어요.</string>
     <string name="cleanup_storage_ok">저장공간은 괜찮아 보여요!</string>
     <string name="cleanup_notification_last_scan_format">마지막 스캔: %1$d일 전. %2$s</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Twój telefon zasługuje na odświeżenie</string>
     <string name="cleanup_storage_very_high">Pamięć jest bardzo zapełniona. Chcesz trochę posprzątać?</string>
     <string name="cleanup_storage_high">Masz %1$d%% — stuknij, aby przeskanować w razie potrzeby.</string>
+    <string name="cleanup_storage_high_2">Masz zużyte %1$d%% — szybkie skanowanie może pomóc.</string>
+    <string name="cleanup_storage_high_3">%1$d%% zapełnione. Robi się tu ciasno.</string>
+    <string name="cleanup_storage_high_4">Miejsce się zapełnia. Teraz użyte %1$d%%.</string>
+    <string name="cleanup_storage_high_5">%1$d%% użyte. Czas na czyszczenie?</string>
+    <string name="cleanup_storage_high_6">Zbliżasz się do pełna. %1$d%% zajęte.</string>
     <string name="cleanup_storage_medium">Jest tu całkiem sporo rzeczy. Skan może pomóc.</string>
     <string name="cleanup_storage_ok">Twoja pamięć wygląda dobrze!</string>
     <string name="cleanup_notification_last_scan_format">Ostatnie skanowanie: %1$d dni temu. %2$s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Seu telefone merece um refresco</string>
     <string name="cleanup_storage_very_high">O armazenamento está bem cheio. Quer limpar um pouco?</string>
     <string name="cleanup_storage_high">Você está em %1$d%% — toque para escanear se necessário.</string>
+    <string name="cleanup_storage_high_2">Você está com %1$d%% usado — uma verificação rápida pode ajudar.</string>
+    <string name="cleanup_storage_high_3">%1$d%% preenchido. Está ficando apertado aqui.</string>
+    <string name="cleanup_storage_high_4">O espaço está acabando. %1$d%% usado agora.</string>
+    <string name="cleanup_storage_high_5">%1$d%% usado. Hora de limpar?</string>
+    <string name="cleanup_storage_high_6">Quase cheio. %1$d%% em uso.</string>
     <string name="cleanup_storage_medium">Tem bastante coisa aqui. Um scan pode ajudar.</string>
     <string name="cleanup_storage_ok">Seu armazenamento está ok!</string>
     <string name="cleanup_notification_last_scan_format">Última varredura: há %1$d dias. %2$s</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Telefonul tău merită o reîmprospătare</string>
     <string name="cleanup_storage_very_high">Spațiul de stocare e foarte aglomerat. Vrei să cureți puțin?</string>
     <string name="cleanup_storage_high">Ești la %1$d%% — atinge pentru scanare dacă e nevoie.</string>
+    <string name="cleanup_storage_high_2">Ești la %1$d%% folosit — o scanare rapidă ar putea ajuta.</string>
+    <string name="cleanup_storage_high_3">%1$d%% ocupat. Începe să fie cam înghesuit.</string>
+    <string name="cleanup_storage_high_4">Spațiul se umple. %1$d%% folosit acum.</string>
+    <string name="cleanup_storage_high_5">%1$d%% folosit. Curățăm?</string>
+    <string name="cleanup_storage_high_6">Aproape plin. %1$d%% utilizat.</string>
     <string name="cleanup_storage_medium">Sunt destule lucruri aici. Un scan ar putea ajuta.</string>
     <string name="cleanup_storage_ok">Spațiul tău arată bine!</string>
     <string name="cleanup_notification_last_scan_format">Ultimul scan: acum %1$d zile. %2$s</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Ваш телефон заслуживает обновления</string>
     <string name="cleanup_storage_very_high">Хранилище почти заполнено. Хотите немного почистить?</string>
     <string name="cleanup_storage_high">Вы используете %1$d%% — нажмите для сканирования при необходимости.</string>
+    <string name="cleanup_storage_high_2">Использовано %1$d%% — быстрый скан может помочь.</string>
+    <string name="cleanup_storage_high_3">%1$d%% занято. Здесь становится тесновато.</string>
+    <string name="cleanup_storage_high_4">Место заполняется. Сейчас занято %1$d%%.</string>
+    <string name="cleanup_storage_high_5">%1$d%% занято. Почистить?</string>
+    <string name="cleanup_storage_high_6">Почти заполнено. %1$d%% используется.</string>
     <string name="cleanup_storage_medium">Здесь много всего. Сканирование может помочь.</string>
     <string name="cleanup_storage_ok">Ваше хранилище в порядке!</string>
     <string name="cleanup_notification_last_scan_format">Последнее сканирование: %1$d дней назад. %2$s</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Din telefon förtjänar en uppfräschning</string>
     <string name="cleanup_storage_very_high">Lagringen är riktigt full. Vill du städa lite?</string>
     <string name="cleanup_storage_high">Du är på %1$d%% — tryck för att skanna vid behov.</string>
+    <string name="cleanup_storage_high_2">Du har använt %1$d%% — en snabb skanning kan hjälpa.</string>
+    <string name="cleanup_storage_high_3">%1$d%% fyllt. Det börjar bli trångt här.</string>
+    <string name="cleanup_storage_high_4">Utrymmet fylls på. %1$d%% används nu.</string>
+    <string name="cleanup_storage_high_5">%1$d%% används. Dags att städa?</string>
+    <string name="cleanup_storage_high_6">Du börjar få slut på utrymme. %1$d%% i bruk.</string>
     <string name="cleanup_storage_medium">Här finns mycket innehåll. En skanning kan hjälpa.</string>
     <string name="cleanup_storage_ok">Ditt lagringsutrymme ser bra ut!</string>
     <string name="cleanup_notification_last_scan_format">Senaste skanning: för %1$d dagar sedan. %2$s</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">ได้เวลาล้างเครื่องเบา ๆ แล้วหรือยัง?</string>
     <string name="cleanup_storage_very_high">พื้นที่จัดเก็บแน่นมาก ต้องการล้างหน่อยไหม?</string>
     <string name="cleanup_storage_high">คุณใช้ไปแล้ว %1$d%% — แตะเพื่อสแกนหากจำเป็น</string>
+    <string name="cleanup_storage_high_2">คุณใช้ไปแล้ว %1$d%% — การสแกนด่วนอาจช่วยได้.</string>
+    <string name="cleanup_storage_high_3">เต็มไปแล้ว %1$d%% เริ่มคับที่.</string>
+    <string name="cleanup_storage_high_4">พื้นที่กำลังจะเต็ม ตอนนี้ใช้ไป %1$d%%.</string>
+    <string name="cleanup_storage_high_5">ใช้ไป %1$d%% แล้ว ล้างไหม?</string>
+    <string name="cleanup_storage_high_6">ใกล้เต็มแล้ว ใช้งาน %1$d%% อยู่.</string>
     <string name="cleanup_storage_medium">มีของเยอะมากที่นี่ การสแกนอาจช่วยได้</string>
     <string name="cleanup_storage_ok">พื้นที่จัดเก็บของคุณดูโอเค!</string>
     <string name="cleanup_notification_last_scan_format">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Telefonun bir yenilenmeyi hak ediyor</string>
     <string name="cleanup_storage_very_high">Depolama çok dolu. Biraz temizlemek ister misin?</string>
     <string name="cleanup_storage_high">%1$d%% dolu — gerekirse taramak için dokun.</string>
+    <string name="cleanup_storage_high_2">%1$d%% kullanılmış — hızlı bir tarama yardımcı olabilir.</string>
+    <string name="cleanup_storage_high_3">%1$d%% dolu. Burada biraz daralıyor.</string>
+    <string name="cleanup_storage_high_4">Yer doluyor. Şu an %1$d%% kullanılıyor.</string>
+    <string name="cleanup_storage_high_5">%1$d%% kullanılıyor. Temizleyelim mi?</string>
+    <string name="cleanup_storage_high_6">Neredeyse dolu. %1$d%% kullanımda.</string>
     <string name="cleanup_storage_medium">Burada epey şey var. Tarama yardımcı olabilir.</string>
     <string name="cleanup_storage_ok">Depolaman gayet iyi!</string>
     <string name="cleanup_notification_last_scan_format">Son tarama: %1$d gün önce. %2$s</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Ваш телефон заслуговує на оновлення</string>
     <string name="cleanup_storage_very_high">Пам’ять майже заповнена. Хочете трохи почистити?</string>
     <string name="cleanup_storage_high">У вас %1$d%% — торкніться для сканування за потреби.</string>
+    <string name="cleanup_storage_high_2">Ви використали %1$d%% — швидке сканування може допомогти.</string>
+    <string name="cleanup_storage_high_3">%1$d%% заповнено. Тут стає тісно.</string>
+    <string name="cleanup_storage_high_4">Місце закінчується. Зараз використано %1$d%%.</string>
+    <string name="cleanup_storage_high_5">%1$d%% використано. Час чистити?</string>
+    <string name="cleanup_storage_high_6">Майже заповнено. Використано %1$d%%.</string>
     <string name="cleanup_storage_medium">Тут багато всього. Сканування може допомогти.</string>
     <string name="cleanup_storage_ok">Пам’ять у хорошому стані!</string>
     <string name="cleanup_notification_last_scan_format">Останнє сканування: %1$d днів тому. %2$s</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -12,6 +12,11 @@
     <string name="cleanup_title_variant5">کیا ہلکی سی ریفریش کا وقت ہے؟</string>
     <string name="cleanup_storage_very_high">اسٹوریج بہت تنگ ہے۔ تھوڑا صاف کرنا چاہیں گے؟</string>
     <string name="cleanup_storage_high">آپ %1$d%% پر ہیں—ضرورت ہو تو اسکین کے لیے ٹیپ کریں۔</string>
+    <string name="cleanup_storage_high_2">آپ %1$d%% استعمال کرچکے ہیں—ایک فوری اسکین مددگار ہوسکتا ہے۔</string>
+    <string name="cleanup_storage_high_3">%1$d%% بھر چکا ہے۔ جگہ کچھ تنگ ہورہی ہے۔</string>
+    <string name="cleanup_storage_high_4">جگہ بھر رہی ہے۔ اب %1$d%% استعمال میں ہے۔</string>
+    <string name="cleanup_storage_high_5">%1$d%% استعمال ہے۔ صاف کریں؟</string>
+    <string name="cleanup_storage_high_6">تقریباً مکمل ہورہا ہے۔ %1$d%% زیرِ استعمال ہے۔</string>
     <string name="cleanup_storage_medium">یہاں کافی چیزیں ہیں۔ اسکین مددگار ہو سکتا ہے۔</string>
     <string name="cleanup_storage_ok">آپ کا اسٹوریج ٹھیک ہے!</string>
     <string name="cleanup_notification_last_scan_format">آخری اسکین: %1$d دن پہلے۔ %2$s</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">Điện thoại của bạn xứng đáng được làm mới</string>
     <string name="cleanup_storage_very_high">Bộ nhớ rất chật. Bạn muốn dọn dẹp chút không?</string>
     <string name="cleanup_storage_high">Bạn đã dùng %1$d%% — nhấn để quét nếu cần.</string>
+    <string name="cleanup_storage_high_2">Bạn đã dùng %1$d%% — quét nhanh có thể giúp đỡ.</string>
+    <string name="cleanup_storage_high_3">Đã đầy %1$d%%. Bắt đầu hơi chật chội.</string>
+    <string name="cleanup_storage_high_4">Dung lượng sắp đầy. Hiện dùng %1$d%%.</string>
+    <string name="cleanup_storage_high_5">%1$d%% đã dùng. Dọn dẹp chứ?</string>
+    <string name="cleanup_storage_high_6">Sắp đầy rồi. Đang dùng %1$d%%.</string>
     <string name="cleanup_storage_medium">Có khá nhiều thứ ở đây. Quét có thể giúp.</string>
     <string name="cleanup_storage_ok">Bộ nhớ của bạn vẫn ổn!</string>
     <string name="cleanup_notification_last_scan_format">Lần quét cuối: %1$d ngày trước. %2$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -22,6 +22,11 @@
     <string name="cleanup_title_variant15">你的手機值得煥然一新</string>
     <string name="cleanup_storage_very_high">儲存空間相當吃緊，要清一下嗎？</string>
     <string name="cleanup_storage_high">您已使用 %1$d%% — 如有需要點擊掃描。</string>
+    <string name="cleanup_storage_high_2">您已使用 %1$d%% — 快速掃描或許有幫助。</string>
+    <string name="cleanup_storage_high_3">%1$d%% 已滿。 空間有點吃緊。</string>
+    <string name="cleanup_storage_high_4">空間正在填滿，目前已用 %1$d%%。</string>
+    <string name="cleanup_storage_high_5">已用 %1$d%%。 要清理嗎？</string>
+    <string name="cleanup_storage_high_6">快滿了，%1$d%% 已在使用。</string>
     <string name="cleanup_storage_medium">這裡有很多內容，掃描或許有幫助。</string>
     <string name="cleanup_storage_ok">您的儲存空間狀況良好！</string>
     <string name="cleanup_notification_last_scan_format">上次掃描：%1$d 天前。%2$s</string>


### PR DESCRIPTION
## Summary
Added translations for new storage warning strings in all supported languages.

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e301b0f0c832d927f2aa1b6fffc06