### PR TITLE
Update translations for new strings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -340,6 +340,7 @@
     <string name="no_files_selected_move_to_trash">لم يتم تحديد ملفات للانتقال إلى المهملات.</string>
     <string name="failed_to_move_files_to_trash">فشل في نقل الملفات إلى القمامة: %1$s</string>
     <string name="data_not_available">البيانات غير متوفرة.</string>
+    <string name="feature_not_available">الميزة غير متوفرة بعد.</string>
     <string name="no_files_selected_to_clean">لم يتم تحديد ملفات لتنظيف.</string>
     <string name="failed_to_update_trash_size">فشل في تحديث حجم القمامة: %1$s</string>
     <string name="no_cleaning_options_selected">يرجى اختيار تفضيلات التنظيف الخاصة بك في الإعدادات للمتابعة.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Състояние: Няма избрани файлове</string>
     <string name="select_all">Избери всички</string>
+    <string name="delete_confirmation_title">Изтриване на избраното</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Да изтрия %1$d елемент?</item>
+        <item quantity="other">Да изтрия %1$d елемента?</item>
+    </plurals>
     <string name="delete">Изтриване</string>
     <string name="original">Оригинал</string>
     <string name="today">Днес</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Не са избрани файлове, за да се преместят в боклук.</string>
     <string name="failed_to_move_files_to_trash">Неуспешно преместване на файлове в Trash: %1$s</string>
     <string name="data_not_available">Данните не са налични.</string>
+    <string name="feature_not_available">Функцията все още не е налична.</string>
     <string name="no_files_selected_to_clean">Не са избрани файлове за почистване.</string>
     <string name="failed_to_update_trash_size">Неуспешно актуализиране на размера на боклука: %1$s</string>
     <string name="no_cleaning_options_selected">Моля, изберете вашите предпочитания за почистване в настройките, за да продължите.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">স্থিতি: কোনও ফাইল নির্বাচিত নেই</string>
     <string name="select_all">সব নির্বাচন করুন</string>
+    <string name="delete_confirmation_title">নির্বাচিত মুছে ফেলুন</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">কী %1$d আইটেম মুছে ফেলতে চান?</item>
+        <item quantity="other">কী %1$d আইটেম মুছে ফেলতে চান?</item>
+    </plurals>
     <string name="delete">মুছুন</string>
     <string name="original">মূল</string>
     <string name="today">আজ</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">ট্র্যাশে যাওয়ার জন্য কোনও ফাইল নির্বাচিত নয়।</string>
     <string name="failed_to_move_files_to_trash">ফাইলগুলি ট্র্যাশে সরাতে ব্যর্থ: %1$s</string>
     <string name="data_not_available">ডেটা উপলভ্য নয়।</string>
+    <string name="feature_not_available">ফিচারটি এখনও উপলভ্য নয়।</string>
     <string name="no_files_selected_to_clean">কোনও ফাইল পরিষ্কার করার জন্য নির্বাচিত নয়।</string>
     <string name="failed_to_update_trash_size">আবর্জনার আকার আপডেট করতে ব্যর্থ: %1$s</string>
     <string name="no_cleaning_options_selected">এগিয়ে যেতে সেটিংসে আপনার পরিষ্কারের পছন্দগুলি চয়ন করুন।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -332,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Keine Dateien ausgewählt, um zum Müll zu wechseln.</string>
     <string name="failed_to_move_files_to_trash">Verschiebung von Dateien auf Müll nicht: %1$s</string>
     <string name="data_not_available">Daten nicht verfügbar.</string>
+    <string name="feature_not_available">Funktion noch nicht verfügbar.</string>
     <string name="no_files_selected_to_clean">Keine zum Reinigen ausgewählten Dateien.</string>
     <string name="failed_to_update_trash_size">Die Müllgröße nicht aktualisieren: %1$s</string>
     <string name="no_cleaning_options_selected">Bitte wählen Sie Ihre Reinigungseinstellungen in Einstellungen, um fortzufahren.</string></resources>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -166,6 +166,11 @@
     </plurals>
     <string name="status_no_files_selected">Estado: No hay archivos seleccionados</string>
     <string name="select_all">Seleccionar todo</string>
+    <string name="delete_confirmation_title">Eliminar seleccionado</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">¿Eliminar %1$d elemento?</item>
+        <item quantity="other">¿Eliminar %1$d elementos?</item>
+    </plurals>
     <string name="delete">Eliminar</string>
     <string name="original">Original</string>
     <string name="today">Hoy</string>
@@ -329,6 +334,7 @@
     <string name="no_files_selected_move_to_trash">No hay archivos seleccionados para moverse a la basura.</string>
     <string name="failed_to_move_files_to_trash">No se pudo mover archivos a la basura: %1$s</string>
     <string name="data_not_available">Datos no disponibles.</string>
+    <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -334,6 +334,7 @@
     <string name="no_files_selected_move_to_trash">No hay archivos seleccionados para moverse a la basura.</string>
     <string name="failed_to_move_files_to_trash">No se pudo mover archivos a la basura: %1$s</string>
     <string name="data_not_available">Datos no disponibles.</string>
+    <string name="feature_not_available">Función aún no disponible.</string>
     <string name="no_files_selected_to_clean">No hay archivos seleccionados para limpiar.</string>
     <string name="failed_to_update_trash_size">No se pudo actualizar el tamaño de la basura: %1$s</string>
     <string name="no_cleaning_options_selected">Elija sus preferencias de limpieza en Configuración para continuar.</string></resources>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Katayuan: Walang napiling file</string>
     <string name="select_all">Piliin Lahat</string>
+    <string name="delete_confirmation_title">Tanggalin ang Napili</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Tanggalin ang %1$d item?</item>
+        <item quantity="other">Tanggalin ang %1$d item?</item>
+    </plurals>
     <string name="delete">Burahin</string>
     <string name="original">Orihinal</string>
     <string name="today">Ngayon</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Walang mga file na napili upang lumipat sa basurahan.</string>
     <string name="failed_to_move_files_to_trash">Nabigong ilipat ang mga file sa basurahan: %1$s</string>
     <string name="data_not_available">Hindi magagamit ang data.</string>
+    <string name="feature_not_available">Hindi pa magagamit ang tampok.</string>
     <string name="no_files_selected_to_clean">Walang mga file na napili upang linisin.</string>
     <string name="failed_to_update_trash_size">Nabigong i -update ang laki ng basurahan: %1$s</string>
     <string name="no_cleaning_options_selected">Mangyaring piliin ang iyong mga kagustuhan sa paglilinis sa mga setting upang magpatuloy.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -335,6 +335,7 @@
     <string name="no_files_selected_move_to_trash">Aucun fichier sélectionné pour passer à la poubelle.</string>
     <string name="failed_to_move_files_to_trash">Échec de déplacer des fichiers vers les déchets: %1$s</string>
     <string name="data_not_available">Données non disponibles.</string>
+    <string name="feature_not_available">Fonctionnalité pas encore disponible.</string>
     <string name="no_files_selected_to_clean">Aucun fichier sélectionné pour nettoyer.</string>
     <string name="failed_to_update_trash_size">Échec de la mise à jour de la taille des poubelles: %1$s</string>
     <string name="no_cleaning_options_selected">Veuillez choisir vos préférences de nettoyage dans les paramètres pour continuer.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -332,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">कोई फाइलें कचरा करने के लिए नहीं चुनी गई हैं।</string>
     <string name="failed_to_move_files_to_trash">फाइलों को कचरा करने में विफल: %1$s</string>
     <string name="data_not_available">डेटा उपलब्ध नहीं।</string>
+    <string name="feature_not_available">फ़ीचर अभी उपलब्ध नहीं है।</string>
     <string name="no_files_selected_to_clean">कोई फाइलें साफ करने के लिए नहीं चुनी गईं।</string>
     <string name="failed_to_update_trash_size">कचरा आकार अपडेट करने में विफल: %1$s</string>
     <string name="no_cleaning_options_selected">कृपया आगे बढ़ने के लिए सेटिंग्स में अपनी सफाई वरीयताएँ चुनें।</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Állapot: Nincs kiválasztott fájl</string>
     <string name="select_all">Összes kijelölése</string>
+    <string name="delete_confirmation_title">Kiválasztottak törlése</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Töröljem a(z) %1$d elemet?</item>
+        <item quantity="other">Töröljem a(z) %1$d elemet?</item>
+    </plurals>
     <string name="delete">Törlés</string>
     <string name="original">Eredeti</string>
     <string name="today">Ma</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Nincs olyan fájl, amelyet a kukába költöznek.</string>
     <string name="failed_to_move_files_to_trash">Nem sikerült a fájlokat kukába mozgatni: %1$s</string>
     <string name="data_not_available">Az adatok nem állnak rendelkezésre.</string>
+    <string name="feature_not_available">A funkció még nem elérhető.</string>
     <string name="no_files_selected_to_clean">A tisztításhoz nincs kiválasztott fájl.</string>
     <string name="failed_to_update_trash_size">Nem sikerült frissíteni a szemét méretét: %1$s</string>
     <string name="no_cleaning_options_selected">Kérjük, válassza ki a tisztítási beállításokat a beállításokban.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -330,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">Tidak ada file yang dipilih untuk pindah ke tempat sampah.</string>
     <string name="failed_to_move_files_to_trash">Gagal memindahkan file ke sampah: %1$s</string>
     <string name="data_not_available">Data tidak tersedia.</string>
+    <string name="feature_not_available">Fitur belum tersedia.</string>
     <string name="no_files_selected_to_clean">Tidak ada file yang dipilih untuk dibersihkan.</string>
     <string name="failed_to_update_trash_size">Gagal memperbarui ukuran sampah: %1$s</string>
     <string name="no_cleaning_options_selected">Pilih preferensi pembersihan Anda dalam pengaturan untuk melanjutkan.</string></resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -166,6 +166,11 @@
     </plurals>
     <string name="status_no_files_selected">Stato: Nessun file selezionato</string>
     <string name="select_all">Seleziona tutto</string>
+    <string name="delete_confirmation_title">Elimina selezionati</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Eliminare %1$d elemento?</item>
+        <item quantity="other">Eliminare %1$d elementi?</item>
+    </plurals>
     <string name="delete">Elimina</string>
     <string name="original">Originale</string>
     <string name="today">Oggi</string>
@@ -329,6 +334,7 @@
     <string name="no_files_selected_move_to_trash">Nessun file selezionato per passare alla spazzatura.</string>
     <string name="failed_to_move_files_to_trash">Impossibile spostare i file in trash: %1$s</string>
     <string name="data_not_available">Dati non disponibili.</string>
+    <string name="feature_not_available">Funzionalità non ancora disponibile.</string>
     <string name="no_files_selected_to_clean">Nessun file selezionato per pulire.</string>
     <string name="failed_to_update_trash_size">Impossibile aggiornare la dimensione della spazzatura: %1$s</string>
     <string name="no_cleaning_options_selected">Scegli le tue preferenze di pulizia nelle impostazioni per procedere.</string></resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -330,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">ゴミに移動するために選択されたファイルはありません。</string>
     <string name="failed_to_move_files_to_trash">ファイルをゴミに移動できませんでした：%1$s</string>
     <string name="data_not_available">データは利用できません。</string>
+    <string name="feature_not_available">機能はまだ利用できません。</string>
     <string name="no_files_selected_to_clean">クリーニングするために選択されたファイルはありません。</string>
     <string name="failed_to_update_trash_size">ゴミのサイズの更新に失敗しました：%1$s</string>
     <string name="no_cleaning_options_selected">続行するには、設定のクリーニング設定を選択してください。</string></resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -164,6 +164,11 @@
     </plurals>
     <string name="status_no_files_selected">상태: 선택된 파일 없음</string>
     <string name="select_all">모두 선택</string>
+    <string name="delete_confirmation_title">선택 항목 삭제</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">%1$d개 항목을 삭제할까요?</item>
+        <item quantity="other">%1$d개 항목을 삭제할까요?</item>
+    </plurals>
     <string name="delete">삭제</string>
     <string name="original">원본</string>
     <string name="today">오늘</string>
@@ -325,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">휴지통으로 이동하기 위해 선택된 파일이 없습니다.</string>
     <string name="failed_to_move_files_to_trash">파일을 쓰레기로 이동하지 못했습니다 : %1$s</string>
     <string name="data_not_available">데이터를 사용할 수 없습니다.</string>
+    <string name="feature_not_available">기능을 아직 사용할 수 없습니다.</string>
     <string name="no_files_selected_to_clean">청소할 파일이 없습니다.</string>
     <string name="failed_to_update_trash_size">쓰레기 크기를 업데이트하지 못했습니다 : %1$s</string>
     <string name="no_cleaning_options_selected">진행할 설정에서 청소 환경 설정을 선택하십시오.</string></resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -167,6 +167,13 @@
     </plurals>
     <string name="status_no_files_selected">Status: Nie wybrano plików</string>
     <string name="select_all">Zaznacz wszystko</string>
+    <string name="delete_confirmation_title">Usuń zaznaczone</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Usunąć %1$d element?</item>
+        <item quantity="few">Usunąć %1$d elementy?</item>
+        <item quantity="many">Usunąć %1$d elementów?</item>
+        <item quantity="other">Usunąć %1$d elementów?</item>
+    </plurals>
     <string name="delete">Usuń</string>
     <string name="original">Oryginał</string>
     <string name="today">Dzisiaj</string>
@@ -331,6 +338,7 @@
     <string name="no_files_selected_move_to_trash">Brak plików wybranych do przeniesienia się do śmieci.</string>
     <string name="failed_to_move_files_to_trash">Nie udało się przenieść plików na śmieci: %1$s</string>
     <string name="data_not_available">Dane niedostępne.</string>
+    <string name="feature_not_available">Funkcja jest jeszcze niedostępna.</string>
     <string name="no_files_selected_to_clean">Brak plików do czyszczenia.</string>
     <string name="failed_to_update_trash_size">Nie udało się zaktualizować rozmiaru śmieci: %1$s</string>
     <string name="no_cleaning_options_selected">Wybierz swoje preferencje czyszczące w ustawieniach, aby kontynuować.</string></resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -334,6 +334,7 @@
     <string name="no_files_selected_move_to_trash">Nenhum arquivo selecionado para se mover para o lixo.</string>
     <string name="failed_to_move_files_to_trash">Falha ao mover arquivos para o lixo: %1$s</string>
     <string name="data_not_available">Dados não disponíveis.</string>
+    <string name="feature_not_available">Recurso ainda não disponível.</string>
     <string name="no_files_selected_to_clean">Nenhum arquivo selecionado para limpar.</string>
     <string name="failed_to_update_trash_size">Falha ao atualizar o tamanho do lixo: %1$s</string>
     <string name="no_cleaning_options_selected">Escolha suas preferências de limpeza nas configurações para prosseguir.</string></resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -166,6 +166,11 @@
     </plurals>
     <string name="status_no_files_selected">Stare: Niciun fișier selectat</string>
     <string name="select_all">Selectează tot</string>
+    <string name="delete_confirmation_title">Șterge selectate</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Șterge %1$d element?</item>
+        <item quantity="other">Șterge %1$d elemente?</item>
+    </plurals>
     <string name="delete">Șterge</string>
     <string name="original">Original</string>
     <string name="today">Astăzi</string>
@@ -329,6 +334,7 @@
     <string name="no_files_selected_move_to_trash">Nu există fișiere selectate pentru a se muta la gunoi.</string>
     <string name="failed_to_move_files_to_trash">Nu a reușit să mute fișierele în gunoi: %1$s</string>
     <string name="data_not_available">Datele nu sunt disponibile.</string>
+    <string name="feature_not_available">Funcția nu este disponibilă încă.</string>
     <string name="no_files_selected_to_clean">Nu există fișiere selectate pentru a curăța.</string>
     <string name="failed_to_update_trash_size">Nu a reușit să actualizeze dimensiunea gunoiului: %1$s</string>
     <string name="no_cleaning_options_selected">Vă rugăm să alegeți preferințele dvs. de curățare în setări pentru a continua.</string></resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -336,6 +336,7 @@
     <string name="no_files_selected_move_to_trash">Никаких файлов, выбранных для перемещения в мусор.</string>
     <string name="failed_to_move_files_to_trash">Не удалось перенести файлы в мусор: %1$s</string>
     <string name="data_not_available">Данные недоступны.</string>
+    <string name="feature_not_available">Функция пока недоступна.</string>
     <string name="no_files_selected_to_clean">Нет файлов, выбранных для очистки.</string>
     <string name="failed_to_update_trash_size">Не удалось обновить размер мусора: %1$s</string>
     <string name="no_cleaning_options_selected">Пожалуйста, выберите свои предпочтения в уборке в настройках, чтобы продолжить.</string></resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Status: Inga filer valda</string>
     <string name="select_all">Välj alla</string>
+    <string name="delete_confirmation_title">Ta bort markerade</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Ta bort %1$d objekt?</item>
+        <item quantity="other">Ta bort %1$d objekt?</item>
+    </plurals>
     <string name="delete">Radera</string>
     <string name="original">Original</string>
     <string name="today">Idag</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Inga filer som valts för att flytta till skräp.</string>
     <string name="failed_to_move_files_to_trash">Det gick inte att flytta filer till skräp: %1$s</string>
     <string name="data_not_available">Data inte tillgängliga.</string>
+    <string name="feature_not_available">Funktionen är inte tillgänglig än.</string>
     <string name="no_files_selected_to_clean">Inga filer valda för att rengöra.</string>
     <string name="failed_to_update_trash_size">Det gick inte att uppdatera skräpstorlek: %1$s</string>
     <string name="no_cleaning_options_selected">Välj dina rengöringspreferenser i inställningar för att fortsätta.</string></resources>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -164,6 +164,11 @@
     </plurals>
     <string name="status_no_files_selected">สถานะ: ไม่ได้เลือกไฟล์</string>
     <string name="select_all">เลือกทั้งหมด</string>
+    <string name="delete_confirmation_title">ลบที่เลือก</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">ลบ %1$d รายการหรือไม่?</item>
+        <item quantity="other">ลบ %1$d รายการหรือไม่?</item>
+    </plurals>
     <string name="delete">ลบ</string>
     <string name="original">ต้นฉบับ</string>
     <string name="today">วันนี้</string>
@@ -325,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">ไม่มีการเลือกไฟล์เพื่อย้ายไปที่ถังขยะ</string>
     <string name="failed_to_move_files_to_trash">ไม่สามารถย้ายไฟล์ไปยังถังขยะ: %1$s</string>
     <string name="data_not_available">ข้อมูลไม่พร้อมใช้งาน</string>
+    <string name="feature_not_available">ฟีเจอร์ยังไม่พร้อมใช้งาน</string>
     <string name="no_files_selected_to_clean">ไม่มีไฟล์ที่เลือกเพื่อทำความสะอาด</string>
     <string name="failed_to_update_trash_size">ไม่สามารถอัปเดตขนาดถังขยะ: %1$s</string>
     <string name="no_cleaning_options_selected">โปรดเลือกการตั้งค่าการทำความสะอาดของคุณในการตั้งค่าเพื่อดำเนินการต่อ</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">Durum: Hiçbir dosya seçilmedi</string>
     <string name="select_all">Tümünü Seç</string>
+    <string name="delete_confirmation_title">Seçilenleri Sil</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">%1$d öğeyi sil?</item>
+        <item quantity="other">%1$d öğeyi sil?</item>
+    </plurals>
     <string name="delete">Sil</string>
     <string name="original">Orijinal</string>
     <string name="today">Bugün</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">Çöp kutusuna geçmek için hiçbir dosya seçilmedi.</string>
     <string name="failed_to_move_files_to_trash">Dosyaları çöpe taşıyamadı: %1$s</string>
     <string name="data_not_available">Veriler mevcut değil.</string>
+    <string name="feature_not_available">Özellik henüz kullanılamıyor.</string>
     <string name="no_files_selected_to_clean">Temizlemek için dosya seçilmedi.</string>
     <string name="failed_to_update_trash_size">Çöp Boyutunu Güncelleme: %1$s</string>
     <string name="no_cleaning_options_selected">Lütfen devam etmek için ayarlarda temizlik tercihlerinizi seçin.</string></resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -167,6 +167,13 @@
     </plurals>
     <string name="status_no_files_selected">Статус: Файли не вибрано</string>
     <string name="select_all">Вибрати все</string>
+    <string name="delete_confirmation_title">Видалити вибране</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Видалити %1$d елемент?</item>
+        <item quantity="few">Видалити %1$d елементи?</item>
+        <item quantity="many">Видалити %1$d елементів?</item>
+        <item quantity="other">Видалити %1$d елементів?</item>
+    </plurals>
     <string name="delete">Видалити</string>
     <string name="original">Оригінал</string>
     <string name="today">Сьогодні</string>
@@ -331,6 +338,7 @@
     <string name="no_files_selected_move_to_trash">Жодних файлів, вибраних для переходу на сміття.</string>
     <string name="failed_to_move_files_to_trash">Не вдалося перемістити файли на сміття: %1$s</string>
     <string name="data_not_available">Дані недоступні.</string>
+    <string name="feature_not_available">Функція поки недоступна.</string>
     <string name="no_files_selected_to_clean">Жодних файлів, вибраних для очищення.</string>
     <string name="failed_to_update_trash_size">Не вдалося оновити розмір сміття: %1$s</string>
     <string name="no_cleaning_options_selected">Будь ласка, виберіть свої вподобання прибирання в налаштуваннях для продовження.</string></resources>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -165,6 +165,11 @@
     </plurals>
     <string name="status_no_files_selected">حیثیت: کوئی فائل منتخب نہیں کی گئی</string>
     <string name="select_all">سب کو منتخب کریں</string>
+    <string name="delete_confirmation_title">منتخب حذف کریں</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">کیا %1$d آئٹم حذف کریں؟</item>
+        <item quantity="other">کیا %1$d آئٹمز حذف کریں؟</item>
+    </plurals>
     <string name="delete">حذف کریں</string>
     <string name="original">اصل</string>
     <string name="today">آج</string>
@@ -327,6 +332,7 @@
     <string name="no_files_selected_move_to_trash">ردی کی ٹوکری میں جانے کے لئے کوئی فائلیں منتخب نہیں کی گئیں۔</string>
     <string name="failed_to_move_files_to_trash">فائلوں کو ردی کی ٹوکری میں منتقل کرنے میں ناکام: %1$s</string>
     <string name="data_not_available">ڈیٹا دستیاب نہیں ہے۔</string>
+    <string name="feature_not_available">فیچر ابھی دستیاب نہیں ہے۔</string>
     <string name="no_files_selected_to_clean">صاف کرنے کے لئے کوئی فائلیں منتخب نہیں کی گئیں۔</string>
     <string name="failed_to_update_trash_size">کوڑے دان کے سائز کو اپ ڈیٹ کرنے میں ناکام: %1$s</string>
     <string name="no_cleaning_options_selected">براہ کرم آگے بڑھنے کے لئے ترتیبات میں اپنی صفائی کی ترجیحات کا انتخاب کریں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -164,6 +164,11 @@
     </plurals>
     <string name="status_no_files_selected">Trạng thái: Chưa chọn tệp nào</string>
     <string name="select_all">Chọn tất cả</string>
+    <string name="delete_confirmation_title">Xóa đã chọn</string>
+    <plurals name="delete_confirmation_message">
+        <item quantity="one">Xóa %1$d mục?</item>
+        <item quantity="other">Xóa %1$d mục?</item>
+    </plurals>
     <string name="delete">Xóa</string>
     <string name="original">Bản gốc</string>
     <string name="today">Hôm nay</string>
@@ -325,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">Không có tập tin được chọn để chuyển sang rác.</string>
     <string name="failed_to_move_files_to_trash">Không thể chuyển các tập tin đến rác: %1$s</string>
     <string name="data_not_available">Dữ liệu không có sẵn.</string>
+    <string name="feature_not_available">Tính năng hiện chưa khả dụng.</string>
     <string name="no_files_selected_to_clean">Không có tệp được chọn để làm sạch.</string>
     <string name="failed_to_update_trash_size">Không cập nhật kích thước rác: %1$s</string>
     <string name="no_cleaning_options_selected">Vui lòng chọn tùy chọn làm sạch của bạn trong cài đặt để tiếp tục.</string></resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -330,6 +330,7 @@
     <string name="no_files_selected_move_to_trash">未選取要移至垃圾桶的檔案。</string>
     <string name="failed_to_move_files_to_trash">將檔案移至垃圾桶失敗：%1$s</string>
     <string name="data_not_available">無可用資料。</string>
+    <string name="feature_not_available">功能尚未可用。</string>
     <string name="no_files_selected_to_clean">未選取要清理的檔案。</string>
     <string name="failed_to_update_trash_size">更新垃圾桶大小失敗：%1$s</string>
     <string name="no_cleaning_options_selected">請在設定中選擇您的清理偏好以繼續。</string>


### PR DESCRIPTION
## Summary
- localize confirmation strings across all languages
- add missing `feature_not_available` message everywhere

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9fef468c832da10703da2b6f254c