### PR TITLE
Enable clicking on memory breakdown items

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/MemoryManagerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/MemoryManagerScreen.kt
@@ -35,6 +35,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import android.os.Environment
+import android.provider.Settings
+import android.content.Intent
+import java.io.File
+import com.d4rk.cleaner.core.utils.helpers.FileManagerHelper
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
@@ -139,8 +144,49 @@ fun MemoryManagerScreenContent(viewModel : MemoryManagerViewModel , screenData :
 
         screenData.storageInfo?.storageBreakdown?.let { storageBreakdown ->
             if (screenData.listExpanded && storageBreakdown.isNotEmpty()) {
-                StorageBreakdownGrid(storageBreakdown = screenData.storageInfo.storageBreakdown)
+                StorageBreakdownGrid(
+                    storageBreakdown = screenData.storageInfo.storageBreakdown,
+                    onItemClick = { category -> handleStorageItemClick(context, category) }
+                )
             }
         }
+    }
+}
+
+private fun handleStorageItemClick(context: Context, category: String) {
+    val pm = context.packageManager
+    when (category) {
+        context.getString(R.string.installed_apps) -> {
+            val intent = Intent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
+            if (intent.resolveActivity(pm) != null) {
+                context.startActivity(intent)
+            }
+        }
+        context.getString(R.string.system) -> {
+            val intent = Intent(Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
+            if (intent.resolveActivity(pm) != null) {
+                context.startActivity(intent)
+            }
+        }
+        context.getString(R.string.music) -> FileManagerHelper.openFolderOrSettings(
+            context,
+            File(Environment.getExternalStorageDirectory(), "Music")
+        )
+        context.getString(R.string.images) -> FileManagerHelper.openFolderOrSettings(
+            context,
+            File(Environment.getExternalStorageDirectory(), "DCIM")
+        )
+        context.getString(R.string.documents) -> FileManagerHelper.openFolderOrSettings(
+            context,
+            File(Environment.getExternalStorageDirectory(), "Documents")
+        )
+        context.getString(R.string.downloads) -> FileManagerHelper.openFolderOrSettings(
+            context,
+            File(Environment.getExternalStorageDirectory(), "Download")
+        )
+        context.getString(R.string.other_files) -> FileManagerHelper.openFolderOrSettings(
+            context,
+            Environment.getExternalStorageDirectory()
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownGrid.kt
@@ -10,7 +10,10 @@ import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
-fun StorageBreakdownGrid(storageBreakdown : Map<String , Long>) {
+fun StorageBreakdownGrid(
+    storageBreakdown: Map<String, Long>,
+    onItemClick: (String) -> Unit = {}
+) {
     Column(
         modifier = Modifier
                 .fillMaxWidth()
@@ -23,7 +26,12 @@ fun StorageBreakdownGrid(storageBreakdown : Map<String , Long>) {
                     .animateContentSize()) {
                 for (item : Map.Entry<String , Long> in chunk) {
                     val (icon : String , size : Long) = item
-                    StorageBreakdownItem(icon = icon, size = size, modifier = Modifier.weight(weight = 1f))
+                    StorageBreakdownItem(
+                        icon = icon,
+                        size = size,
+                        modifier = Modifier.weight(weight = 1f),
+                        onClick = { onItemClick(icon) }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.clickable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,7 +37,12 @@ import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils.formatSize
 
 @Composable
-fun StorageBreakdownItem(icon : String , size : Long , modifier : Modifier = Modifier) {
+fun StorageBreakdownItem(
+    icon: String,
+    size: Long,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
     val storageIcons : Map<String , ImageVector> = mapOf(
         stringResource(id = R.string.installed_apps) to Icons.Outlined.Apps ,
         stringResource(id = R.string.system) to Icons.Outlined.Android ,
@@ -48,8 +54,10 @@ fun StorageBreakdownItem(icon : String , size : Long , modifier : Modifier = Mod
     )
     Card(
         modifier = modifier
-                .padding(all = SizeConstants.ExtraSmallSize)
-                .animateContentSize()
+            .padding(all = SizeConstants.ExtraSmallSize)
+            .animateContentSize()
+            .bounceClick()
+            .clickable { onClick() }
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
@@ -1,0 +1,44 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.d4rk.cleaner.R
+import java.io.File
+
+object FileManagerHelper {
+    fun openFolderOrSettings(context: Context, folder: File) {
+        runCatching {
+            val uri = FileProvider.getUriForFile(
+                context,
+                context.packageName + ".fileprovider",
+                folder
+            )
+            val intent = Intent(Intent.ACTION_VIEW).setDataAndType(uri, "*/*")
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            val packageManager = context.packageManager
+            if (intent.resolveActivity(packageManager) != null) {
+                context.startActivity(intent)
+            } else {
+                val settingsIntent = Intent(Settings.ACTION_INTERNAL_STORAGE_SETTINGS)
+                if (settingsIntent.resolveActivity(packageManager) != null) {
+                    context.startActivity(settingsIntent)
+                } else {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.no_application_found),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        }.onFailure {
+            Toast.makeText(
+                context,
+                context.getString(R.string.something_went_wrong),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make memory breakdown grid items clickable
- add helper to open folders or fallback to settings

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdd9b6ce8832da084875486cf3a31