### PR TITLE
Centralize MD5 hashing

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.security.MessageDigest
+import com.d4rk.cleaner.core.utils.extensions.md5
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ScannerViewModel(
@@ -401,18 +401,6 @@ class ScannerViewModel(
         return hashMap.values.filter { it.size > 1 }
     }
 
-    private fun File.md5(): String? = runCatching {
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        val md = MessageDigest.getInstance("MD5")
-        inputStream().use { stream ->
-            var read = stream.read(buffer)
-            while (read > 0) {
-                md.update(buffer, 0, read)
-                read = stream.read(buffer)
-            }
-        }
-        md.digest().joinToString("") { "%02x".format(it) }
-    }.getOrNull()
 
     private fun deleteFiles(files: Set<File>) {
         launch(context = dispatchers.io) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/DuplicateUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/DuplicateUtils.kt
@@ -1,7 +1,7 @@
 package com.d4rk.cleaner.app.clean.scanner.utils.helpers
 
 import java.io.File
-import java.security.MessageDigest
+import com.d4rk.cleaner.core.utils.extensions.md5
 
 /**
  * Groups duplicate files by their original version.
@@ -25,16 +25,3 @@ fun groupDuplicatesByOriginal(files: List<File>): List<List<File>> {
     }
     return groups
 }
-
-private fun File.md5(): String? = runCatching {
-    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-    val md = MessageDigest.getInstance("MD5")
-    inputStream().use { stream ->
-        var read = stream.read(buffer)
-        while (read > 0) {
-            md.update(buffer, 0, read)
-            read = stream.read(buffer)
-        }
-    }
-    md.digest().joinToString("") { "%02x".format(it) }
-}.getOrNull()

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/extensions/FileExtensions.kt
@@ -1,0 +1,17 @@
+package com.d4rk.cleaner.core.utils.extensions
+
+import java.io.File
+import java.security.MessageDigest
+
+fun File.md5(): String? = runCatching {
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    val md = MessageDigest.getInstance("MD5")
+    inputStream().use { stream ->
+        var read = stream.read(buffer)
+        while (read > 0) {
+            md.update(buffer, 0, read)
+            read = stream.read(buffer)
+        }
+    }
+    md.digest().joinToString("") { "%02x".format(it) }
+}.getOrNull()


### PR DESCRIPTION
## Summary
- add `md5()` extension for `File`
- update duplicate utilities to use new extension
- update scanner view model to use new extension

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870085f01d0832d97ca977ce65dc1ab