### PR TITLE
Add translations for cleanup messages

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% belegt. Zeit zum Aufräumen?</string>
     <string name="cleanup_storage_high_6">Du bist fast voll. %1$d%% in Benutzung.</string>
     <string name="cleanup_storage_medium">Hier gibt es einiges. Ein Scan könnte helfen.</string>
+    <string name="cleanup_storage_medium_2">Du hast hier schon einiges gesammelt.</string>
+    <string name="cleanup_storage_medium_3">Mach doch mal einen Scan — vielleicht wirst du überrascht sein.</string>
+    <string name="cleanup_storage_medium_4">Es ist noch Platz, aber aufräumen schadet nicht.</string>
+    <string name="cleanup_storage_medium_5">Vielleicht ist es Zeit für einen kurzen Rundgang.</string>
+    <string name="cleanup_storage_medium_6">Hier ist etwas Unordnung. Willst du scannen?</string>
     <string name="cleanup_storage_ok">Dein Speicher sieht gut aus!</string>
+    <string name="cleanup_storage_ok_2">Du bist im grünen Bereich. Alles gut!</string>
+    <string name="cleanup_storage_ok_3">Prima! Du hast genug freien Speicher.</string>
+    <string name="cleanup_storage_ok_4">Sieht gut aus — nichts zu tun.</string>
+    <string name="cleanup_storage_ok_5">Der Speicher ist unter Kontrolle!</string>
+    <string name="cleanup_storage_ok_6">Sauber und klar. Gut gemacht!</string>
     <string name="cleanup_notification_last_scan_format">Letzter Scan: vor %1$d Tagen. %2$s</string>
     <string name="cleanup_notification_never_scanned">Du hast dein Handy noch nicht gescannt. Tippe, um zu starten.</string>
 

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% usado. ¿Hora de limpiar?</string>
     <string name="cleanup_storage_high_6">Te estás acercando al límite. %1$d%% en uso.</string>
     <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
+    <string name="cleanup_storage_medium_2">Tienes bastante contenido aquí.</string>
+    <string name="cleanup_storage_medium_3">Considera un escaneo — podrías sorprenderte.</string>
+    <string name="cleanup_storage_medium_4">Queda espacio, pero una limpieza no vendría mal.</string>
+    <string name="cleanup_storage_medium_5">Puede que sea momento de una limpieza ligera.</string>
+    <string name="cleanup_storage_medium_6">Hay un poco de desorden. ¿Quieres escanear?</string>
     <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
+    <string name="cleanup_storage_ok_2">Estás en la zona segura. ¡Todo bien!</string>
+    <string name="cleanup_storage_ok_3">¡Genial! Tienes suficiente espacio libre.</string>
+    <string name="cleanup_storage_ok_4">Todo se ve bien — no hace falta hacer nada.</string>
+    <string name="cleanup_storage_ok_5">¡El almacenamiento está bajo control!</string>
+    <string name="cleanup_storage_ok_6">Limpio y despejado. ¡Bien hecho!</string>
     <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
     <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% usado. ¿Hora de limpiar?</string>
     <string name="cleanup_storage_high_6">Te estás acercando al límite. %1$d%% en uso.</string>
     <string name="cleanup_storage_medium">Hay bastantes cosas aquí. Un escaneo podría ayudar.</string>
+    <string name="cleanup_storage_medium_2">Tienes bastante contenido aquí.</string>
+    <string name="cleanup_storage_medium_3">Considera un escaneo — podrías sorprenderte.</string>
+    <string name="cleanup_storage_medium_4">Queda espacio, pero una limpieza no vendría mal.</string>
+    <string name="cleanup_storage_medium_5">Puede que sea momento de una limpieza ligera.</string>
+    <string name="cleanup_storage_medium_6">Hay un poco de desorden. ¿Quieres escanear?</string>
     <string name="cleanup_storage_ok">¡Tu almacenamiento se ve bien!</string>
+    <string name="cleanup_storage_ok_2">Estás en la zona segura. ¡Todo bien!</string>
+    <string name="cleanup_storage_ok_3">¡Genial! Tienes suficiente espacio libre.</string>
+    <string name="cleanup_storage_ok_4">Todo se ve bien — no hace falta hacer nada.</string>
+    <string name="cleanup_storage_ok_5">¡El almacenamiento está bajo control!</string>
+    <string name="cleanup_storage_ok_6">Limpio y despejado. ¡Bien hecho!</string>
     <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
     <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
 
@@ -240,5 +250,4 @@
     <string name="data_not_available">Datos no disponibles.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
-    <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>
-</resources>
+    <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string></resources>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% utilisé. On nettoie ?</string>
     <string name="cleanup_storage_high_6">Vous approchez de la limite. %1$d%% utilisés.</string>
     <string name="cleanup_storage_medium">Il y a pas mal de choses ici. Un scan pourrait aider.</string>
+    <string name="cleanup_storage_medium_2">Vous avez pas mal de choses ici.</string>
+    <string name="cleanup_storage_medium_3">Pensez à une analyse — ça pourrait surprendre.</string>
+    <string name="cleanup_storage_medium_4">Il reste de la place, mais un nettoyage ne ferait pas de mal.</string>
+    <string name="cleanup_storage_medium_5">Il est peut-être temps d'un petit coup de balai.</string>
+    <string name="cleanup_storage_medium_6">Il y a un peu de bazar. Envie de scanner ?</string>
     <string name="cleanup_storage_ok">Votre stockage est en bon état !</string>
+    <string name="cleanup_storage_ok_2">Vous êtes dans la zone de sécurité. Tout va bien !</string>
+    <string name="cleanup_storage_ok_3">Super ! Vous avez assez d’espace libre.</string>
+    <string name="cleanup_storage_ok_4">Tout semble bon — aucune action nécessaire.</string>
+    <string name="cleanup_storage_ok_5">Le stockage est sous contrôle !</string>
+    <string name="cleanup_storage_ok_6">Propre et net. Bien joué !</string>
     <string name="cleanup_notification_last_scan_format">Dernière analyse : il y a %1$d jours. %2$s</string>
     <string name="cleanup_notification_never_scanned">Vous n’avez pas encore analysé votre téléphone. Appuyez pour commencer.</string>
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% usato. È ora di pulire?</string>
     <string name="cleanup_storage_high_6">Stai per esaurire lo spazio. %1$d%% in uso.</string>
     <string name="cleanup_storage_medium">C’è un bel po’ di roba qui. Una scansione potrebbe aiutare.</string>
+    <string name="cleanup_storage_medium_2">Hai parecchia roba qui.</string>
+    <string name="cleanup_storage_medium_3">Fai una scansione — potresti rimanere sorpreso.</string>
+    <string name="cleanup_storage_medium_4">C'e spazio, ma una pulizia non guasterebbe.</string>
+    <string name="cleanup_storage_medium_5">Potrebbe essere il momento di una pulizia veloce.</string>
+    <string name="cleanup_storage_medium_6">C'e un po' di disordine. Vuoi scansionare?</string>
     <string name="cleanup_storage_ok">La tua memoria sembra a posto!</string>
+    <string name="cleanup_storage_ok_2">Sei nella zona sicura. Tutto ok!</string>
+    <string name="cleanup_storage_ok_3">Ottimo! Hai abbastanza spazio libero.</string>
+    <string name="cleanup_storage_ok_4">Sembra tutto a posto — nessuna azione necessaria.</string>
+    <string name="cleanup_storage_ok_5">Lo spazio è sotto controllo!</string>
+    <string name="cleanup_storage_ok_6">Pulito e ordinato. Ben fatto!</string>
     <string name="cleanup_notification_last_scan_format">Ultima scansione: %1$d giorni fa. %2$s</string>
     <string name="cleanup_notification_never_scanned">Non hai ancora scansionato il telefono. Tocca per iniziare.</string>
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%%使用中。掃除しますか？</string>
     <string name="cleanup_storage_high_6">ほぼ満杯です。%1$d%%使用中。</string>
     <string name="cleanup_storage_medium">ここにはたくさんのものがあります。スキャンが役立つかもしれません。</string>
+    <string name="cleanup_storage_medium_2">ここにはなかなか多くのものがあります。</string>
+    <string name="cleanup_storage_medium_3">スキャンを検討してください — 意外な結果かもしれません。</string>
+    <string name="cleanup_storage_medium_4">まだ余裕はありますが、掃除しても損はありません。</string>
+    <string name="cleanup_storage_medium_5">軽く掃除する頃かもしれません。</string>
+    <string name="cleanup_storage_medium_6">少し散らかっています。スキャンしますか？</string>
     <string name="cleanup_storage_ok">ストレージは良好です！</string>
+    <string name="cleanup_storage_ok_2">安全圏内です。問題ありません！</string>
+    <string name="cleanup_storage_ok_3">いいですね！十分な空き容量があります。</string>
+    <string name="cleanup_storage_ok_4">順調です — 特に作業は不要です。</string>
+    <string name="cleanup_storage_ok_5">ストレージは管理されています！</string>
+    <string name="cleanup_storage_ok_6">すっきりクリーン。お見事！</string>
     <string name="cleanup_notification_last_scan_format">最終スキャン: %1$d日前。%2$s</string>
     <string name="cleanup_notification_never_scanned">まだスキャンしていません。タップして開始してください。</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% usado. Hora de limpar?</string>
     <string name="cleanup_storage_high_6">Quase cheio. %1$d%% em uso.</string>
     <string name="cleanup_storage_medium">Tem bastante coisa aqui. Um scan pode ajudar.</string>
+    <string name="cleanup_storage_medium_2">Você tem bastante coisa aqui.</string>
+    <string name="cleanup_storage_medium_3">Considere uma análise — você pode se surpreender.</string>
+    <string name="cleanup_storage_medium_4">Ainda há espaço, mas uma limpeza não faria mal.</string>
+    <string name="cleanup_storage_medium_5">Talvez seja hora de uma limpeza leve.</string>
+    <string name="cleanup_storage_medium_6">Há um pouco de bagunça. Quer escanear?</string>
     <string name="cleanup_storage_ok">Seu armazenamento está ok!</string>
+    <string name="cleanup_storage_ok_2">Você está na zona segura. Tudo certo!</string>
+    <string name="cleanup_storage_ok_3">Ótimo! Você tem espaço livre suficiente.</string>
+    <string name="cleanup_storage_ok_4">Tudo parece bem — nenhuma ação necessária.</string>
+    <string name="cleanup_storage_ok_5">O armazenamento está sob controle!</string>
+    <string name="cleanup_storage_ok_6">Limpo e organizado. Muito bem!</string>
     <string name="cleanup_notification_last_scan_format">Última varredura: há %1$d dias. %2$s</string>
     <string name="cleanup_notification_never_scanned">Você ainda não escaneou o telefone. Toque para começar.</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">%1$d%% занято. Почистить?</string>
     <string name="cleanup_storage_high_6">Почти заполнено. %1$d%% используется.</string>
     <string name="cleanup_storage_medium">Здесь много всего. Сканирование может помочь.</string>
+    <string name="cleanup_storage_medium_2">Здесь у вас достаточно много всего.</string>
+    <string name="cleanup_storage_medium_3">Подумайте о сканировании — результат может удивить.</string>
+    <string name="cleanup_storage_medium_4">Место ещё есть, но уборка не помешает.</string>
+    <string name="cleanup_storage_medium_5">Похоже, пора навести лёгкий порядок.</string>
+    <string name="cleanup_storage_medium_6">Немного беспорядка. Хотите просканировать?</string>
     <string name="cleanup_storage_ok">Ваше хранилище в порядке!</string>
+    <string name="cleanup_storage_ok_2">Вы в безопасной зоне. Всё хорошо!</string>
+    <string name="cleanup_storage_ok_3">Отлично! У вас достаточно свободного места.</string>
+    <string name="cleanup_storage_ok_4">Всё отлично — действий не требуется.</string>
+    <string name="cleanup_storage_ok_5">Хранилище под контролем!</string>
+    <string name="cleanup_storage_ok_6">Чисто и аккуратно. Молодцы!</string>
     <string name="cleanup_notification_last_scan_format">Последнее сканирование: %1$d дней назад. %2$s</string>
     <string name="cleanup_notification_never_scanned">Вы ещё не сканировали телефон. Нажмите, чтобы начать.</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -33,7 +33,17 @@
     <string name="cleanup_storage_high_5">已用 %1$d%%。 要清理嗎？</string>
     <string name="cleanup_storage_high_6">快滿了，%1$d%% 已在使用。</string>
     <string name="cleanup_storage_medium">這裡有很多內容，掃描或許有幫助。</string>
+    <string name="cleanup_storage_medium_2">這裡的內容不少。</string>
+    <string name="cleanup_storage_medium_3">建議掃描一下—可能會有驚喜。</string>
+    <string name="cleanup_storage_medium_4">還有空間，但清理一下也無妨。</string>
+    <string name="cleanup_storage_medium_5">也許是輕鬆清掃的時候了。</string>
+    <string name="cleanup_storage_medium_6">有點雜亂，要掃描一下嗎？</string>
     <string name="cleanup_storage_ok">您的儲存空間狀況良好！</string>
+    <string name="cleanup_storage_ok_2">目前安全無虞，一切正常！</string>
+    <string name="cleanup_storage_ok_3">太好了！你的空間還很充裕。</string>
+    <string name="cleanup_storage_ok_4">看起來不錯—無需任何操作。</string>
+    <string name="cleanup_storage_ok_5">儲存空間一切掌控！</string>
+    <string name="cleanup_storage_ok_6">乾淨清爽，做得好！</string>
     <string name="cleanup_notification_last_scan_format">上次掃描：%1$d 天前。%2$s</string>
     <string name="cleanup_notification_never_scanned">您尚未掃描手機，點擊即可開始。</string>
 


### PR DESCRIPTION
## Summary
- translate cleanup medium and ok strings into French, German, Spanish, Italian, Portuguese (Brazil), Russian, Japanese, and Chinese (Traditional)

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e70558b74832d8639c36f6ecdb83c