### PR TITLE
Add missing translations for cleanup storage messages

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">يمكن يكون وقت تنظيف خفيف.</string>
     <string name="cleanup_storage_medium_6">في شوية فوضى. عايز تفحص؟</string>
     <string name="cleanup_storage_ok">المساحة عندك تمام!</string>
+    <string name="cleanup_storage_ok_2">أنت في المنطقة الآمنة. كل شيء جيد!</string>
+    <string name="cleanup_storage_ok_3">جميل! لديك مساحة حرة كافية.</string>
+    <string name="cleanup_storage_ok_4">تبدو جيدة — لا حاجة إلى أي إجراء.</string>
+    <string name="cleanup_storage_ok_5">التخزين تحت السيطرة!</string>
+    <string name="cleanup_storage_ok_6">نظيف وواضح. أحسنت!</string>
     <string name="cleanup_notification_last_scan_format">آخر فحص: من %1$d يوم. %2$s</string>
     <string name="cleanup_notification_never_scanned">لسه ما فحصتش تليفونك. اضغط للبدء.</string>
 

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Може би е време за леко почистване.</string>
     <string name="cleanup_storage_medium_6">Има малко безпорядък. Искате ли да сканирате?</string>
     <string name="cleanup_storage_ok">Паметта ви изглежда добре!</string>
+    <string name="cleanup_storage_ok_2">Вие сте в безопасната зона. Всичко добре!</string>
+    <string name="cleanup_storage_ok_3">Хубаво! Имате достатъчно свободно пространство.</string>
+    <string name="cleanup_storage_ok_4">Изглежда добре — не са необходими действия.</string>
+    <string name="cleanup_storage_ok_5">Съхранението е под контрол!</string>
+    <string name="cleanup_storage_ok_6">Чисто и ясно. Браво!</string>
     <string name="cleanup_notification_last_scan_format">Последно сканиране: преди %1$d дни. %2$s</string>
     <string name="cleanup_notification_never_scanned">Все още не сте сканирали телефона си. Докоснете, за да започнете.</string>
 

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">হালকা একটা পরিষ্কার করার সময় হতে পারে।</string>
     <string name="cleanup_storage_medium_6">একটু অগোছালো আছে। স্ক্যান করবেন?</string>
     <string name="cleanup_storage_ok">আপনার স্টোরেজ ঠিক আছে!</string>
+    <string name="cleanup_storage_ok_2">আপনি নিরাপদ অঞ্চলে রয়েছেন। সব ভাল!</string>
+    <string name="cleanup_storage_ok_3">ভাল! আপনি যথেষ্ট মুক্ত স্থান পেয়েছেন।</string>
+    <string name="cleanup_storage_ok_4">ভাল লাগছে — কোনও পদক্ষেপের প্রয়োজন নেই।</string>
+    <string name="cleanup_storage_ok_5">স্টোরেজ নিয়ন্ত্রণে আছে!</string>
+    <string name="cleanup_storage_ok_6">পরিষ্কার ও পরিষ্কার। ভাল!</string>
     <string name="cleanup_notification_last_scan_format">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</string>
     <string name="cleanup_notification_never_scanned">আপনি এখনও ফোন স্ক্যান করেননি। শুরু করতে ট্যাপ করুন।</string>
 

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Mukhang oras na para sa magaan na paglilinis.</string>
     <string name="cleanup_storage_medium_6">Medyo magulo. Gusto mo bang mag-scan?</string>
     <string name="cleanup_storage_ok">Ayos naman ang storage mo!</string>
+    <string name="cleanup_storage_ok_2">Nasa Safe Zone ka. Lahat ng mabuti!</string>
+    <string name="cleanup_storage_ok_3">Maganda! Mayroon kang sapat na libreng puwang.</string>
+    <string name="cleanup_storage_ok_4">Mukhang maayos — wala nang dapat gawin.</string>
+    <string name="cleanup_storage_ok_5">Nasa kontrol ang storage!</string>
+    <string name="cleanup_storage_ok_6">Malinis at malinaw. Magaling!</string>
     <string name="cleanup_notification_last_scan_format">Huling scan: %1$d araw na ang nakalipas. %2$s</string>
     <string name="cleanup_notification_never_scanned">Hindi mo pa na-scan ang iyong telepono. Tapikin para magsimula.</string>
 

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">हो सकता है हल्की-सी सफ़ाई का समय हो.</string>
     <string name="cleanup_storage_medium_6">थोड़ा-सा सामान बिखरा है। स्कैन करना चाहेंगे?</string>
     <string name="cleanup_storage_ok">आपका स्टोरेज ठीक दिख रहा है!</string>
+    <string name="cleanup_storage_ok_2">आप सुरक्षित क्षेत्र में हैं। सब अच्छा!</string>
+    <string name="cleanup_storage_ok_3">अच्छा! आपको पर्याप्त खाली जगह मिली है।</string>
+    <string name="cleanup_storage_ok_4">अच्छा लग रहा है — कोई कार्रवाई की जरूरत नहीं।</string>
+    <string name="cleanup_storage_ok_5">भंडारण नियंत्रण में है!</string>
+    <string name="cleanup_storage_ok_6">साफ़-सुथरा है। शाबाश!</string>
     <string name="cleanup_notification_last_scan_format">आख़िरी स्कैन: %1$d दिन पहले. %2$s</string>
     <string name="cleanup_notification_never_scanned">आपने अभी तक फ़ोन स्कैन नहीं किया है। शुरू करने के लिए टैप करें.</string>
 

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Lehet, hogy ideje egy gyors söprésnek.</string>
     <string name="cleanup_storage_medium_6">Kicsit rendetlen. Szeretnél keresni?</string>
     <string name="cleanup_storage_ok">A tárhelyed rendben van!</string>
+    <string name="cleanup_storage_ok_2">A biztonságos zónában vagy. Minden jó!</string>
+    <string name="cleanup_storage_ok_3">Szép! Van elég szabad helyed.</string>
+    <string name="cleanup_storage_ok_4">Jól néz ki — nincs szükség műveletre.</string>
+    <string name="cleanup_storage_ok_5">A tárolás ellenőrzés alatt áll!</string>
+    <string name="cleanup_storage_ok_6">Tiszta és átlátható. Szép munka!</string>
     <string name="cleanup_notification_last_scan_format">Utolsó keresés: %1$d napja. %2$s</string>
     <string name="cleanup_notification_never_scanned">Még nem vizsgáltad át a telefonod. Kezdéshez érints ide.</string>
 

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Sepertinya saatnya bersih-bersih ringan.</string>
     <string name="cleanup_storage_medium_6">Sedikit berantakan nih. Mau pindai?</string>
     <string name="cleanup_storage_ok">Penyimpanan Anda terlihat baik!</string>
+    <string name="cleanup_storage_ok_2">Anda berada di zona aman. Semua bagus!</string>
+    <string name="cleanup_storage_ok_3">Bagus! Anda memiliki ruang kosong yang cukup.</string>
+    <string name="cleanup_storage_ok_4">Terlihat baik — tidak perlu tindakan.</string>
+    <string name="cleanup_storage_ok_5">Penyimpanan terkendali!</string>
+    <string name="cleanup_storage_ok_6">Bersih dan jelas. Bagus sekali!</string>
     <string name="cleanup_notification_last_scan_format">Pemindaian terakhir: %1$d hari lalu. %2$s</string>
     <string name="cleanup_notification_never_scanned">Anda belum pernah memindai ponsel. Ketuk untuk mulai.</string>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">가볍게 한번 쓸어낼 시간일지도 몰라요.</string>
     <string name="cleanup_storage_medium_6">조금 어수선해요. 스캔해볼까요?</string>
     <string name="cleanup_storage_ok">저장공간은 괜찮아 보여요!</string>
+    <string name="cleanup_storage_ok_2">안전 구역입니다. 문제 없어요!</string>
+    <string name="cleanup_storage_ok_3">멋진! 충분한 여유 공간이 있습니다.</string>
+    <string name="cleanup_storage_ok_4">좋아 보이네요 — 조치가 필요 없어요.</string>
+    <string name="cleanup_storage_ok_5">저장공간이 잘 관리되고 있어요!</string>
+    <string name="cleanup_storage_ok_6">깔끔하고 명확합니다. 잘하셨어요!</string>
     <string name="cleanup_notification_last_scan_format">마지막 스캔: %1$d일 전. %2$s</string>
     <string name="cleanup_notification_never_scanned">아직 휴대폰을 스캔하지 않았어요. 시작하려면 탭하세요.</string>
 

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Może pora na szybkie sprzątanko.</string>
     <string name="cleanup_storage_medium_6">Jest tu trochę bałaganu. Zeskanować?</string>
     <string name="cleanup_storage_ok">Twoja pamięć wygląda dobrze!</string>
+    <string name="cleanup_storage_ok_2">Jesteś w bezpiecznej strefie. Wszystko dobrze!</string>
+    <string name="cleanup_storage_ok_3">Super! Masz wystarczająco dużo wolnej przestrzeni.</string>
+    <string name="cleanup_storage_ok_4">Wygląda dobrze — nic nie trzeba robić.</string>
+    <string name="cleanup_storage_ok_5">Przechowywanie jest pod kontrolą!</string>
+    <string name="cleanup_storage_ok_6">Czysto i przejrzyście. Dobra robota!</string>
     <string name="cleanup_notification_last_scan_format">Ostatnie skanowanie: %1$d dni temu. %2$s</string>
     <string name="cleanup_notification_never_scanned">Nie przeskanowałeś jeszcze telefonu. Stuknij, aby zacząć.</string>
 

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Poate e timpul pentru o mică curățenie.</string>
     <string name="cleanup_storage_medium_6">E un pic de dezordine. Vrei să scanezi?</string>
     <string name="cleanup_storage_ok">Spațiul tău arată bine!</string>
+    <string name="cleanup_storage_ok_2">Te afli în zona sigură. Bine!</string>
+    <string name="cleanup_storage_ok_3">Frumos! Aveți suficient spațiu liber.</string>
+    <string name="cleanup_storage_ok_4">Arată bine — nu e nevoie de acțiune.</string>
+    <string name="cleanup_storage_ok_5">Depozitarea este sub control!</string>
+    <string name="cleanup_storage_ok_6">Curat și limpede. Bine făcut!</string>
     <string name="cleanup_notification_last_scan_format">Ultimul scan: acum %1$d zile. %2$s</string>
     <string name="cleanup_notification_never_scanned">Nu ți-ai scanat încă telefonul. Atinge pentru a începe.</string>
 

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Kanske dags för en lätt genomgång.</string>
     <string name="cleanup_storage_medium_6">Det är lite rörigt. Vill du skanna?</string>
     <string name="cleanup_storage_ok">Ditt lagringsutrymme ser bra ut!</string>
+    <string name="cleanup_storage_ok_2">Du är i den säkra zonen. Allt bra!</string>
+    <string name="cleanup_storage_ok_3">Snyggt! Du har gott om ledigt utrymme.</string>
+    <string name="cleanup_storage_ok_4">Ser bra ut — ingen åtgärd behövs.</string>
+    <string name="cleanup_storage_ok_5">Lagring är under kontroll!</string>
+    <string name="cleanup_storage_ok_6">Rent och tydligt. Bra gjort!</string>
     <string name="cleanup_notification_last_scan_format">Senaste skanning: för %1$d dagar sedan. %2$s</string>
     <string name="cleanup_notification_never_scanned">Du har inte skannat din telefon än. Tryck för att börja.</string>
 

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">อาจถึงเวลาปัดกวาดเบา ๆ.</string>
     <string name="cleanup_storage_medium_6">มีของรกนิดหน่อย สแกนไหม?</string>
     <string name="cleanup_storage_ok">พื้นที่จัดเก็บของคุณดูโอเค!</string>
+    <string name="cleanup_storage_ok_2">คุณอยู่ในเขตปลอดภัย ดีทั้งหมด!</string>
+    <string name="cleanup_storage_ok_3">เยี่ยม! คุณมีพื้นที่ว่างพอแล้ว</string>
+    <string name="cleanup_storage_ok_4">ดูดี ไม่มีอะไรต้องทำ</string>
+    <string name="cleanup_storage_ok_5">ที่เก็บข้อมูลอยู่ภายใต้การควบคุม!</string>
+    <string name="cleanup_storage_ok_6">สะอาดและชัดเจน ทำได้ดี!</string>
     <string name="cleanup_notification_last_scan_format">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</string>
     <string name="cleanup_notification_never_scanned">คุณยังไม่ได้สแกนโทรศัพท์ แตะเพื่อเริ่มต้น</string>
 

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Hafif bir süpürme zamanı olabilir.</string>
     <string name="cleanup_storage_medium_6">Biraz dağınık. Tarama yapmak ister misin?</string>
     <string name="cleanup_storage_ok">Depolaman gayet iyi!</string>
+    <string name="cleanup_storage_ok_2">Güvenli bölgedesiniz. Her şey iyi!</string>
+    <string name="cleanup_storage_ok_3">Güzel! Yeterince boş alanınız var.</string>
+    <string name="cleanup_storage_ok_4">Gayet iyi — bir işlem gerekmez.</string>
+    <string name="cleanup_storage_ok_5">Depolama kontrol altında!</string>
+    <string name="cleanup_storage_ok_6">Temiz ve net. Tebrikler!</string>
     <string name="cleanup_notification_last_scan_format">Son tarama: %1$d gün önce. %2$s</string>
     <string name="cleanup_notification_never_scanned">Telefonunu henüz taramadın. Başlamak için dokun.</string>
 

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Може, час на легке прибирання.</string>
     <string name="cleanup_storage_medium_6">Трохи безладу. Хочете сканувати?</string>
     <string name="cleanup_storage_ok">Пам’ять у хорошому стані!</string>
+    <string name="cleanup_storage_ok_2">Ви в безпечній зоні. Все добре!</string>
+    <string name="cleanup_storage_ok_3">Приємно! У вас достатньо вільного місця.</string>
+    <string name="cleanup_storage_ok_4">Виглядає добре — дій не потрібно.</string>
+    <string name="cleanup_storage_ok_5">Зберігання знаходиться під контролем!</string>
+    <string name="cleanup_storage_ok_6">Чисто й зрозуміло. Молодці!</string>
     <string name="cleanup_notification_last_scan_format">Останнє сканування: %1$d днів тому. %2$s</string>
     <string name="cleanup_notification_never_scanned">Ви ще не сканували телефон. Торкніться, щоб почати.</string>
 

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">ہو سکتا ہے ہلکی سی صفائی کا وقت ہو۔</string>
     <string name="cleanup_storage_medium_6">تھوڑا سا انتشار ہے۔ اسکین کرنا چاہیں گے؟</string>
     <string name="cleanup_storage_ok">آپ کا اسٹوریج ٹھیک ہے!</string>
+    <string name="cleanup_storage_ok_2">آپ محفوظ زون میں ہیں۔ سب اچھا!</string>
+    <string name="cleanup_storage_ok_3">اچھا! آپ کو کافی مفت جگہ مل گئی ہے۔</string>
+    <string name="cleanup_storage_ok_4">اچھا لگ رہا ہے — کسی کارروائی کی ضرورت نہیں۔</string>
+    <string name="cleanup_storage_ok_5">اسٹوریج کنٹرول میں ہے!</string>
+    <string name="cleanup_storage_ok_6">صاف ستھرا، شاباش!</string>
     <string name="cleanup_notification_last_scan_format">آخری اسکین: %1$d دن پہلے۔ %2$s</string>
     <string name="cleanup_notification_never_scanned">آپ نے ابھی تک فون اسکین نہیں کیا۔ شروع کرنے کے لیے ٹیپ کریں۔</string>
 

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -39,6 +39,11 @@
     <string name="cleanup_storage_medium_5">Có lẽ đến lúc quét nhẹ nhàng.</string>
     <string name="cleanup_storage_medium_6">Hơi bừa bộn. Muốn quét không?</string>
     <string name="cleanup_storage_ok">Bộ nhớ của bạn vẫn ổn!</string>
+    <string name="cleanup_storage_ok_2">Bạn đang ở vùng an toàn. Mọi thứ ổn!</string>
+    <string name="cleanup_storage_ok_3">Đẹp! Bạn có đủ không gian trống.</string>
+    <string name="cleanup_storage_ok_4">Nhìn tốt — không cần hành động.</string>
+    <string name="cleanup_storage_ok_5">Lưu trữ đang được kiểm soát!</string>
+    <string name="cleanup_storage_ok_6">Sạch sẽ và rõ ràng. Làm tốt!</string>
     <string name="cleanup_notification_last_scan_format">Lần quét cuối: %1$d ngày trước. %2$s</string>
     <string name="cleanup_notification_never_scanned">Bạn chưa quét điện thoại. Nhấn để bắt đầu.</string>
 


### PR DESCRIPTION
## Summary
- add `cleanup_storage_ok_2` through `cleanup_storage_ok_6` in multiple locales

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f59774d48832dab7d0204d176381a