### PR TITLE
Add translations for storage warnings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">يمكن أن يساعدك التنظيف على البقاء سريعًا</string>
     <string name="cleanup_title_variant15">هاتفك يستحق تحديث</string>
     <string name="cleanup_storage_very_high">المساحة ضيقة جدًا. عايز تنظف شوية؟</string>
+    <string name="cleanup_storage_very_high_2">المساحة قربت تتملي! وقت التنظيف؟</string>
+    <string name="cleanup_storage_very_high_3">المساحة حرجة. خلينا نسترجع شوية مساحة.</string>
+    <string name="cleanup_storage_very_high_4">المساحة بتخلص بسرعة!</string>
+    <string name="cleanup_storage_very_high_5">تحذير: المساحة منخفضة جدًا.</string>
+    <string name="cleanup_storage_very_high_6">وصلت للحد! خلينا ننضف بسرعة.</string>
     <string name="cleanup_storage_high">انت على %1$d%% — اضغط للفحص لو حبيت.</string>
     <string name="cleanup_storage_high_2">انت مستخدم %1$d%% — فحص سريع ممكن يساعد.</string>
     <string name="cleanup_storage_high_3">%1$d%% مليانة. المكان بيضيق شوي.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Почистването може да ви помогне да останете бързо</string>
     <string name="cleanup_title_variant15">Телефонът ви заслужава опресняване</string>
     <string name="cleanup_storage_very_high">Паметта е доста запълнена. Искате ли да почистите малко?</string>
+    <string name="cleanup_storage_very_high_2">Почти нямате място! Време за почистване?</string>
+    <string name="cleanup_storage_very_high_3">Критичен капацитет. Нека освободим малко място.</string>
+    <string name="cleanup_storage_very_high_4">Бързо свършва мястото!</string>
+    <string name="cleanup_storage_very_high_5">Предупреждение: мястото е опасно малко.</string>
+    <string name="cleanup_storage_very_high_6">Максимално запълнено! Нека почистим бързо.</string>
     <string name="cleanup_storage_high">Вие сте на %1$d%% — докоснете за сканиране при нужда.</string>
     <string name="cleanup_storage_high_2">Използвани са %1$d%% — бързо сканиране може да помогне.</string>
     <string name="cleanup_storage_high_3">%1$d%% запълнени. Става малко тясно.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">ক্লিনআপ আপনাকে দ্রুত থাকতে সহায়তা করতে পারে</string>
     <string name="cleanup_title_variant15">আপনার ফোন একটি রিফ্রেশ প্রাপ্য</string>
     <string name="cleanup_storage_very_high">স্টোরেজ খুব টাইট। একটু পরিষ্কার করতে চান?</string>
+    <string name="cleanup_storage_very_high_2">প্রায় পুরো ভরেছে! একটু পরিষ্কার করবেন?</string>
+    <string name="cleanup_storage_very_high_3">স্টোরেজ সংকটাপন্ন। কিছু জায়গা উদ্ধার করি।</string>
+    <string name="cleanup_storage_very_high_4">দ্রুতই জায়গা ফুরিয়ে যাচ্ছে!</string>
+    <string name="cleanup_storage_very_high_5">সতর্কতা: স্টোরেজ বিপজ্জনকভাবে কম।</string>
+    <string name="cleanup_storage_very_high_6">ম্যাক্স হয়ে গেছে! দ্রুত পরিষ্কার করি।</string>
     <string name="cleanup_storage_high">আপনি %1$d%% এ আছেন — প্রয়োজনে স্ক্যান করতে ট্যাপ করুন।</string>
     <string name="cleanup_storage_high_2">আপনি %1$d%% ব্যবহার করছেন — দ্রুত স্ক্যান সাহায্য করতে পারে।</string>
     <string name="cleanup_storage_high_3">%1$d%% পূর্ণ হয়েছে। জায়গা একটু টাইট হয়ে যাচ্ছে।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Aufräumen hilft dir, schnell zu bleiben</string>
     <string name="cleanup_title_variant15">Dein Handy verdient eine Auffrischung</string>
     <string name="cleanup_storage_very_high">Speicher ist sehr knapp. Möchtest du ein bisschen aufräumen?</string>
+    <string name="cleanup_storage_very_high_2">Du bist fast voll! Zeit für eine Aufräumaktion?</string>
+    <string name="cleanup_storage_very_high_3">Speicher kritisch. Lass uns etwas Platz zurückholen.</string>
+    <string name="cleanup_storage_very_high_4">Der Platz geht rasch aus!</string>
+    <string name="cleanup_storage_very_high_5">Warnung: Speicher gefährlich niedrig.</string>
+    <string name="cleanup_storage_very_high_6">Voll ausgelastet! Schnell aufräumen.</string>
     <string name="cleanup_storage_high">Du bist bei %1$d%% — tippe zum Scannen, wenn nötig.</string>
     <string name="cleanup_storage_high_2">Du bist bei %1$d%% Auslastung — ein schneller Scan könnte helfen.</string>
     <string name="cleanup_storage_high_3">%1$d%% belegt. Hier wird es langsam eng.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">La limpieza puede ayudarte a mantener la velocidad</string>
     <string name="cleanup_title_variant15">Tu teléfono merece un refresco</string>
     <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
+    <string name="cleanup_storage_very_high_2">¡Casi lleno! ¿Hora de limpiar?</string>
+    <string name="cleanup_storage_very_high_3">Almacenamiento crítico. Recuperemos algo de espacio.</string>
+    <string name="cleanup_storage_very_high_4">¡El espacio se acaba rápido!</string>
+    <string name="cleanup_storage_very_high_5">Advertencia: almacenamiento peligrosamente bajo.</string>
+    <string name="cleanup_storage_very_high_6">¡Al máximo! Limpiemos rápido.</string>
     <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si lo necesitas.</string>
     <string name="cleanup_storage_high_2">Estás con %1$d%% usado — un escaneo rápido podría ayudar.</string>
     <string name="cleanup_storage_high_3">%1$d%% ocupado. Esto empieza a apretarse.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">La limpieza puede ayudarte a mantener la velocidad</string>
     <string name="cleanup_title_variant15">Tu teléfono merece un refresco</string>
     <string name="cleanup_storage_very_high">El almacenamiento está muy lleno. ¿Quieres limpiar un poco?</string>
+    <string name="cleanup_storage_very_high_2">¡Casi lleno! ¿Hora de limpiar?</string>
+    <string name="cleanup_storage_very_high_3">Almacenamiento crítico. Recuperemos algo de espacio.</string>
+    <string name="cleanup_storage_very_high_4">¡El espacio se acaba rápido!</string>
+    <string name="cleanup_storage_very_high_5">Advertencia: almacenamiento peligrosamente bajo.</string>
+    <string name="cleanup_storage_very_high_6">¡Al máximo! Limpiemos rápido.</string>
     <string name="cleanup_storage_high">Estás al %1$d%% — toca para escanear si es necesario.</string>
     <string name="cleanup_storage_high_2">Estás con %1$d%% usado — un escaneo rápido podría ayudar.</string>
     <string name="cleanup_storage_high_3">%1$d%% ocupado. Esto empieza a apretarse.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Ang paglilinis ay makakatulong sa iyo na manatiling mabilis</string>
     <string name="cleanup_title_variant15">Ang iyong telepono ay nararapat sa isang pag -refresh</string>
     <string name="cleanup_storage_very_high">Sobrang sikip ng storage. Gusto mo bang linisin ng kaunti?</string>
+    <string name="cleanup_storage_very_high_2">Halos puno na! Maglinis na tayo?</string>
+    <string name="cleanup_storage_very_high_3">Kritikal na ang storage. Bawiin natin ang ilang espasyo.</string>
+    <string name="cleanup_storage_very_high_4">Mabilis nauubos ang espasyo!</string>
+    <string name="cleanup_storage_very_high_5">Babala: sobrang baba ng storage.</string>
+    <string name="cleanup_storage_very_high_6">Punung-puno na! Maglinis agad tayo.</string>
     <string name="cleanup_storage_high">Nasa %1$d%% ka na — tapikin para mag-scan kung kailangan.</string>
     <string name="cleanup_storage_high_2">Nasa %1$d%% kang gamit — baka makatulong ang mabilisang scan.</string>
     <string name="cleanup_storage_high_3">%1$d%% na ang puno. Medyo masikip na rito.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Le nettoyage peut vous aider à rester rapide</string>
     <string name="cleanup_title_variant15">Votre téléphone mérite un rafraîchissement</string>
     <string name="cleanup_storage_very_high">Le stockage est vraiment plein. Un peu de ménage ?</string>
+    <string name="cleanup_storage_very_high_2">Vous êtes presque plein ! Un petit nettoyage ?</string>
+    <string name="cleanup_storage_very_high_3">Stockage critique. Récupérons un peu d’espace.</string>
+    <string name="cleanup_storage_very_high_4">Plus beaucoup de place !</string>
+    <string name="cleanup_storage_very_high_5">Attention : stockage dangereusement bas.</string>
+    <string name="cleanup_storage_very_high_6">Saturé ! Nettoyons rapidement.</string>
     <string name="cleanup_storage_high">Vous êtes à %1$d%% — appuyez pour analyser si nécessaire.</string>
     <string name="cleanup_storage_high_2">Vous en êtes à %1$d%% utilisé — un scan rapide pourrait aider.</string>
     <string name="cleanup_storage_high_3">%1$d%% remplis. Ça commence à se serrer ici.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">क्लीनअप आपको तेजी से रहने में मदद कर सकता है</string>
     <string name="cleanup_title_variant15">आपका फ़ोन एक रिफ्रेश का हकदार है</string>
     <string name="cleanup_storage_very_high">स्टोरेज बहुत कम है। थोड़ा साफ़ करना चाहेंगे?</string>
+    <string name="cleanup_storage_very_high_2">आप लगभग भर चुके हैं! क्या साफ़ करें?</string>
+    <string name="cleanup_storage_very_high_3">स्टोरेज गंभीर है। चलिए थोड़ी जगह खाली करें।</string>
+    <string name="cleanup_storage_very_high_4">जगह तेजी से खत्म हो रही है!</string>
+    <string name="cleanup_storage_very_high_5">चेतावनी: स्टोरेज खतरनाक रूप से कम है।</string>
+    <string name="cleanup_storage_very_high_6">सब कुछ भरा हुआ है! जल्दी से साफ़ करें।</string>
     <string name="cleanup_storage_high">आप %1$d%% पर हैं — ज़रूरत हो तो स्कैन करने के लिए टैप करें.</string>
     <string name="cleanup_storage_high_2">आप %1$d%% उपयोग कर चुके हैं — जल्दी से स्कैन कर लें तो मदद मिल सकती है।</string>
     <string name="cleanup_storage_high_3">%1$d%% भर चुका है। यहाँ थोड़ी तंगी लग रही है।</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">A takarítás segíthet abban, hogy gyorsan maradjon</string>
     <string name="cleanup_title_variant15">A telefonod megérdemel egy frissítést</string>
     <string name="cleanup_storage_very_high">Nagyon szűkös a tárhely. Szeretnél kicsit takarítani?</string>
+    <string name="cleanup_storage_very_high_2">Majdnem tele van! Ideje takarítani?</string>
+    <string name="cleanup_storage_very_high_3">Kritikus a tárhely. Szabadítsunk fel némi helyet.</string>
+    <string name="cleanup_storage_very_high_4">Gyorsan fogy a hely!</string>
+    <string name="cleanup_storage_very_high_5">Figyelem: a tárhely veszélyesen alacsony.</string>
+    <string name="cleanup_storage_very_high_6">Teljesen megtelt! Takarítsunk gyorsan.</string>
     <string name="cleanup_storage_high">Már %1$d%%-n állsz — érints rá a kereséshez, ha szükséges.</string>
     <string name="cleanup_storage_high_2">Már %1$d%%-ot használsz — egy gyors keresés segíthet.</string>
     <string name="cleanup_storage_high_3">%1$d%% betelt. Kezd szűkös lenni.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Bersih-bersih bisa membantu ponsel tetap cepat</string>
     <string name="cleanup_title_variant15">Ponselmu pantas mendapatkan penyegaran</string>
     <string name="cleanup_storage_very_high">Penyimpanan sangat penuh. Ingin bersih-bersih?</string>
+    <string name="cleanup_storage_very_high_2">Hampir penuh! Bersih-bersih sekarang?</string>
+    <string name="cleanup_storage_very_high_3">Penyimpanan kritis. Mari bebaskan sedikit ruang.</string>
+    <string name="cleanup_storage_very_high_4">Ruang cepat habis!</string>
+    <string name="cleanup_storage_very_high_5">Peringatan: penyimpanan sangat rendah.</string>
+    <string name="cleanup_storage_very_high_6">Sudah penuh! Ayo bersihkan cepat.</string>
     <string name="cleanup_storage_high">Kamu di %1$d%% — ketuk untuk memindai jika perlu.</string>
     <string name="cleanup_storage_high_2">Kamu sudah memakai %1$d%% — pemindaian cepat bisa membantu.</string>
     <string name="cleanup_storage_high_3">%1$d%% terisi. Mulai terasa sempit.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">La pulizia può aiutarti a restare veloce</string>
     <string name="cleanup_title_variant15">Il tuo telefono merita un rinnovamento</string>
     <string name="cleanup_storage_very_high">La memoria è davvero piena. Vuoi pulire un po’?</string>
+    <string name="cleanup_storage_very_high_2">Sei quasi al completo! È ora di pulire?</string>
+    <string name="cleanup_storage_very_high_3">Memoria critica. Recuperiamo un po’ di spazio.</string>
+    <string name="cleanup_storage_very_high_4">Spazio in esaurimento rapido!</string>
+    <string name="cleanup_storage_very_high_5">Attenzione: spazio di archiviazione pericolosamente basso.</string>
+    <string name="cleanup_storage_very_high_6">Tutto pieno! Puliamo velocemente.</string>
     <string name="cleanup_storage_high">Sei al %1$d%% — tocca per scansionare se necessario.</string>
     <string name="cleanup_storage_high_2">Sei al %1$d%% di utilizzo — una scansione rapida potrebbe aiutare.</string>
     <string name="cleanup_storage_high_3">%1$d%% pieno. Inizia a farsi stretto qui.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">クリーンアップで快適さを保てます</string>
     <string name="cleanup_title_variant15">あなたのスマホにリフレッシュを</string>
     <string name="cleanup_storage_very_high">ストレージがかなり不足しています。少しクリーンアップしますか？</string>
+    <string name="cleanup_storage_very_high_2">ほぼいっぱいです！クリーンアップしますか？</string>
+    <string name="cleanup_storage_very_high_3">ストレージが危機的です。空き容量を確保しましょう。</string>
+    <string name="cleanup_storage_very_high_4">急速に容量がなくなっています！</string>
+    <string name="cleanup_storage_very_high_5">警告: ストレージが危険なほど少なくなっています。</string>
+    <string name="cleanup_storage_very_high_6">容量が限界です！早急にクリーンアップしましょう。</string>
     <string name="cleanup_storage_high">現在%1$d%%です—必要に応じてタップしてスキャンしてください。</string>
     <string name="cleanup_storage_high_2">%1$d%%使用中です — すばやくスキャンするとよいかもしれません。</string>
     <string name="cleanup_storage_high_3">%1$d%%埋まっています。少し手狭になってきました。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">정리하면 빠른 속도를 유지할 수 있어요</string>
     <string name="cleanup_title_variant15">휴대폰도 새 단장을 할 자격이 있죠</string>
     <string name="cleanup_storage_very_high">저장공간이 매우 부족합니다. 조금 정리해볼까요?</string>
+    <string name="cleanup_storage_very_high_2">거의 다 찼어요! 정리할까요?</string>
+    <string name="cleanup_storage_very_high_3">저장공간이 위급합니다. 공간을 좀 확보하죠.</string>
+    <string name="cleanup_storage_very_high_4">공간이 빠르게 줄어들고 있어요!</string>
+    <string name="cleanup_storage_very_high_5">경고: 저장공간이 위험할 정도로 부족합니다.</string>
+    <string name="cleanup_storage_very_high_6">최대치예요! 빨리 정리합시다.</string>
     <string name="cleanup_storage_high">%1$d%% 사용 중 — 필요하면 탭해서 스캔하세요.</string>
     <string name="cleanup_storage_high_2">%1$d%% 사용 중 — 빠른 스캔이 도움이 될 수 있어요.</string>
     <string name="cleanup_storage_high_3">%1$d%% 채워졌어요. 조금 비좁네요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Czyszczenie pomaga zachować szybkość</string>
     <string name="cleanup_title_variant15">Twój telefon zasługuje na odświeżenie</string>
     <string name="cleanup_storage_very_high">Pamięć jest bardzo zapełniona. Chcesz trochę posprzątać?</string>
+    <string name="cleanup_storage_very_high_2">Prawie pełno! Czas na czyszczenie?</string>
+    <string name="cleanup_storage_very_high_3">Pamięć krytyczna. Odzyskajmy trochę miejsca.</string>
+    <string name="cleanup_storage_very_high_4">Szybko kończy się miejsce!</string>
+    <string name="cleanup_storage_very_high_5">Uwaga: miejsce niebezpiecznie małe.</string>
+    <string name="cleanup_storage_very_high_6">Limit osiągnięty! Posprzątajmy szybko.</string>
     <string name="cleanup_storage_high">Masz %1$d%% — stuknij, aby przeskanować w razie potrzeby.</string>
     <string name="cleanup_storage_high_2">Masz zużyte %1$d%% — szybkie skanowanie może pomóc.</string>
     <string name="cleanup_storage_high_3">%1$d%% zapełnione. Robi się tu ciasno.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">A limpeza ajuda você a manter a velocidade</string>
     <string name="cleanup_title_variant15">Seu telefone merece um refresco</string>
     <string name="cleanup_storage_very_high">O armazenamento está bem cheio. Quer limpar um pouco?</string>
+    <string name="cleanup_storage_very_high_2">Quase lotado! Hora de limpar?</string>
+    <string name="cleanup_storage_very_high_3">Armazenamento crítico. Vamos liberar espaço.</string>
+    <string name="cleanup_storage_very_high_4">O espaço está acabando rápido!</string>
+    <string name="cleanup_storage_very_high_5">Aviso: armazenamento perigosamente baixo.</string>
+    <string name="cleanup_storage_very_high_6">No limite! Vamos limpar rapidinho.</string>
     <string name="cleanup_storage_high">Você está em %1$d%% — toque para escanear se necessário.</string>
     <string name="cleanup_storage_high_2">Você está com %1$d%% usado — uma verificação rápida pode ajudar.</string>
     <string name="cleanup_storage_high_3">%1$d%% preenchido. Está ficando apertado aqui.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Curățarea te ajută să rămâi rapid</string>
     <string name="cleanup_title_variant15">Telefonul tău merită o reîmprospătare</string>
     <string name="cleanup_storage_very_high">Spațiul de stocare e foarte aglomerat. Vrei să cureți puțin?</string>
+    <string name="cleanup_storage_very_high_2">Ești aproape plin! Facem curățenie?</string>
+    <string name="cleanup_storage_very_high_3">Stocarea e critică. Hai să eliberăm spațiu.</string>
+    <string name="cleanup_storage_very_high_4">Rămâi rapid fără spațiu!</string>
+    <string name="cleanup_storage_very_high_5">Avertisment: spațiu de stocare periculos de mic.</string>
+    <string name="cleanup_storage_very_high_6">La maximum! Să curățăm rapid.</string>
     <string name="cleanup_storage_high">Ești la %1$d%% — atinge pentru scanare dacă e nevoie.</string>
     <string name="cleanup_storage_high_2">Ești la %1$d%% folosit — o scanare rapidă ar putea ajuta.</string>
     <string name="cleanup_storage_high_3">%1$d%% ocupat. Începe să fie cam înghesuit.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Очистка поможет сохранить скорость</string>
     <string name="cleanup_title_variant15">Ваш телефон заслуживает обновления</string>
     <string name="cleanup_storage_very_high">Хранилище почти заполнено. Хотите немного почистить?</string>
+    <string name="cleanup_storage_very_high_2">Память почти заполнена! Почистить?</string>
+    <string name="cleanup_storage_very_high_3">Критическое заполнение. Давайте освободим место.</string>
+    <string name="cleanup_storage_very_high_4">Свободное место быстро заканчивается!</string>
+    <string name="cleanup_storage_very_high_5">Предупреждение: памяти критически мало.</string>
+    <string name="cleanup_storage_very_high_6">Предел! Быстро очистим.</string>
     <string name="cleanup_storage_high">Вы используете %1$d%% — нажмите для сканирования при необходимости.</string>
     <string name="cleanup_storage_high_2">Использовано %1$d%% — быстрый скан может помочь.</string>
     <string name="cleanup_storage_high_3">%1$d%% занято. Здесь становится тесновато.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">En rensning hjälper dig att hålla farten</string>
     <string name="cleanup_title_variant15">Din telefon förtjänar en uppfräschning</string>
     <string name="cleanup_storage_very_high">Lagringen är riktigt full. Vill du städa lite?</string>
+    <string name="cleanup_storage_very_high_2">Nästan fullt! Dags att städa?</string>
+    <string name="cleanup_storage_very_high_3">Kritiskt utrymme. Låt oss frigöra lite.</string>
+    <string name="cleanup_storage_very_high_4">Utrymmet tar slut snabbt!</string>
+    <string name="cleanup_storage_very_high_5">Varning: lagringen är farligt låg.</string>
+    <string name="cleanup_storage_very_high_6">Maxat! Vi rensar snabbt.</string>
     <string name="cleanup_storage_high">Du är på %1$d%% — tryck för att skanna vid behov.</string>
     <string name="cleanup_storage_high_2">Du har använt %1$d%% — en snabb skanning kan hjälpa.</string>
     <string name="cleanup_storage_high_3">%1$d%% fyllt. Det börjar bli trångt här.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">การทำความสะอาดสามารถช่วยให้คุณอยู่ได้อย่างรวดเร็ว</string>
     <string name="cleanup_title_variant15">โทรศัพท์ของคุณสมควรได้รับการรีเฟรช</string>
     <string name="cleanup_storage_very_high">พื้นที่จัดเก็บแน่นมาก ต้องการล้างหน่อยไหม?</string>
+    <string name="cleanup_storage_very_high_2">เกือบเต็มแล้ว! ทำความสะอาดเลยไหม?</string>
+    <string name="cleanup_storage_very_high_3">พื้นที่จัดเก็บเข้าขั้นวิกฤต มาช่วยเคลียร์พื้นที่กันเถอะ</string>
+    <string name="cleanup_storage_very_high_4">พื้นที่กำลังจะหมดเร็วมาก!</string>
+    <string name="cleanup_storage_very_high_5">คำเตือน: พื้นที่จัดเก็บเหลือน้อยมาก</string>
+    <string name="cleanup_storage_very_high_6">เต็มความจุแล้ว! มาทำความสะอาดด่วน</string>
     <string name="cleanup_storage_high">คุณใช้ไปแล้ว %1$d%% — แตะเพื่อสแกนหากจำเป็น</string>
     <string name="cleanup_storage_high_2">คุณใช้ไปแล้ว %1$d%% — การสแกนด่วนอาจช่วยได้.</string>
     <string name="cleanup_storage_high_3">เต็มไปแล้ว %1$d%% เริ่มคับที่.</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Temizlik hızlı kalmana yardımcı olur</string>
     <string name="cleanup_title_variant15">Telefonun bir yenilenmeyi hak ediyor</string>
     <string name="cleanup_storage_very_high">Depolama çok dolu. Biraz temizlemek ister misin?</string>
+    <string name="cleanup_storage_very_high_2">Neredeyse dolu! Temizlik zamanı mı?</string>
+    <string name="cleanup_storage_very_high_3">Depolama kritik. Biraz alan açalım.</string>
+    <string name="cleanup_storage_very_high_4">Yer çok hızlı tükeniyor!</string>
+    <string name="cleanup_storage_very_high_5">Uyarı: depolama tehlikeli derecede az.</string>
+    <string name="cleanup_storage_very_high_6">Tamamen dolu! Hızlıca temizleyelim.</string>
     <string name="cleanup_storage_high">%1$d%% dolu — gerekirse taramak için dokun.</string>
     <string name="cleanup_storage_high_2">%1$d%% kullanılmış — hızlı bir tarama yardımcı olabilir.</string>
     <string name="cleanup_storage_high_3">%1$d%% dolu. Burada biraz daralıyor.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Очищення допоможе залишатися швидким</string>
     <string name="cleanup_title_variant15">Ваш телефон заслуговує на оновлення</string>
     <string name="cleanup_storage_very_high">Пам’ять майже заповнена. Хочете трохи почистити?</string>
+    <string name="cleanup_storage_very_high_2">Майже все заповнено! Почистити?</string>
+    <string name="cleanup_storage_very_high_3">Критичний рівень пам’яті. Давайте звільнимо місце.</string>
+    <string name="cleanup_storage_very_high_4">Місце швидко закінчується!</string>
+    <string name="cleanup_storage_very_high_5">Попередження: пам’ять небезпечно заповнена.</string>
+    <string name="cleanup_storage_very_high_6">Максимум! Почистимо швидко.</string>
     <string name="cleanup_storage_high">У вас %1$d%% — торкніться для сканування за потреби.</string>
     <string name="cleanup_storage_high_2">Ви використали %1$d%% — швидке сканування може допомогти.</string>
     <string name="cleanup_storage_high_3">%1$d%% заповнено. Тут стає тісно.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">صفائی آپ کو تیز رہنے میں مدد فراہم کرسکتی ہے</string>
     <string name="cleanup_title_variant15">آپ کا فون ریفریش کا مستحق ہے</string>
     <string name="cleanup_storage_very_high">اسٹوریج بہت تنگ ہے۔ تھوڑا صاف کرنا چاہیں گے؟</string>
+    <string name="cleanup_storage_very_high_2">تقریباً بھر چکا ہے! صفائی کریں؟</string>
+    <string name="cleanup_storage_very_high_3">اسٹوریج نازک حالت میں ہے۔ کچھ جگہ واپس لیں۔</string>
+    <string name="cleanup_storage_very_high_4">جگہ تیزی سے ختم ہورہی ہے!</string>
+    <string name="cleanup_storage_very_high_5">انتباہ: اسٹوریج خطرناک حد تک کم ہے۔</string>
+    <string name="cleanup_storage_very_high_6">مکمل بھر گیا! جلدی سے صاف کرلیں۔</string>
     <string name="cleanup_storage_high">آپ %1$d%% پر ہیں—ضرورت ہو تو اسکین کے لیے ٹیپ کریں۔</string>
     <string name="cleanup_storage_high_2">آپ %1$d%% استعمال کرچکے ہیں—ایک فوری اسکین مددگار ہوسکتا ہے۔</string>
     <string name="cleanup_storage_high_3">%1$d%% بھر چکا ہے۔ جگہ کچھ تنگ ہورہی ہے۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">Dọn dẹp giúp máy luôn nhanh</string>
     <string name="cleanup_title_variant15">Điện thoại của bạn xứng đáng được làm mới</string>
     <string name="cleanup_storage_very_high">Bộ nhớ rất chật. Bạn muốn dọn dẹp chút không?</string>
+    <string name="cleanup_storage_very_high_2">Gần đầy rồi! Dọn dẹp ngay?</string>
+    <string name="cleanup_storage_very_high_3">Bộ nhớ nguy cấp. Hãy giải phóng chút không gian.</string>
+    <string name="cleanup_storage_very_high_4">Sắp hết chỗ rất nhanh!</string>
+    <string name="cleanup_storage_very_high_5">Cảnh báo: bộ nhớ còn lại quá ít.</string>
+    <string name="cleanup_storage_very_high_6">Đã đầy! Hãy dọn dẹp gấp.</string>
     <string name="cleanup_storage_high">Bạn đã dùng %1$d%% — nhấn để quét nếu cần.</string>
     <string name="cleanup_storage_high_2">Bạn đã dùng %1$d%% — quét nhanh có thể giúp đỡ.</string>
     <string name="cleanup_storage_high_3">Đã đầy %1$d%%. Bắt đầu hơi chật chội.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,11 @@
     <string name="cleanup_title_variant14">清理能幫助保持速度</string>
     <string name="cleanup_title_variant15">你的手機值得煥然一新</string>
     <string name="cleanup_storage_very_high">儲存空間相當吃緊，要清一下嗎？</string>
+    <string name="cleanup_storage_very_high_2">快滿了！要清理一下嗎？</string>
+    <string name="cleanup_storage_very_high_3">儲存空間危急，我們來釋放一些吧。</string>
+    <string name="cleanup_storage_very_high_4">空間很快就要用完！</string>
+    <string name="cleanup_storage_very_high_5">警告：儲存空間極低。</string>
+    <string name="cleanup_storage_very_high_6">已達上限！趕緊清理吧。</string>
     <string name="cleanup_storage_high">您已使用 %1$d%% — 如有需要點擊掃描。</string>
     <string name="cleanup_storage_high_2">您已使用 %1$d%% — 快速掃描或許有幫助。</string>
     <string name="cleanup_storage_high_3">%1$d%% 已滿。 空間有點吃緊。</string>


### PR DESCRIPTION
## Summary
- localize the critical storage warning strings across existing languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e368a4244832d8ee4b96fab9a54f0