### PR TITLE
Implement unified size formatting and intent helpers

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/ApkItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/ApkItem.kt
@@ -41,6 +41,7 @@ import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.actions.AppManagerEvent
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.AppManagerItem
 import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
 
 @Composable
@@ -75,7 +76,8 @@ fun ApkItem(apkPath : String , viewModel : AppManagerViewModel , modifier : Modi
                     style = MaterialTheme.typography.titleMedium ,
                 )
                 Text(
-                    text = "%.2f MB".format(apkFile.length() / 1024 / 1024.toFloat()) , style = MaterialTheme.typography.bodyMedium
+                    text = FileSizeFormatter.format(apkFile.length()),
+                    style = MaterialTheme.typography.bodyMedium
                 )
             }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/AppItemComposable.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/components/AppItemComposable.kt
@@ -46,6 +46,7 @@ import com.d4rk.cleaner.R.string
 import com.d4rk.cleaner.app.apps.manager.domain.actions.AppManagerEvent
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.AppManagerItem
 import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
 
 @Composable
@@ -60,9 +61,7 @@ fun AppItemComposable(
     val apkPath: String = app.publicSourceDir
     val apkFile = File(apkPath)
     val sizeInBytes: Long = apkFile.length()
-    val sizeInKB: Long = sizeInBytes / 1024
-    val sizeInMB: Long = sizeInKB / 1024
-    val appSize: String = "%.2f MB".format(sizeInMB.toFloat())
+    val appSize: String = FileSizeFormatter.format(sizeInBytes)
     var showMenu: Boolean by remember { mutableStateOf(value = false) }
     val model: Drawable = app.loadIcon(packageManager)
     OutlinedCard(modifier = modifier) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/components/FileCard.kt
@@ -1,8 +1,7 @@
 package com.d4rk.cleaner.app.clean.analyze.components
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
+import com.d4rk.cleaner.core.utils.helpers.FileManagerHelper
 import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.Image
@@ -35,7 +34,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -72,13 +70,7 @@ fun FileCard(
             .bounceClick()
             .clickable {
                 if (!file.isDirectory) {
-                    val intent = Intent(Intent.ACTION_VIEW)
-                    val uri: Uri = FileProvider.getUriForFile(
-                        context, "${context.packageName}.fileprovider", file
-                    )
-                    intent.setDataAndType(uri, context.contentResolver.getType(uri))
-                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    context.startActivity(intent)
+                    FileManagerHelper.openFile(context, file)
                 }
             } ,
     ) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/domain/data/model/StorageInfo.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/domain/data/model/StorageInfo.kt
@@ -10,5 +10,5 @@ data class StorageInfo(
     val storageBreakdown : Map<String , Long> = emptyMap() ,
     val usedStorageFormatted : String = "" ,
     val totalStorageFormatted : String = "" ,
-    val cleanedSpace : String = "0 KB" ,
+    val cleanedSpace : String = "0 B" ,
 )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageBreakdownItem.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
-import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils.formatSize
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter.format as formatSize
 
 @Composable
 fun StorageBreakdownItem(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageInfoText.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/memory/ui/components/StorageInfoText.kt
@@ -3,7 +3,7 @@ package com.d4rk.cleaner.app.clean.memory.ui.components
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils.formatSize
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter.format as formatSize
 
 @Composable
 fun StorageInfoText(label : String , size : Long) {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -34,7 +34,7 @@ import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetPromotedAppUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetStorageInfoUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.MoveToTrashUseCase
 import com.d4rk.cleaner.app.clean.scanner.domain.usecases.UpdateTrashSizeUseCase
-import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import com.d4rk.cleaner.app.clean.scanner.utils.helpers.getWhatsAppMediaSummary
 import com.d4rk.cleaner.app.settings.cleaning.utils.constants.ExtensionsConstants
 import com.d4rk.cleaner.core.data.datastore.DataStore
@@ -174,7 +174,7 @@ class ScannerViewModel(
                     val updatedStorageInfo: StorageInfo = currentData.storageInfo.copy(
                         isFreeSpaceLoading = storageState is DataState.Loading,
                         isCleanedSpaceLoading = false,
-                        cleanedSpace = StorageUtils.formatSizeReadable(cleanedSpaceValue)
+                        cleanedSpace = FileSizeFormatter.format(cleanedSpaceValue)
                     )
                     val finalStorageInfo = if (storageState is DataState.Success) {
                         storageState.data.storageInfo.copy(
@@ -874,7 +874,7 @@ class ScannerViewModel(
                 _uiState.successData {
                     copy(
                         storageInfo = storageInfo.copy(
-                            cleanedSpace = StorageUtils.formatSizeReadable(cleanedSpace)
+                            cleanedSpace = FileSizeFormatter.format(cleanedSpace)
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -36,7 +36,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVertical
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.ApkInfo
-import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import java.io.File
 
 @Composable
@@ -100,7 +100,7 @@ fun ApkCleanerCard(
 
                         ApkPreviewItem(
                             name = appName,
-                            size = StorageUtils.formatSizeReadable(apk.size),
+                            size = FileSizeFormatter.format(apk.size),
                             icon = icon
                         )
                     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/StorageUtils.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/utils/helpers/StorageUtils.kt
@@ -9,8 +9,7 @@ import android.os.storage.StorageManager
 import android.os.storage.StorageVolume
 import java.util.Locale
 import java.util.UUID
-import kotlin.math.log10
-import kotlin.math.pow
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 
 object StorageUtils {
 
@@ -49,29 +48,7 @@ object StorageUtils {
         callback(usedFormatted , totalFormatted , totalSize , usageProgress , freeSpacePercentage)
     }
 
-    fun formatSize(size : Long) : String {
-        if (size <= 0) return "0 B"
-        val units : Array<String> = arrayOf("B" , "KB" , "MB" , "GB" , "TB")
-        val digitGroups : Int = (log10(size.toDouble()) / log10(x = 1024.0)).toInt()
-        val value : Double = size / 1024.0.pow(digitGroups.toDouble())
+    fun formatSize(size: Long): String = FileSizeFormatter.format(size)
 
-        return String.format(Locale.US , "%.2f %s" , value , units[digitGroups])
-    }
-
-    fun formatSizeReadable(size: Long): String {
-        if (size < 1024) return "$size B"
-
-        val kb: Double = size / 1024.0
-        if (kb < 1024) {
-            return String.format(Locale.US, "%.1f KB", kb)
-        }
-
-        val mb: Double = kb / 1024.0
-        if (mb < 1024) {
-            return String.format(Locale.US, "%.1f MB", mb)
-        }
-
-        val gb: Double = mb / 1024.0
-        return String.format(Locale.US, "%.1f GB", gb)
-    }
+    fun formatSizeReadable(size: Long): String = FileSizeFormatter.format(size)
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -13,6 +13,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleane
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.DeleteWhatsAppMediaUseCase
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.usecases.GetWhatsAppMediaSummaryUseCase
 import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -86,7 +87,7 @@ class WhatsappCleanerSummaryViewModel(
                         WhatsAppCleanerAction.ShowSnackbar(
                             UiSnackbar(
                                 message = UiTextHelper.DynamicString(
-                                    "Cleaned ${freed / 1024 / 1024} MB"
+                                    "Cleaned ${FileSizeFormatter.format(freed)}"
                                 )
                             )
                         )
@@ -108,7 +109,7 @@ class WhatsappCleanerSummaryViewModel(
                         WhatsAppCleanerAction.ShowSnackbar(
                             UiSnackbar(
                                 message = UiTextHelper.DynamicString(
-                                    "Cleaned ${freed / 1024 / 1024} MB"
+                                    "Cleaned ${FileSizeFormatter.format(freed)}"
                                 )
                             )
                         )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/utils/helpers/FileOpener.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/utils/helpers/FileOpener.kt
@@ -1,26 +1,9 @@
 package com.d4rk.cleaner.app.clean.whatsapp.utils.helpers
 
-import android.content.ActivityNotFoundException
 import android.content.Context
-import android.content.Intent
-import android.webkit.MimeTypeMap
-import android.widget.Toast
-import androidx.core.content.FileProvider
-import com.d4rk.cleaner.R
+import com.d4rk.cleaner.core.utils.helpers.FileManagerHelper
 import java.io.File
 
 fun openFile(context: Context, file: File) {
-    runCatching {
-        val uri = FileProvider.getUriForFile(context, context.packageName + ".fileprovider", file)
-        val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(file.extension)
-        val intent = Intent(Intent.ACTION_VIEW).setDataAndType(uri, mime ?: "*/*")
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        context.startActivity(intent)
-    }.onFailure { exception ->
-        when (exception) {
-            is ActivityNotFoundException -> Toast.makeText(context, context.getString(R.string.no_application_found), Toast.LENGTH_SHORT).show()
-            is IllegalArgumentException -> Toast.makeText(context, context.getString(R.string.something_went_wrong), Toast.LENGTH_SHORT).show()
-            else -> throw exception
-        }
-    }
+    FileManagerHelper.openFile(context, file)
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/images/compressor/ui/ImageOptimizerScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
@@ -191,7 +192,7 @@ fun ImageDisplay(viewModel : ImageOptimizerViewModel) {
             ) {
                 Text(
 
-                    text = "${state.value.compressedSizeKB} KB" ,
+                    text = FileSizeFormatter.format((state.value.compressedSizeKB * 1024).toLong()),
                     modifier = Modifier
                             .padding(all = SizeConstants.ExtraSmallSize)
                             .animateContentSize() ,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/main/ui/MainViewModel.kt
@@ -15,7 +15,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import com.d4rk.cleaner.app.clean.scanner.utils.helpers.StorageUtils
+import com.d4rk.cleaner.core.utils.helpers.FileSizeFormatter
 import com.d4rk.cleaner.app.clean.trash.domain.usecases.GetTrashSizeUseCase
 import com.d4rk.cleaner.app.main.domain.actions.MainAction
 import com.d4rk.cleaner.app.main.domain.actions.MainEvent
@@ -46,7 +46,7 @@ class MainViewModel(
     private fun loadNavigationItems() {
         launch {
             val trashSize = getTrashSizeUseCase()
-            val trashBadge = if (trashSize > 0) StorageUtils.formatSizeReadable(trashSize) else ""
+            val trashBadge = if (trashSize > 0) FileSizeFormatter.format(trashSize) else ""
 
             screenState.successData {
                 copy(

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileManagerHelper.kt
@@ -1,5 +1,6 @@
 package com.d4rk.cleaner.core.utils.helpers
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
@@ -9,6 +10,33 @@ import com.d4rk.cleaner.R
 import java.io.File
 
 object FileManagerHelper {
+    fun openFile(context: Context, file: File) {
+        runCatching {
+            val uri = FileProvider.getUriForFile(
+                context,
+                context.packageName + ".fileprovider",
+                file
+            )
+            val mime = context.contentResolver.getType(uri) ?: "*/*"
+            val intent = Intent(Intent.ACTION_VIEW).setDataAndType(uri, mime)
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            context.startActivity(intent)
+        }.onFailure { exception ->
+            when (exception) {
+                is ActivityNotFoundException -> Toast.makeText(
+                    context,
+                    context.getString(R.string.no_application_found),
+                    Toast.LENGTH_SHORT
+                ).show()
+                is IllegalArgumentException -> Toast.makeText(
+                    context,
+                    context.getString(R.string.something_went_wrong),
+                    Toast.LENGTH_SHORT
+                ).show()
+                else -> throw exception
+            }
+        }
+    }
     fun openFolderOrSettings(context: Context, folder: File) {
         runCatching {
             val uri = FileProvider.getUriForFile(

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileSizeFormatter.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/helpers/FileSizeFormatter.kt
@@ -1,0 +1,15 @@
+package com.d4rk.cleaner.core.utils.helpers
+
+import java.util.Locale
+import kotlin.math.log10
+import kotlin.math.pow
+
+object FileSizeFormatter {
+    fun format(size: Long): String {
+        if (size <= 0) return "0 B"
+        val units = arrayOf("B", "KB", "MB", "GB", "TB")
+        val digitGroups = (log10(size.toDouble()) / log10(1024.0)).toInt()
+        val value = size / 1024.0.pow(digitGroups.toDouble())
+        return String.format(Locale.US, "%.2f %s", value, units[digitGroups])
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `FileSizeFormatter`
- delegate `StorageUtils` formatting to the new helper
- display formatted sizes using `FileSizeFormatter` across the UI
- centralize file opening in `FileManagerHelper` and use it where needed

## Testing
- `./gradlew --version`
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700a9f3e64832da5a75d34cfacbc09