### PR TITLE
Add translations for new WhatsApp media strings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">ملفات ويندوز</string>
     <string name="videos">الفيديوهات</string>
     <string name="audios">الصوتيات</string>
+    <string name="statuses">الحالات</string>
+    <string name="voice_notes">ملاحظات صوتية</string>
+    <string name="video_notes">ملاحظات فيديو</string>
+    <string name="gifs">ملفات GIF</string>
+    <string name="wallpapers">الخلفيات</string>
+    <string name="stickers">الملصقات</string>
+    <string name="profile_photos">صور الملف الشخصي</string>
+    <string name="received">الواردة</string>
+    <string name="sent">المرسلة</string>
+    <string name="private_tab">خاص</string>
+    <string name="can_be_freed">يمكن تفريغه</string>
     <string name="empty_folders">مجلدات فاضية</string>
     <string name="duplicates">ملفات مكررة</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Файлове на Windows</string>
     <string name="videos">Видеоклипове</string>
     <string name="audios">Аудио файлове</string>
+    <string name="statuses">Статуси</string>
+    <string name="voice_notes">Гласови бележки</string>
+    <string name="video_notes">Видео бележки</string>
+    <string name="gifs">GIF файлове</string>
+    <string name="wallpapers">Тапети</string>
+    <string name="stickers">Стикери</string>
+    <string name="profile_photos">Профилни снимки</string>
+    <string name="received">Получени</string>
+    <string name="sent">Изпратени</string>
+    <string name="private_tab">Лични</string>
+    <string name="can_be_freed">Може да се освободи</string>
     <string name="empty_folders">Празни папки</string>
     <string name="duplicates">Дублиращи файлове</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">উইন্ডোজ ফাইলসমূহ</string>
     <string name="videos">ভিডিওসমূহ</string>
     <string name="audios">অডিওসমূহ</string>
+    <string name="statuses">স্ট্যাটাসসমূহ</string>
+    <string name="voice_notes">ভয়েস নোটসমূহ</string>
+    <string name="video_notes">ভিডিও নোটসমূহ</string>
+    <string name="gifs">GIF সমূহ</string>
+    <string name="wallpapers">ওয়ালপেপারসমূহ</string>
+    <string name="stickers">স্টিকারসমূহ</string>
+    <string name="profile_photos">প্রোফাইল ফটোসমূহ</string>
+    <string name="received">প্রাপ্ত</string>
+    <string name="sent">প্রেরিত</string>
+    <string name="private_tab">ব্যক্তিগত</string>
+    <string name="can_be_freed">মুক্ত করা যাবে</string>
     <string name="empty_folders">খালি ফোল্ডারসমূহ</string>
     <string name="duplicates">সদৃশ ফাইল</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Windows-Dateien</string>
     <string name="videos">Videos</string>
     <string name="audios">Audiodateien</string>
+    <string name="statuses">Statusmeldungen</string>
+    <string name="voice_notes">Sprachnotizen</string>
+    <string name="video_notes">Videonotizen</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">Hintergründe</string>
+    <string name="stickers">Sticker</string>
+    <string name="profile_photos">Profilfotos</string>
+    <string name="received">Empfangen</string>
+    <string name="sent">Gesendet</string>
+    <string name="private_tab">Privat</string>
+    <string name="can_be_freed">Kann freigegeben werden</string>
     <string name="empty_folders">Leere Ordner</string>
     <string name="duplicates">Doppelte Dateien</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Archivos de Windows</string>
     <string name="videos">Vídeos</string>
     <string name="audios">Audios</string>
+    <string name="statuses">Estados</string>
+    <string name="voice_notes">Notas de voz</string>
+    <string name="video_notes">Notas de video</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">Fondos de pantalla</string>
+    <string name="stickers">Stickers</string>
+    <string name="profile_photos">Fotos de perfil</string>
+    <string name="received">Recibidos</string>
+    <string name="sent">Enviados</string>
+    <string name="private_tab">Privado</string>
+    <string name="can_be_freed">Se puede liberar</string>
     <string name="empty_folders">Carpetas vacías</string>
     <string name="duplicates">Archivos duplicados</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Archivos de Windows</string>
     <string name="videos">Videos</string>
     <string name="audios">Audios</string>
+    <string name="statuses">Estados</string>
+    <string name="voice_notes">Notas de voz</string>
+    <string name="video_notes">Notas de video</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">Fondos de pantalla</string>
+    <string name="stickers">Stickers</string>
+    <string name="profile_photos">Fotos de perfil</string>
+    <string name="received">Recibidos</string>
+    <string name="sent">Enviados</string>
+    <string name="private_tab">Privado</string>
+    <string name="can_be_freed">Se puede liberar</string>
     <string name="empty_folders">Carpetas vacías</string>
     <string name="duplicates">Archivos duplicados</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Mga Windows File</string>
     <string name="videos">Mga Video</string>
     <string name="audios">Mga Audio</string>
+    <string name="statuses">Mga Status</string>
+    <string name="voice_notes">Mga Voice Note</string>
+    <string name="video_notes">Mga Video Note</string>
+    <string name="gifs">Mga GIF</string>
+    <string name="wallpapers">Mga Wallpaper</string>
+    <string name="stickers">Mga Sticker</string>
+    <string name="profile_photos">Mga Larawan ng Profile</string>
+    <string name="received">Natanggap</string>
+    <string name="sent">Naipadala</string>
+    <string name="private_tab">Pribado</string>
+    <string name="can_be_freed">Maaaring i-free</string>
     <string name="empty_folders">Mga Walang Lamang Folder</string>
     <string name="duplicates">Dobleng mga file</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Fichiers Windows</string>
     <string name="videos">Vidéos</string>
     <string name="audios">Audios</string>
+    <string name="statuses">Statuts</string>
+    <string name="voice_notes">Notes vocales</string>
+    <string name="video_notes">Notes vidéo</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">Fonds d’écran</string>
+    <string name="stickers">Stickers</string>
+    <string name="profile_photos">Photos de profil</string>
+    <string name="received">Reçus</string>
+    <string name="sent">Envoyés</string>
+    <string name="private_tab">Privé</string>
+    <string name="can_be_freed">Peut être libéré</string>
     <string name="empty_folders">Dossiers vides</string>
     <string name="duplicates">Fichiers en double</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">विंडोज फ़ाइलें</string>
     <string name="videos">वीडियो</string>
     <string name="audios">ऑडियो</string>
+    <string name="statuses">स्टेटस</string>
+    <string name="voice_notes">वॉयस नोट्स</string>
+    <string name="video_notes">वीडियो नोट्स</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">वॉलपेपर</string>
+    <string name="stickers">स्टीकर</string>
+    <string name="profile_photos">प्रोफ़ाइल फ़ोटो</string>
+    <string name="received">प्राप्त</string>
+    <string name="sent">भेजे गए</string>
+    <string name="private_tab">निजी</string>
+    <string name="can_be_freed">खाली किया जा सकता है</string>
     <string name="empty_folders">खाली फ़ोल्डर</string>
     <string name="duplicates">डुप्लिकेट फ़ाइलें</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Windows fájlok</string>
     <string name="videos">Videók</string>
     <string name="audios">Hangfájlok</string>
+    <string name="statuses">Állapotok</string>
+    <string name="voice_notes">Hangjegyzetek</string>
+    <string name="video_notes">Videójegyzetek</string>
+    <string name="gifs">GIF-ek</string>
+    <string name="wallpapers">Háttérképek</string>
+    <string name="stickers">Matricák</string>
+    <string name="profile_photos">Profilképek</string>
+    <string name="received">Fogadott</string>
+    <string name="sent">Elküldött</string>
+    <string name="private_tab">Privát</string>
+    <string name="can_be_freed">Felszabadítható</string>
     <string name="empty_folders">Üres mappák</string>
     <string name="duplicates">Másolatú fájlok</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">File Windows</string>
     <string name="videos">Video</string>
     <string name="audios">Audio</string>
+    <string name="statuses">Status</string>
+    <string name="voice_notes">Catatan suara</string>
+    <string name="video_notes">Catatan video</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">Wallpaper</string>
+    <string name="stickers">Stiker</string>
+    <string name="profile_photos">Foto profil</string>
+    <string name="received">Diterima</string>
+    <string name="sent">Terkirim</string>
+    <string name="private_tab">Pribadi</string>
+    <string name="can_be_freed">Dapat dibebaskan</string>
     <string name="empty_folders">Folder Kosong</string>
     <string name="duplicates">Duplikat file</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">File di Windows</string>
     <string name="videos">Video</string>
     <string name="audios">Audio</string>
+    <string name="statuses">Stati</string>
+    <string name="voice_notes">Note vocali</string>
+    <string name="video_notes">Note video</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">Sfondi</string>
+    <string name="stickers">Sticker</string>
+    <string name="profile_photos">Foto profilo</string>
+    <string name="received">Ricevuti</string>
+    <string name="sent">Inviati</string>
+    <string name="private_tab">Privato</string>
+    <string name="can_be_freed">Può essere liberato</string>
     <string name="empty_folders">Cartelle vuote</string>
     <string name="duplicates">File duplicati</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Windowsファイル</string>
     <string name="videos">動画</string>
     <string name="audios">音声</string>
+    <string name="statuses">ステータス</string>
+    <string name="voice_notes">ボイスメモ</string>
+    <string name="video_notes">ビデオメモ</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">壁紙</string>
+    <string name="stickers">ステッカー</string>
+    <string name="profile_photos">プロフィール写真</string>
+    <string name="received">受信</string>
+    <string name="sent">送信</string>
+    <string name="private_tab">プライベート</string>
+    <string name="can_be_freed">解放可能</string>
     <string name="empty_folders">空のフォルダ</string>
     <string name="duplicates">ファイルの複製</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Windows 파일</string>
     <string name="videos">동영상</string>
     <string name="audios">오디오</string>
+    <string name="statuses">상태</string>
+    <string name="voice_notes">음성 노트</string>
+    <string name="video_notes">비디오 노트</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">배경화면</string>
+    <string name="stickers">스티커</string>
+    <string name="profile_photos">프로필 사진</string>
+    <string name="received">받은</string>
+    <string name="sent">보낸</string>
+    <string name="private_tab">비공개</string>
+    <string name="can_be_freed">해제 가능</string>
     <string name="empty_folders">빈 폴더</string>
     <string name="duplicates">중복 파일</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Pliki Windows</string>
     <string name="videos">Filmy</string>
     <string name="audios">Pliki audio</string>
+    <string name="statuses">Statusy</string>
+    <string name="voice_notes">Notatki głosowe</string>
+    <string name="video_notes">Notatki wideo</string>
+    <string name="gifs">GIF-y</string>
+    <string name="wallpapers">Tapety</string>
+    <string name="stickers">Naklejki</string>
+    <string name="profile_photos">Zdjęcia profilowe</string>
+    <string name="received">Odebrane</string>
+    <string name="sent">Wysłane</string>
+    <string name="private_tab">Prywatne</string>
+    <string name="can_be_freed">Można zwolnić</string>
     <string name="empty_folders">Puste foldery</string>
     <string name="duplicates">Duplikat plików</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Arquivos do Windows</string>
     <string name="videos">Vídeos</string>
     <string name="audios">Áudios</string>
+    <string name="statuses">Status</string>
+    <string name="voice_notes">Mensagens de voz</string>
+    <string name="video_notes">Mensagens de vídeo</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">Papéis de parede</string>
+    <string name="stickers">Figurinhas</string>
+    <string name="profile_photos">Fotos de perfil</string>
+    <string name="received">Recebidos</string>
+    <string name="sent">Enviados</string>
+    <string name="private_tab">Privado</string>
+    <string name="can_be_freed">Pode ser liberado</string>
     <string name="empty_folders">Pastas Vazias</string>
     <string name="duplicates">Arquivos duplicados</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Fișiere Windows</string>
     <string name="videos">Videoclipuri</string>
     <string name="audios">Fișiere audio</string>
+    <string name="statuses">Stări</string>
+    <string name="voice_notes">Note vocale</string>
+    <string name="video_notes">Note video</string>
+    <string name="gifs">GIF-uri</string>
+    <string name="wallpapers">Fundaluri</string>
+    <string name="stickers">Stickere</string>
+    <string name="profile_photos">Fotografii de profil</string>
+    <string name="received">Primite</string>
+    <string name="sent">Trimise</string>
+    <string name="private_tab">Privat</string>
+    <string name="can_be_freed">Poate fi eliberat</string>
     <string name="empty_folders">Foldere goale</string>
     <string name="duplicates">Fișiere duplicate</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Файлы Windows</string>
     <string name="videos">Видео</string>
     <string name="audios">Аудио</string>
+    <string name="statuses">Статусы</string>
+    <string name="voice_notes">Голосовые заметки</string>
+    <string name="video_notes">Видео заметки</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">Обои</string>
+    <string name="stickers">Стикеры</string>
+    <string name="profile_photos">Фотографии профиля</string>
+    <string name="received">Полученные</string>
+    <string name="sent">Отправленные</string>
+    <string name="private_tab">Приватные</string>
+    <string name="can_be_freed">Можно освободить</string>
     <string name="empty_folders">Пустые папки</string>
     <string name="duplicates">Дублировать файлы</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Windows-filer</string>
     <string name="videos">Videor</string>
     <string name="audios">Ljudfiler</string>
+    <string name="statuses">Statusar</string>
+    <string name="voice_notes">Röstanteckningar</string>
+    <string name="video_notes">Videoanteckningar</string>
+    <string name="gifs">GIF:ar</string>
+    <string name="wallpapers">Bakgrundsbilder</string>
+    <string name="stickers">Stickers</string>
+    <string name="profile_photos">Profilbilder</string>
+    <string name="received">Mottagna</string>
+    <string name="sent">Skickade</string>
+    <string name="private_tab">Privat</string>
+    <string name="can_be_freed">Kan frigöras</string>
     <string name="empty_folders">Tomma mappar</string>
     <string name="duplicates">Duplicerade filer</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">ไฟล์ Windows</string>
     <string name="videos">วิดีโอ</string>
     <string name="audios">ไฟล์เสียง</string>
+    <string name="statuses">สถานะ</string>
+    <string name="voice_notes">บันทึกเสียง</string>
+    <string name="video_notes">บันทึกวิดีโอ</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">วอลเปเปอร์</string>
+    <string name="stickers">สติกเกอร์</string>
+    <string name="profile_photos">รูปโปรไฟล์</string>
+    <string name="received">ที่ได้รับ</string>
+    <string name="sent">ที่ส่ง</string>
+    <string name="private_tab">ส่วนตัว</string>
+    <string name="can_be_freed">สามารถล้างได้</string>
     <string name="empty_folders">โฟลเดอร์ว่าง</string>
     <string name="duplicates">ไฟล์ที่ซ้ำกัน</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Windows Dosyaları</string>
     <string name="videos">Videolar</string>
     <string name="audios">Ses Dosyaları</string>
+    <string name="statuses">Durumlar</string>
+    <string name="voice_notes">Sesli notlar</string>
+    <string name="video_notes">Video notlar</string>
+    <string name="gifs">GIF'ler</string>
+    <string name="wallpapers">Duvar kağıtları</string>
+    <string name="stickers">Çıkartmalar</string>
+    <string name="profile_photos">Profil fotoğrafları</string>
+    <string name="received">Alınan</string>
+    <string name="sent">Gönderilen</string>
+    <string name="private_tab">Özel</string>
+    <string name="can_be_freed">Boşaltılabilir</string>
     <string name="empty_folders">Boş Klasörler</string>
     <string name="duplicates">Yinelenen dosyalar</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -131,6 +131,17 @@
     <string name="windows_files">Файли Windows</string>
     <string name="videos">Відео</string>
     <string name="audios">Аудіо</string>
+    <string name="statuses">Статуси</string>
+    <string name="voice_notes">Голосові нотатки</string>
+    <string name="video_notes">Відео нотатки</string>
+    <string name="gifs">GIF-файли</string>
+    <string name="wallpapers">Шпалери</string>
+    <string name="stickers">Наліпки</string>
+    <string name="profile_photos">Фото профілю</string>
+    <string name="received">Отримані</string>
+    <string name="sent">Надіслані</string>
+    <string name="private_tab">Приватне</string>
+    <string name="can_be_freed">Можна звільнити</string>
     <string name="empty_folders">Порожні теки</string>
     <string name="duplicates">Дублікат файлів</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">ونڈوز فائلیں</string>
     <string name="videos">ویڈیوز</string>
     <string name="audios">آڈیوز</string>
+    <string name="statuses">اسٹیٹسز</string>
+    <string name="voice_notes">وائس نوٹس</string>
+    <string name="video_notes">ویڈیو نوٹس</string>
+    <string name="gifs">GIFs</string>
+    <string name="wallpapers">وال پیپرز</string>
+    <string name="stickers">اسٹیکرز</string>
+    <string name="profile_photos">پروفائل فوٹوز</string>
+    <string name="received">موصولہ</string>
+    <string name="sent">بھیجے گئے</string>
+    <string name="private_tab">نجی</string>
+    <string name="can_be_freed">خالی کیا جا سکتا ہے</string>
     <string name="empty_folders">خالی فولڈرز</string>
     <string name="duplicates">ڈپلیکیٹ فائلیں</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Tệp Windows</string>
     <string name="videos">Video</string>
     <string name="audios">Âm thanh</string>
+    <string name="statuses">Trạng thái</string>
+    <string name="voice_notes">Ghi chú thoại</string>
+    <string name="video_notes">Ghi chú video</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">Hình nền</string>
+    <string name="stickers">Nhãn dán</string>
+    <string name="profile_photos">Ảnh hồ sơ</string>
+    <string name="received">Đã nhận</string>
+    <string name="sent">Đã gửi</string>
+    <string name="private_tab">Riêng tư</string>
+    <string name="can_be_freed">Có thể giải phóng</string>
     <string name="empty_folders">Thư mục trống</string>
     <string name="duplicates">Các tập tin trùng lặp</string>
     <plurals name="status_selected_files">

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -114,6 +114,17 @@
     <string name="windows_files">Windows 檔案</string>
     <string name="videos">影片</string>
     <string name="audios">音訊</string>
+    <string name="statuses">狀態</string>
+    <string name="voice_notes">語音筆記</string>
+    <string name="video_notes">影片筆記</string>
+    <string name="gifs">GIF</string>
+    <string name="wallpapers">桌布</string>
+    <string name="stickers">貼圖</string>
+    <string name="profile_photos">大頭貼照</string>
+    <string name="received">已接收</string>
+    <string name="sent">已傳送</string>
+    <string name="private_tab">私人</string>
+    <string name="can_be_freed">可釋出</string>
     <string name="empty_folders">空資料夾</string>
     <string name="duplicates">重複檔案</string>
     <plurals name="status_selected_files">


### PR DESCRIPTION
## Summary
- translate WhatsApp media related strings for all supported languages

## Testing
- `./gradlew tasks --all` *(passed)*
- `./gradlew test --no-daemon` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f72eefc78832d83ba7d4cd342dcc8