### PR TITLE
Use toolkit button components

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/AnalyzeScreen.kt
@@ -100,7 +100,7 @@ fun AnalyzeScreen(
             },
             onEndButtonIcon = Icons.Outlined.DeleteForever,
             onEndButtonText = R.string.delete_forever,
-            view = view)
+        )
 
         if (data.analyzeState.isDeleteForeverConfirmationDialogVisible || data.analyzeState.isMoveToTrashConfirmationDialogVisible) {
             DeleteOrTrashConfirmation(data = data, viewModel = viewModel)

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/nofilesfound/ui/NoFilesFoundScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/nofilesfound/ui/NoFilesFoundScreen.kt
@@ -9,15 +9,13 @@ import androidx.compose.material.icons.outlined.FolderOff
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
@@ -36,15 +34,13 @@ fun NoFilesFoundScreen(viewModel : ScannerViewModel) {
                 text = stringResource(id = R.string.no_files_found) , style = MaterialTheme.typography.bodyLarge , color = MaterialTheme.colorScheme.onSurface
             )
 
-            OutlinedButton(modifier = Modifier.bounceClick() , onClick = {
-                viewModel.onEvent(ScannerEvent.ToggleAnalyzeScreen(true))
-            }) {
-                Icon(
-                    modifier = Modifier.size(size = SizeConstants.ButtonIconSize) , imageVector = Icons.Outlined.Refresh , contentDescription = null
-                )
-                ButtonIconSpacer()
-                Text(text = stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.try_again))
-            }
+            OutlinedIconButtonWithText(
+                onClick = { viewModel.onEvent(ScannerEvent.ToggleAnalyzeScreen(true)) },
+                modifier = Modifier,
+                icon = Icons.Outlined.Refresh,
+                iconContentDescription = null,
+                label = stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.try_again)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -117,7 +118,7 @@ fun ApkCleanerCard(
             if (isLoading) {
                 FilledTonalButton(
                     onClick = { onCleanClick(apkFiles) },
-                    modifier = Modifier.align(Alignment.End).bounceClick(),
+                    modifier = Modifier.align(Alignment.End),
                     enabled = false,
                 ) {
                     CircularProgressIndicator(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.material.icons.outlined.DeleteSweep
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -31,6 +30,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
@@ -114,24 +114,24 @@ fun ApkCleanerCard(
                 }
             }
 
-            FilledTonalButton(
-                onClick = { onCleanClick(apkFiles) },
-                modifier = Modifier.align(Alignment.End).bounceClick(),
-                enabled = !isLoading,
-            ) {
-                if (isLoading) {
+            if (isLoading) {
+                FilledTonalButton(
+                    onClick = { onCleanClick(apkFiles) },
+                    modifier = Modifier.align(Alignment.End).bounceClick(),
+                    enabled = false,
+                ) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(SizeConstants.ButtonIconSize)
                     )
-                } else {
-                    Icon(
-                        modifier = Modifier.size(SizeConstants.ButtonIconSize),
-                        imageVector = Icons.Outlined.DeleteSweep,
-                        contentDescription = null,
-                    )
-                    ButtonIconSpacer()
-                    Text(text = stringResource(id = R.string.clean_apks))
                 }
+            } else {
+                TonalIconButtonWithText(
+                    modifier = Modifier.align(Alignment.End),
+                    onClick = { onCleanClick(apkFiles) },
+                    label = stringResource(id = R.string.clean_apks),
+                    icon = Icons.Outlined.DeleteSweep,
+                    enabled = true,
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/TwoRowButtons.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/TwoRowButtons.kt
@@ -1,73 +1,53 @@
 package com.d4rk.cleaner.app.clean.scanner.ui.components
 
-import android.view.SoundEffectConstants
-import android.view.View
-import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 
 @Composable
 fun TwoRowButtons(
-    modifier : Modifier , enabled : Boolean , onStartButtonClick : () -> Unit , onStartButtonIcon : ImageVector , onStartButtonText : Int , onEndButtonClick : () -> Unit , onEndButtonIcon : ImageVector , onEndButtonText : Int , view : View
+    modifier: Modifier,
+    enabled: Boolean,
+    onStartButtonClick: () -> Unit,
+    onStartButtonIcon: ImageVector,
+    onStartButtonText: Int,
+    onEndButtonClick: () -> Unit,
+    onEndButtonIcon: ImageVector,
+    onEndButtonText: Int,
 ) {
 
     Row(
-        modifier = modifier.fillMaxWidth() , horizontalArrangement = Arrangement.SpaceAround
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceAround
     ) {
-        OutlinedButton(
-            enabled = enabled ,
-            onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                onStartButtonClick()
-            } ,
-            modifier = Modifier
-                    .weight(weight = 1f)
-                    .bounceClick() ,
-        ) {
-            Icon(
-                imageVector = onStartButtonIcon ,
-                contentDescription = stringResource(id = R.string.move_to_trash_icon_description) ,
-                modifier = Modifier.size(size = SizeConstants.ButtonIconSize)
-            )
-            ButtonIconSpacer()
-            Text(text = stringResource(id = onStartButtonText) , modifier = Modifier.basicMarquee())
-        }
+        OutlinedIconButtonWithText(
+            modifier = Modifier.weight(1f),
+            onClick = onStartButtonClick,
+            enabled = enabled,
+            icon = onStartButtonIcon,
+            iconContentDescription = stringResource(id = R.string.move_to_trash_icon_description),
+            label = stringResource(id = onStartButtonText)
+        )
 
         Spacer(Modifier.width(width = SizeConstants.SmallSize))
 
-        Button(
-            enabled = enabled ,
-            onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                onEndButtonClick()
-            } ,
-            modifier = Modifier
-                    .weight(1f)
-                    .bounceClick() ,
-        ) {
-            Icon(
-                imageVector = onEndButtonIcon ,
-                contentDescription = stringResource(id = R.string.delete_forever_icon_description) ,
-                modifier = Modifier.size(size = SizeConstants.ButtonIconSize)
-            )
-            ButtonIconSpacer()
-            Text(text = stringResource(id = onEndButtonText) , modifier = Modifier.basicMarquee())
-        }
+        IconButtonWithText(
+            modifier = Modifier.weight(1f),
+            onClick = onEndButtonClick,
+            enabled = enabled,
+            icon = onEndButtonIcon,
+            iconContentDescription = stringResource(id = R.string.delete_forever_icon_description),
+            label = stringResource(id = onEndButtonText)
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -66,10 +66,14 @@ fun WeeklyCleanStreakCard(
                     modifier = Modifier.align(Alignment.Center)
                 )
                 IconButton(
-                    modifier = Modifier.align(Alignment.CenterEnd).bounceClick(),
+                    modifier = Modifier.align(Alignment.CenterEnd),
                     onClick = onDismiss
                 ) {
-                    Icon(modifier = Modifier.size(SizeConstants.ButtonIconSize), imageVector = Icons.Outlined.Close, contentDescription = null)
+                    Icon(
+                        modifier = Modifier.size(SizeConstants.ButtonIconSize),
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = null
+                    )
                 }
             }
             Text(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 
@@ -67,14 +66,10 @@ fun WeeklyCleanStreakCard(
                 )
                 IconButton(
                     modifier = Modifier.align(Alignment.CenterEnd),
-                    onClick = onDismiss
-                ) {
-                    Icon(
-                        modifier = Modifier.size(SizeConstants.ButtonIconSize),
-                        imageVector = Icons.Outlined.Close,
-                        contentDescription = null
-                    )
-                }
+                    onClick = onDismiss,
+                    icon = Icons.Outlined.Close,
+                    iconContentDescription = null
+                )
             }
             Text(
                 text = message,

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/trash/ui/TrashScreen.kt
@@ -93,7 +93,6 @@ fun TrashScreen(activity : TrashActivity) {
                     } ,
                     onEndButtonIcon = Icons.Outlined.DeleteForever ,
                     onEndButtonText = R.string.delete_forever ,
-                    view = view ,
                 )
             }
         })


### PR DESCRIPTION
## Summary
- replace Compose buttons with App Toolkit button components
- simplify button parameters
- remove unused imports

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687122510dc4832d96bd3abfa7270428