### PR TITLE
Add medium storage translations

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% مستخدم. ننضف؟</string>
     <string name="cleanup_storage_high_6">قربت تتملي. %1$d%% مستخدم.</string>
     <string name="cleanup_storage_medium">فيه حاجات كتير هنا. الفحص ممكن يفيد.</string>
+    <string name="cleanup_storage_medium_2">عندك كمية محترمة من الملفات هنا.</string>
+    <string name="cleanup_storage_medium_3">جرّب فحص — يمكن تتفاجئ.</string>
+    <string name="cleanup_storage_medium_4">في مساحة فاضية، لكن التنظيف مش هيضر.</string>
+    <string name="cleanup_storage_medium_5">يمكن يكون وقت تنظيف خفيف.</string>
+    <string name="cleanup_storage_medium_6">في شوية فوضى. عايز تفحص؟</string>
     <string name="cleanup_storage_ok">المساحة عندك تمام!</string>
     <string name="cleanup_notification_last_scan_format">آخر فحص: من %1$d يوم. %2$s</string>
     <string name="cleanup_notification_never_scanned">لسه ما فحصتش تليفونك. اضغط للبدء.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">Използвани са %1$d%%. Време ли е за почистване?</string>
     <string name="cleanup_storage_high_6">Приближавате се до пълно. %1$d%% заето.</string>
     <string name="cleanup_storage_medium">Има доста неща тук. Сканиране може да помогне.</string>
+    <string name="cleanup_storage_medium_2">Натрупали сте доста неща тук.</string>
+    <string name="cleanup_storage_medium_3">Помислете за сканиране — може да се изненадате.</string>
+    <string name="cleanup_storage_medium_4">Има още място, но едно почистване не би навредило.</string>
+    <string name="cleanup_storage_medium_5">Може би е време за леко почистване.</string>
+    <string name="cleanup_storage_medium_6">Има малко безпорядък. Искате ли да сканирате?</string>
     <string name="cleanup_storage_ok">Паметта ви изглежда добре!</string>
     <string name="cleanup_notification_last_scan_format">Последно сканиране: преди %1$d дни. %2$s</string>
     <string name="cleanup_notification_never_scanned">Все още не сте сканирали телефона си. Докоснете, за да започнете.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% ব্যবহার হয়েছে। পরিষ্কার করবেন?</string>
     <string name="cleanup_storage_high_6">প্রায় পুরো হয়ে যাচ্ছে। %1$d%% ব্যবহৃত।</string>
     <string name="cleanup_storage_medium">এখানে অনেক কিছু আছে। একটি স্ক্যান সাহায্য করতে পারে।</string>
+    <string name="cleanup_storage_medium_2">আপনার এখানে ভালো পরিমাণ জিনিস আছে।</string>
+    <string name="cleanup_storage_medium_3">একটি স্ক্যান বিবেচনা করুন — অবাক হতে পারেন।</string>
+    <string name="cleanup_storage_medium_4">এখনও জায়গা আছে, তবে পরিষ্কার করলে মন্দ নয়।</string>
+    <string name="cleanup_storage_medium_5">হালকা একটা পরিষ্কার করার সময় হতে পারে।</string>
+    <string name="cleanup_storage_medium_6">একটু অগোছালো আছে। স্ক্যান করবেন?</string>
     <string name="cleanup_storage_ok">আপনার স্টোরেজ ঠিক আছে!</string>
     <string name="cleanup_notification_last_scan_format">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</string>
     <string name="cleanup_notification_never_scanned">আপনি এখনও ফোন স্ক্যান করেননি। শুরু করতে ট্যাপ করুন।</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% na nagamit. Linisin na?</string>
     <string name="cleanup_storage_high_6">Malapit nang mapuno. %1$d%% na ang gamit.</string>
     <string name="cleanup_storage_medium">Maraming laman dito. Puwedeng makatulong ang scan.</string>
+    <string name="cleanup_storage_medium_2">Marami-rami kang laman dito.</string>
+    <string name="cleanup_storage_medium_3">Subukan mong mag-scan — baka magulat ka.</string>
+    <string name="cleanup_storage_medium_4">May natitira pang espasyo, pero di masamang maglinis.</string>
+    <string name="cleanup_storage_medium_5">Mukhang oras na para sa magaan na paglilinis.</string>
+    <string name="cleanup_storage_medium_6">Medyo magulo. Gusto mo bang mag-scan?</string>
     <string name="cleanup_storage_ok">Ayos naman ang storage mo!</string>
     <string name="cleanup_notification_last_scan_format">Huling scan: %1$d araw na ang nakalipas. %2$s</string>
     <string name="cleanup_notification_never_scanned">Hindi mo pa na-scan ang iyong telepono. Tapikin para magsimula.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% उपयोग में है। साफ़ करें?</string>
     <string name="cleanup_storage_high_6">लगभग भरने वाला है। %1$d%% इस्तेमाल में है।</string>
     <string name="cleanup_storage_medium">यहाँ काफी चीजें हैं। स्कैन मदद कर सकता है.</string>
+    <string name="cleanup_storage_medium_2">आपके पास यहाँ काफी सामान है।</string>
+    <string name="cleanup_storage_medium_3">एक बार स्कैन करके देखें — आपको हैरानी हो सकती है।</string>
+    <string name="cleanup_storage_medium_4">जगह बची है, लेकिन सफ़ाई करने में हर्ज़ नहीं.</string>
+    <string name="cleanup_storage_medium_5">हो सकता है हल्की-सी सफ़ाई का समय हो.</string>
+    <string name="cleanup_storage_medium_6">थोड़ा-सा सामान बिखरा है। स्कैन करना चाहेंगे?</string>
     <string name="cleanup_storage_ok">आपका स्टोरेज ठीक दिख रहा है!</string>
     <string name="cleanup_notification_last_scan_format">आख़िरी स्कैन: %1$d दिन पहले. %2$s</string>
     <string name="cleanup_notification_never_scanned">आपने अभी तक फ़ोन स्कैन नहीं किया है। शुरू करने के लिए टैप करें.</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% foglalt. Ideje tisztítani?</string>
     <string name="cleanup_storage_high_6">Közel a megtelt állapothoz. %1$d%% használatban.</string>
     <string name="cleanup_storage_medium">Elég sok minden van itt. Egy keresés segíthet.</string>
+    <string name="cleanup_storage_medium_2">Elég sok cuccod gyűlt össze itt.</string>
+    <string name="cleanup_storage_medium_3">Érdemes lenne egy keresés — lehet, hogy meglepődsz.</string>
+    <string name="cleanup_storage_medium_4">Van még hely, de egy takarítás nem ártana.</string>
+    <string name="cleanup_storage_medium_5">Lehet, hogy ideje egy gyors söprésnek.</string>
+    <string name="cleanup_storage_medium_6">Kicsit rendetlen. Szeretnél keresni?</string>
     <string name="cleanup_storage_ok">A tárhelyed rendben van!</string>
     <string name="cleanup_notification_last_scan_format">Utolsó keresés: %1$d napja. %2$s</string>
     <string name="cleanup_notification_never_scanned">Még nem vizsgáltad át a telefonod. Kezdéshez érints ide.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% terpakai. Saatnya bersih-bersih?</string>
     <string name="cleanup_storage_high_6">Hampir penuh. %1$d%% terpakai.</string>
     <string name="cleanup_storage_medium">Banyak sekali di sini. Pindai mungkin membantu.</string>
+    <string name="cleanup_storage_medium_2">Kamu punya cukup banyak barang di sini.</string>
+    <string name="cleanup_storage_medium_3">Coba pindai — mungkin kamu akan terkejut.</string>
+    <string name="cleanup_storage_medium_4">Masih ada ruang, tapi bersih-bersih tidak ada salahnya.</string>
+    <string name="cleanup_storage_medium_5">Sepertinya saatnya bersih-bersih ringan.</string>
+    <string name="cleanup_storage_medium_6">Sedikit berantakan nih. Mau pindai?</string>
     <string name="cleanup_storage_ok">Penyimpanan Anda terlihat baik!</string>
     <string name="cleanup_notification_last_scan_format">Pemindaian terakhir: %1$d hari lalu. %2$s</string>
     <string name="cleanup_notification_never_scanned">Anda belum pernah memindai ponsel. Ketuk untuk mulai.</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% 사용 중. 청소할까요?</string>
     <string name="cleanup_storage_high_6">거의 가득 찼어요. %1$d%% 사용 중입니다.</string>
     <string name="cleanup_storage_medium">여기에 내용이 많네요. 스캔이 도움이 될 수 있어요.</string>
+    <string name="cleanup_storage_medium_2">여기에 꽤 많은 파일이 있네요.</string>
+    <string name="cleanup_storage_medium_3">스캔을 고려해보세요 — 의외일 수 있어요.</string>
+    <string name="cleanup_storage_medium_4">공간이 남긴 하지만 정리해도 나쁠 건 없죠.</string>
+    <string name="cleanup_storage_medium_5">가볍게 한번 쓸어낼 시간일지도 몰라요.</string>
+    <string name="cleanup_storage_medium_6">조금 어수선해요. 스캔해볼까요?</string>
     <string name="cleanup_storage_ok">저장공간은 괜찮아 보여요!</string>
     <string name="cleanup_notification_last_scan_format">마지막 스캔: %1$d일 전. %2$s</string>
     <string name="cleanup_notification_never_scanned">아직 휴대폰을 스캔하지 않았어요. 시작하려면 탭하세요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% użyte. Czas na czyszczenie?</string>
     <string name="cleanup_storage_high_6">Zbliżasz się do pełna. %1$d%% zajęte.</string>
     <string name="cleanup_storage_medium">Jest tu całkiem sporo rzeczy. Skan może pomóc.</string>
+    <string name="cleanup_storage_medium_2">Masz tutaj niezłą ilość rzeczy.</string>
+    <string name="cleanup_storage_medium_3">Rozważ skan — możesz się zdziwić.</string>
+    <string name="cleanup_storage_medium_4">Miejsce jest, ale sprzątanie nie zaszkodzi.</string>
+    <string name="cleanup_storage_medium_5">Może pora na szybkie sprzątanko.</string>
+    <string name="cleanup_storage_medium_6">Jest tu trochę bałaganu. Zeskanować?</string>
     <string name="cleanup_storage_ok">Twoja pamięć wygląda dobrze!</string>
     <string name="cleanup_notification_last_scan_format">Ostatnie skanowanie: %1$d dni temu. %2$s</string>
     <string name="cleanup_notification_never_scanned">Nie przeskanowałeś jeszcze telefonu. Stuknij, aby zacząć.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% folosit. Curățăm?</string>
     <string name="cleanup_storage_high_6">Aproape plin. %1$d%% utilizat.</string>
     <string name="cleanup_storage_medium">Sunt destule lucruri aici. Un scan ar putea ajuta.</string>
+    <string name="cleanup_storage_medium_2">Ai destul de multe lucruri aici.</string>
+    <string name="cleanup_storage_medium_3">Ia în calcul o scanare — s-ar putea să te surprindă.</string>
+    <string name="cleanup_storage_medium_4">Mai e loc, dar o curățare nu ar strica.</string>
+    <string name="cleanup_storage_medium_5">Poate e timpul pentru o mică curățenie.</string>
+    <string name="cleanup_storage_medium_6">E un pic de dezordine. Vrei să scanezi?</string>
     <string name="cleanup_storage_ok">Spațiul tău arată bine!</string>
     <string name="cleanup_notification_last_scan_format">Ultimul scan: acum %1$d zile. %2$s</string>
     <string name="cleanup_notification_never_scanned">Nu ți-ai scanat încă telefonul. Atinge pentru a începe.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% används. Dags att städa?</string>
     <string name="cleanup_storage_high_6">Du börjar få slut på utrymme. %1$d%% i bruk.</string>
     <string name="cleanup_storage_medium">Här finns mycket innehåll. En skanning kan hjälpa.</string>
+    <string name="cleanup_storage_medium_2">Du har en hel del saker här.</string>
+    <string name="cleanup_storage_medium_3">Överväg en skanning — du kan bli överraskad.</string>
+    <string name="cleanup_storage_medium_4">Det finns plats kvar, men det skadar inte att städa.</string>
+    <string name="cleanup_storage_medium_5">Kanske dags för en lätt genomgång.</string>
+    <string name="cleanup_storage_medium_6">Det är lite rörigt. Vill du skanna?</string>
     <string name="cleanup_storage_ok">Ditt lagringsutrymme ser bra ut!</string>
     <string name="cleanup_notification_last_scan_format">Senaste skanning: för %1$d dagar sedan. %2$s</string>
     <string name="cleanup_notification_never_scanned">Du har inte skannat din telefon än. Tryck för att börja.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">ใช้ไป %1$d%% แล้ว ล้างไหม?</string>
     <string name="cleanup_storage_high_6">ใกล้เต็มแล้ว ใช้งาน %1$d%% อยู่.</string>
     <string name="cleanup_storage_medium">มีของเยอะมากที่นี่ การสแกนอาจช่วยได้</string>
+    <string name="cleanup_storage_medium_2">คุณมีของอยู่ไม่น้อยที่นี่.</string>
+    <string name="cleanup_storage_medium_3">ลองสแกนดู—อาจจะเซอร์ไพรส์ก็ได้.</string>
+    <string name="cleanup_storage_medium_4">ยังมีที่เหลือ แต่ทำความสะอาดก็ดี.</string>
+    <string name="cleanup_storage_medium_5">อาจถึงเวลาปัดกวาดเบา ๆ.</string>
+    <string name="cleanup_storage_medium_6">มีของรกนิดหน่อย สแกนไหม?</string>
     <string name="cleanup_storage_ok">พื้นที่จัดเก็บของคุณดูโอเค!</string>
     <string name="cleanup_notification_last_scan_format">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</string>
     <string name="cleanup_notification_never_scanned">คุณยังไม่ได้สแกนโทรศัพท์ แตะเพื่อเริ่มต้น</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% kullanılıyor. Temizleyelim mi?</string>
     <string name="cleanup_storage_high_6">Neredeyse dolu. %1$d%% kullanımda.</string>
     <string name="cleanup_storage_medium">Burada epey şey var. Tarama yardımcı olabilir.</string>
+    <string name="cleanup_storage_medium_2">Burada hatırı sayılır miktarda şeyin var.</string>
+    <string name="cleanup_storage_medium_3">Bir taramayı düşün — şaşırabilirsin.</string>
+    <string name="cleanup_storage_medium_4">Yer var ama temizlik fena olmaz.</string>
+    <string name="cleanup_storage_medium_5">Hafif bir süpürme zamanı olabilir.</string>
+    <string name="cleanup_storage_medium_6">Biraz dağınık. Tarama yapmak ister misin?</string>
     <string name="cleanup_storage_ok">Depolaman gayet iyi!</string>
     <string name="cleanup_notification_last_scan_format">Son tarama: %1$d gün önce. %2$s</string>
     <string name="cleanup_notification_never_scanned">Telefonunu henüz taramadın. Başlamak için dokun.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% використано. Час чистити?</string>
     <string name="cleanup_storage_high_6">Майже заповнено. Використано %1$d%%.</string>
     <string name="cleanup_storage_medium">Тут багато всього. Сканування може допомогти.</string>
+    <string name="cleanup_storage_medium_2">У вас тут чимало всього.</string>
+    <string name="cleanup_storage_medium_3">Розгляньте можливість сканування — можете здивуватися.</string>
+    <string name="cleanup_storage_medium_4">Місце ще є, але прибирання не зашкодить.</string>
+    <string name="cleanup_storage_medium_5">Може, час на легке прибирання.</string>
+    <string name="cleanup_storage_medium_6">Трохи безладу. Хочете сканувати?</string>
     <string name="cleanup_storage_ok">Пам’ять у хорошому стані!</string>
     <string name="cleanup_notification_last_scan_format">Останнє сканування: %1$d днів тому. %2$s</string>
     <string name="cleanup_notification_never_scanned">Ви ще не сканували телефон. Торкніться, щоб почати.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% استعمال ہے۔ صاف کریں؟</string>
     <string name="cleanup_storage_high_6">تقریباً مکمل ہورہا ہے۔ %1$d%% زیرِ استعمال ہے۔</string>
     <string name="cleanup_storage_medium">یہاں کافی چیزیں ہیں۔ اسکین مددگار ہو سکتا ہے۔</string>
+    <string name="cleanup_storage_medium_2">آپ کے پاس یہاں کافی مواد موجود ہے۔</string>
+    <string name="cleanup_storage_medium_3">ایک اسکین پر غور کریں — شاید آپ حیران ہوں۔</string>
+    <string name="cleanup_storage_medium_4">جگہ باقی ہے، لیکن صفائی نقصان نہیں دے گی۔</string>
+    <string name="cleanup_storage_medium_5">ہو سکتا ہے ہلکی سی صفائی کا وقت ہو۔</string>
+    <string name="cleanup_storage_medium_6">تھوڑا سا انتشار ہے۔ اسکین کرنا چاہیں گے؟</string>
     <string name="cleanup_storage_ok">آپ کا اسٹوریج ٹھیک ہے!</string>
     <string name="cleanup_notification_last_scan_format">آخری اسکین: %1$d دن پہلے۔ %2$s</string>
     <string name="cleanup_notification_never_scanned">آپ نے ابھی تک فون اسکین نہیں کیا۔ شروع کرنے کے لیے ٹیپ کریں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -33,6 +33,11 @@
     <string name="cleanup_storage_high_5">%1$d%% đã dùng. Dọn dẹp chứ?</string>
     <string name="cleanup_storage_high_6">Sắp đầy rồi. Đang dùng %1$d%%.</string>
     <string name="cleanup_storage_medium">Có khá nhiều thứ ở đây. Quét có thể giúp.</string>
+    <string name="cleanup_storage_medium_2">Bạn có khá nhiều thứ ở đây.</string>
+    <string name="cleanup_storage_medium_3">Hãy thử quét — có thể bạn sẽ bất ngờ.</string>
+    <string name="cleanup_storage_medium_4">Vẫn còn chỗ nhưng dọn dẹp cũng tốt.</string>
+    <string name="cleanup_storage_medium_5">Có lẽ đến lúc quét nhẹ nhàng.</string>
+    <string name="cleanup_storage_medium_6">Hơi bừa bộn. Muốn quét không?</string>
     <string name="cleanup_storage_ok">Bộ nhớ của bạn vẫn ổn!</string>
     <string name="cleanup_notification_last_scan_format">Lần quét cuối: %1$d ngày trước. %2$s</string>
     <string name="cleanup_notification_never_scanned">Bạn chưa quét điện thoại. Nhấn để bắt đầu.</string>


### PR DESCRIPTION
## Summary
- add missing medium storage messages across translation files

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f49c9af00832d9bd724901deed17c