### PR TITLE
Add delete confirmation translations

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -154,6 +154,11 @@
     </plurals>
     <string name="status_no_files_selected">الحالة: مفيش ملفات متحددة</string>
     <string name="select_all">تحديد الكل</string>
+    <string name="delete_confirmation_title">حذف المحدد</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">تحذف %1$d ملف؟</item>
+        <item quantity="other">تحذف %1$d ملف؟</item>
+    </plurals>
     <string name="delete">حذف</string>
     <string name="original">الأصلي</string>
     <string name="today">النهاردة</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Status: Keine Dateien ausgewählt</string>
     <string name="select_all">Alle auswählen</string>
+    <string name="delete_confirmation_title">Auswahl löschen</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">%1$d Element löschen?</item>
+        <item quantity="other">%1$d Elemente löschen?</item>
+    </plurals>
     <string name="delete">Löschen</string>
     <string name="original">Original</string>
     <string name="today">Heute</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -166,6 +166,11 @@
     </plurals>
     <string name="status_no_files_selected">Estado: Ningún archivo seleccionado</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="delete_confirmation_title">Eliminar seleccionado</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">¿Eliminar %1$d elemento?</item>
+        <item quantity="other">¿Eliminar %1$d elementos?</item>
+    </plurals>
     <string name="delete">Eliminar</string>
     <string name="original">Original</string>
     <string name="today">Hoy</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -167,6 +167,11 @@
 
     <string name="status_no_files_selected">Statut : Aucun fichier sélectionné</string>
     <string name="select_all">Tout sélectionner</string>
+    <string name="delete_confirmation_title">Supprimer la sélection</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Supprimer %1$d élément ?</item>
+        <item quantity="other">Supprimer %1$d éléments ?</item>
+    </plurals>
     <string name="delete">Supprimer</string>
     <string name="original">Original</string>
     <string name="today">Aujourd\'hui</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -150,6 +150,11 @@
     </plurals>
     <string name="status_no_files_selected">स्थिति: कोई फ़ाइल चयनित नहीं</string>
     <string name="select_all">सभी चुनें</string>
+    <string name="delete_confirmation_title">चयनित हटाएँ</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">%1$d आइटम हटाएँ?</item>
+        <item quantity="other">%1$d आइटम हटाएँ?</item>
+    </plurals>
     <string name="delete">हटाएं</string>
     <string name="original">मूल</string>
     <string name="today">आज</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -149,6 +149,11 @@
     </plurals>
     <string name="status_no_files_selected">Status: Tidak ada file yang dipilih</string>
     <string name="select_all">Pilih Semua</string>
+    <string name="delete_confirmation_title">Hapus yang Dipilih</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Hapus %1$d item?</item>
+        <item quantity="other">Hapus %1$d item?</item>
+    </plurals>
     <string name="delete">Hapus</string>
     <string name="original">Asli</string>
     <string name="today">Hari ini</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -149,6 +149,11 @@
     </plurals>
     <string name="status_no_files_selected">ステータス: ファイルが選択されていません</string>
     <string name="select_all">すべて選択</string>
+    <string name="delete_confirmation_title">選択項目を削除</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">%1$d 件を削除しますか？</item>
+        <item quantity="other">%1$d 件を削除しますか？</item>
+    </plurals>
     <string name="delete">削除</string>
     <string name="original">オリジナル</string>
     <string name="today">今日</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -166,6 +166,11 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nenhum arquivo selecionado</string>
     <string name="select_all">Selecionar Tudo</string>
+    <string name="delete_confirmation_title">Excluir selecionados</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Excluir %1$d item?</item>
+        <item quantity="other">Excluir %1$d itens?</item>
+    </plurals>
     <string name="delete">Excluir</string>
     <string name="original">Original</string>
     <string name="today">Hoje</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -167,6 +167,11 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файлы не выбраны</string>
     <string name="select_all">Выбрать все</string>
+    <string name="delete_confirmation_title">Удалить выбранное</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Удалить %1$d элемент?</item>
+        <item quantity="other">Удалить %1$d элементов?</item>
+    </plurals>
     <string name="delete">Удалить</string>
     <string name="original">Оригинал</string>
     <string name="today">Сегодня</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -149,6 +149,11 @@
     </plurals>
     <string name="status_no_files_selected">狀態：未選取任何檔案</string>
     <string name="select_all">全選</string>
+    <string name="delete_confirmation_title">刪除所選</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">要刪除 %1$d 個項目嗎？</item>
+        <item quantity="other">要刪除 %1$d 個項目嗎？</item>
+    </plurals>
     <string name="delete">刪除</string>
     <string name="original">原始</string>
     <string name="today">今天</string>


### PR DESCRIPTION
## Summary
- translate delete confirmation strings in 10 language resource files

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f818e319c832db72d7fbdb007f224