### PR TITLE
Add missing translations for delete/original

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -137,6 +137,8 @@
     </plurals>
     <string name="status_no_files_selected">الحالة: مفيش ملفات متحددة</string>
     <string name="select_all">تحديد الكل</string>
+    <string name="delete">حذف</string>
+    <string name="original">الأصلي</string>
     <string name="today">النهاردة</string>
     <string name="yesterday">امبارح</string>
     <string name="a_year_ago">السنة اللي فاتت</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -133,6 +133,8 @@
     </plurals>
     <string name="status_no_files_selected">Състояние: Няма избрани файлове</string>
     <string name="select_all">Избери всички</string>
+    <string name="delete">Изтриване</string>
+    <string name="original">Оригинал</string>
     <string name="today">Днес</string>
     <string name="yesterday">Вчера</string>
     <string name="a_year_ago">Миналата година</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -133,6 +133,8 @@
     </plurals>
     <string name="status_no_files_selected">স্থিতি: কোনও ফাইল নির্বাচিত নেই</string>
     <string name="select_all">সব নির্বাচন করুন</string>
+    <string name="delete">মুছুন</string>
+    <string name="original">মূল</string>
     <string name="today">আজ</string>
     <string name="yesterday">গতকাল</string>
     <string name="a_year_ago">গত বছর</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -150,6 +150,8 @@
     </plurals>
     <string name="status_no_files_selected">Status: Keine Dateien ausgewählt</string>
     <string name="select_all">Alle auswählen</string>
+    <string name="delete">Löschen</string>
+    <string name="original">Original</string>
     <string name="today">Heute</string>
     <string name="yesterday">Gestern</string>
     <string name="a_year_ago">Letztes Jahr</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -151,6 +151,8 @@
     </plurals>
     <string name="status_no_files_selected">Estado: No hay archivos seleccionados</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="delete">Eliminar</string>
+    <string name="original">Original</string>
     <string name="today">Hoy</string>
     <string name="yesterday">Ayer</string>
     <string name="a_year_ago">El año pasado</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -151,6 +151,8 @@
     </plurals>
     <string name="status_no_files_selected">Estado: Ningún archivo seleccionado</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="delete">Eliminar</string>
+    <string name="original">Original</string>
     <string name="today">Hoy</string>
     <string name="yesterday">Ayer</string>
     <string name="a_year_ago">El año pasado</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -133,6 +133,8 @@
     </plurals>
     <string name="status_no_files_selected">Katayuan: Walang napiling file</string>
     <string name="select_all">Piliin Lahat</string>
+    <string name="delete">Burahin</string>
+    <string name="original">Orihinal</string>
     <string name="today">Ngayon</string>
     <string name="yesterday">Kahapon</string>
     <string name="a_year_ago">Noong Nakaraang Taon</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -152,6 +152,8 @@
 
     <string name="status_no_files_selected">Statut : Aucun fichier sélectionné</string>
     <string name="select_all">Tout sélectionner</string>
+    <string name="delete">Supprimer</string>
+    <string name="original">Original</string>
     <string name="today">Aujourd\'hui</string>
     <string name="yesterday">Hier</string>
     <string name="a_year_ago">L\'année dernière</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -133,6 +133,8 @@
     </plurals>
     <string name="status_no_files_selected">स्थिति: कोई फ़ाइल चयनित नहीं</string>
     <string name="select_all">सभी चुनें</string>
+    <string name="delete">हटाएं</string>
+    <string name="original">मूल</string>
     <string name="today">आज</string>
     <string name="yesterday">कल</string>
     <string name="a_year_ago">पिछले साल</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -150,6 +150,8 @@
     </plurals>
     <string name="status_no_files_selected">Állapot: Nincs kiválasztott fájl</string>
     <string name="select_all">Összes kijelölése</string>
+    <string name="delete">Törlés</string>
+    <string name="original">Eredeti</string>
     <string name="today">Ma</string>
     <string name="yesterday">Tegnap</string>
     <string name="a_year_ago">Tavaly</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">Status: Tidak ada file yang dipilih</string>
     <string name="select_all">Pilih Semua</string>
+    <string name="delete">Hapus</string>
+    <string name="original">Asli</string>
     <string name="today">Hari ini</string>
     <string name="yesterday">Kemarin</string>
     <string name="a_year_ago">Tahun Lalu</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -151,6 +151,8 @@
     </plurals>
     <string name="status_no_files_selected">Stato: Nessun file selezionato</string>
     <string name="select_all">Seleziona tutto</string>
+    <string name="delete">Elimina</string>
+    <string name="original">Originale</string>
     <string name="today">Oggi</string>
     <string name="yesterday">Ieri</string>
     <string name="a_year_ago">L\'anno scorso</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">ステータス: ファイルが選択されていません</string>
     <string name="select_all">すべて選択</string>
+    <string name="delete">削除</string>
+    <string name="original">オリジナル</string>
     <string name="today">今日</string>
     <string name="yesterday">昨日</string>
     <string name="a_year_ago">昨年</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">상태: 선택된 파일 없음</string>
     <string name="select_all">모두 선택</string>
+    <string name="delete">삭제</string>
+    <string name="original">원본</string>
     <string name="today">오늘</string>
     <string name="yesterday">어제</string>
     <string name="a_year_ago">작년</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -152,6 +152,8 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nie wybrano plików</string>
     <string name="select_all">Zaznacz wszystko</string>
+    <string name="delete">Usuń</string>
+    <string name="original">Oryginał</string>
     <string name="today">Dzisiaj</string>
     <string name="yesterday">Wczoraj</string>
     <string name="a_year_ago">W zeszłym roku</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -151,6 +151,8 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nenhum arquivo selecionado</string>
     <string name="select_all">Selecionar Tudo</string>
+    <string name="delete">Excluir</string>
+    <string name="original">Original</string>
     <string name="today">Hoje</string>
     <string name="yesterday">Ontem</string>
     <string name="a_year_ago">Ano Passado</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -151,6 +151,8 @@
     </plurals>
     <string name="status_no_files_selected">Stare: Niciun fișier selectat</string>
     <string name="select_all">Selectează tot</string>
+    <string name="delete">Șterge</string>
+    <string name="original">Original</string>
     <string name="today">Astăzi</string>
     <string name="yesterday">Ieri</string>
     <string name="a_year_ago">Anul trecut</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -152,6 +152,8 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файлы не выбраны</string>
     <string name="select_all">Выбрать все</string>
+    <string name="delete">Удалить</string>
+    <string name="original">Оригинал</string>
     <string name="today">Сегодня</string>
     <string name="yesterday">Вчера</string>
     <string name="a_year_ago">В прошлом году</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -150,6 +150,8 @@
     </plurals>
     <string name="status_no_files_selected">Status: Inga filer valda</string>
     <string name="select_all">Välj alla</string>
+    <string name="delete">Radera</string>
+    <string name="original">Original</string>
     <string name="today">Idag</string>
     <string name="yesterday">Igår</string>
     <string name="a_year_ago">Förra året</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">สถานะ: ไม่ได้เลือกไฟล์</string>
     <string name="select_all">เลือกทั้งหมด</string>
+    <string name="delete">ลบ</string>
+    <string name="original">ต้นฉบับ</string>
     <string name="today">วันนี้</string>
     <string name="yesterday">เมื่อวาน</string>
     <string name="a_year_ago">ปีที่แล้ว</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -150,6 +150,8 @@
     </plurals>
     <string name="status_no_files_selected">Durum: Hiçbir dosya seçilmedi</string>
     <string name="select_all">Tümünü Seç</string>
+    <string name="delete">Sil</string>
+    <string name="original">Orijinal</string>
     <string name="today">Bugün</string>
     <string name="yesterday">Dün</string>
     <string name="a_year_ago">Geçen Yıl</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -152,6 +152,8 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файли не вибрано</string>
     <string name="select_all">Вибрати все</string>
+    <string name="delete">Видалити</string>
+    <string name="original">Оригінал</string>
     <string name="today">Сьогодні</string>
     <string name="yesterday">Вчора</string>
     <string name="a_year_ago">Минулого року</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -133,6 +133,8 @@
     </plurals>
     <string name="status_no_files_selected">حیثیت: کوئی فائل منتخب نہیں کی گئی</string>
     <string name="select_all">سب کو منتخب کریں</string>
+    <string name="delete">حذف کریں</string>
+    <string name="original">اصل</string>
     <string name="today">آج</string>
     <string name="yesterday">کل</string>
     <string name="a_year_ago">پچھلے سال</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">Trạng thái: Chưa chọn tệp nào</string>
     <string name="select_all">Chọn tất cả</string>
+    <string name="delete">Xóa</string>
+    <string name="original">Bản gốc</string>
     <string name="today">Hôm nay</string>
     <string name="yesterday">Hôm qua</string>
     <string name="a_year_ago">Năm ngoái</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -132,6 +132,8 @@
     </plurals>
     <string name="status_no_files_selected">狀態：未選取任何檔案</string>
     <string name="select_all">全選</string>
+    <string name="delete">刪除</string>
+    <string name="original">原始</string>
     <string name="today">今天</string>
     <string name="yesterday">昨天</string>
     <string name="a_year_ago">去年</string>


### PR DESCRIPTION
## Summary
- add translations for `delete` and `original` strings across available locales

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f75d2518c832d8fa27ef38c40d6b0