### PR TITLE
Add automatic scheduled cleaning

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/Cleaner.kt
@@ -16,11 +16,15 @@ import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.cleaner.app.notifications.work.CleanupReminderScheduler
 import com.d4rk.cleaner.app.notifications.work.StreakReminderScheduler
+import com.d4rk.cleaner.app.auto.AutoCleanScheduler
 import com.d4rk.cleaner.core.di.initializeKoin
 import com.d4rk.cleaner.core.utils.constants.ads.AdsConstants
 import com.d4rk.cleaner.core.utils.helpers.StreakTracker
+import com.d4rk.cleaner.core.data.datastore.DataStore
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.supervisorScope
 import org.koin.android.ext.android.getKoin
 
@@ -36,6 +40,14 @@ class Cleaner : BaseCoreManager(), SingletonImageLoader.Factory {
         super.onCreate()
         CleanupReminderScheduler.schedule(this)
         StreakReminderScheduler.schedule(this)
+        runBlocking {
+            val ds = DataStore(this@Cleaner)
+            if (ds.autoCleanEnabled.first()) {
+                AutoCleanScheduler.schedule(this@Cleaner)
+            } else {
+                AutoCleanScheduler.cancel(this@Cleaner)
+            }
+        }
         registerActivityLifecycleCallbacks(this)
         ProcessLifecycleOwner.get().lifecycle.addObserver(observer = this)
     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanScheduler.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanScheduler.kt
@@ -1,0 +1,35 @@
+package com.d4rk.cleaner.app.auto
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.d4rk.cleaner.core.data.datastore.DataStore
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.TimeUnit
+
+object AutoCleanScheduler {
+    private const val WORK_NAME = "auto_clean_work"
+
+    fun schedule(context: Context) {
+        val dataStore = DataStore(context)
+        val frequency = runBlocking { dataStore.autoCleanFrequencyDays.first() }
+        val constraints = Constraints.Builder()
+            .setRequiresCharging(true)
+            .setRequiresDeviceIdle(true)
+            .build()
+        val request = PeriodicWorkRequestBuilder<AutoCleanWorker>(frequency.toLong(), TimeUnit.DAYS)
+            .setConstraints(constraints)
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/auto/AutoCleanWorker.kt
@@ -1,0 +1,119 @@
+package com.d4rk.cleaner.app.auto
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.FileTypesData
+import com.d4rk.cleaner.app.clean.scanner.domain.usecases.AnalyzeFilesUseCase
+import com.d4rk.cleaner.app.clean.scanner.domain.usecases.DeleteFilesUseCase
+import com.d4rk.cleaner.app.clean.scanner.domain.usecases.GetFileTypesUseCase
+import com.d4rk.cleaner.app.settings.cleaning.utils.constants.ExtensionsConstants
+import com.d4rk.cleaner.core.data.datastore.DataStore
+import com.d4rk.cleaner.core.utils.helpers.CleaningEventBus
+import com.d4rk.cleaner.core.utils.extensions.md5
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import kotlinx.coroutines.flow.first
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import kotlin.time.Duration.Companion.days
+import java.io.File
+
+class AutoCleanWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params), KoinComponent {
+
+    private val analyzeFiles: AnalyzeFilesUseCase by inject()
+    private val deleteFiles: DeleteFilesUseCase by inject()
+    private val getFileTypes: GetFileTypesUseCase by inject()
+    private val dataStore: DataStore by inject()
+
+    override suspend fun doWork(): Result {
+        if (!dataStore.autoCleanEnabled.first()) return Result.success()
+
+        val frequency = dataStore.autoCleanFrequencyDays.first()
+        val lastScan = dataStore.lastScanTimestamp.first() ?: 0L
+        val now = System.currentTimeMillis()
+        if (frequency <= 0 || now - lastScan < frequency.days.inWholeMilliseconds) {
+            return Result.success()
+        }
+
+        val filesState = analyzeFiles().first { it !is DataState.Loading }
+        if (filesState !is DataState.Success) return Result.success()
+        val (files, emptyFolders) = filesState.data
+
+        val typesState = getFileTypes().first { it !is DataState.Loading }
+        val types = if (typesState is DataState.Success) typesState.data else FileTypesData()
+
+        val prefs = mapOf(
+            ExtensionsConstants.IMAGE_EXTENSIONS to dataStore.deleteImageFiles.first(),
+            ExtensionsConstants.VIDEO_EXTENSIONS to dataStore.deleteVideoFiles.first(),
+            ExtensionsConstants.AUDIO_EXTENSIONS to dataStore.deleteAudioFiles.first(),
+            ExtensionsConstants.OFFICE_EXTENSIONS to dataStore.deleteOfficeFiles.first(),
+            ExtensionsConstants.ARCHIVE_EXTENSIONS to dataStore.deleteArchives.first(),
+            ExtensionsConstants.APK_EXTENSIONS to dataStore.deleteApkFiles.first(),
+            ExtensionsConstants.FONT_EXTENSIONS to dataStore.deleteFontFiles.first(),
+            ExtensionsConstants.WINDOWS_EXTENSIONS to dataStore.deleteWindowsFiles.first(),
+            ExtensionsConstants.EMPTY_FOLDERS to dataStore.deleteEmptyFolders.first(),
+            ExtensionsConstants.OTHER_EXTENSIONS to dataStore.deleteOtherFiles.first()
+        )
+        val includeDuplicates = dataStore.deleteDuplicateFiles.first()
+
+        val toDelete = computeFilesToClean(files, emptyFolders, types, prefs, includeDuplicates)
+        if (toDelete.isEmpty()) return Result.success()
+
+        deleteFiles(filesToDelete = toDelete.toSet()).collect {}
+        dataStore.saveLastScanTimestamp(now)
+        CleaningEventBus.notifyCleaned()
+        return Result.success()
+    }
+
+    private fun computeFilesToClean(
+        scannedFiles: List<File>,
+        emptyFolders: List<File>,
+        fileTypesData: FileTypesData,
+        preferences: Map<String, Boolean>,
+        includeDuplicates: Boolean
+    ): List<File> {
+        val knownExtensions = (fileTypesData.imageExtensions + fileTypesData.videoExtensions +
+            fileTypesData.audioExtensions + fileTypesData.officeExtensions + fileTypesData.archiveExtensions +
+            fileTypesData.apkExtensions + fileTypesData.fontExtensions + fileTypesData.windowsExtensions).toSet()
+        val result = mutableListOf<File>()
+
+        val duplicateGroups = if (includeDuplicates) findDuplicateGroups(scannedFiles) else emptyList()
+        val duplicateFiles = if (includeDuplicates) duplicateGroups.flatten().toSet() else emptySet()
+
+        scannedFiles.forEach { file ->
+            if (includeDuplicates && file in duplicateFiles) {
+                result.add(file)
+            } else {
+                val extension = file.extension.lowercase()
+                val match = when (extension) {
+                    in fileTypesData.imageExtensions -> preferences[ExtensionsConstants.IMAGE_EXTENSIONS] == true
+                    in fileTypesData.videoExtensions -> preferences[ExtensionsConstants.VIDEO_EXTENSIONS] == true
+                    in fileTypesData.audioExtensions -> preferences[ExtensionsConstants.AUDIO_EXTENSIONS] == true
+                    in fileTypesData.officeExtensions -> preferences[ExtensionsConstants.OFFICE_EXTENSIONS] == true
+                    in fileTypesData.archiveExtensions -> preferences[ExtensionsConstants.ARCHIVE_EXTENSIONS] == true
+                    in fileTypesData.apkExtensions -> preferences[ExtensionsConstants.APK_EXTENSIONS] == true
+                    in fileTypesData.fontExtensions -> preferences[ExtensionsConstants.FONT_EXTENSIONS] == true
+                    in fileTypesData.windowsExtensions -> preferences[ExtensionsConstants.WINDOWS_EXTENSIONS] == true
+                    else -> !knownExtensions.contains(extension) && preferences[ExtensionsConstants.OTHER_EXTENSIONS] == true
+                }
+                if (match) result.add(file)
+            }
+        }
+        if (preferences[ExtensionsConstants.EMPTY_FOLDERS] == true) {
+            result.addAll(emptyFolders)
+        }
+        return result
+    }
+
+    private fun findDuplicateGroups(files: List<File>): List<List<File>> {
+        val hashMap = mutableMapOf<String, MutableList<File>>()
+        files.filter { it.isFile }.forEach { file ->
+            val hash = file.md5() ?: return@forEach
+            hashMap.getOrPut(hash) { mutableListOf() }.add(file)
+        }
+        return hashMap.values.filter { it.size > 1 }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/data/datastore/DataStore.kt
@@ -378,4 +378,26 @@ class DataStore(val context : Context) : CommonDataStore(context = context) {
         }
     }
 
+    private val autoCleanEnabledKey = booleanPreferencesKey(AppDataStoreConstants.DATA_STORE_AUTO_CLEAN_ENABLED)
+    val autoCleanEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[autoCleanEnabledKey] ?: false
+    }
+
+    suspend fun saveAutoCleanEnabled(enabled: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[autoCleanEnabledKey] = enabled
+        }
+    }
+
+    private val autoCleanFrequencyDaysKey = intPreferencesKey(AppDataStoreConstants.DATA_STORE_AUTO_CLEAN_FREQUENCY_DAYS)
+    val autoCleanFrequencyDays: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[autoCleanFrequencyDaysKey] ?: 7
+    }
+
+    suspend fun saveAutoCleanFrequencyDays(days: Int) {
+        dataStore.edit { prefs ->
+            prefs[autoCleanFrequencyDaysKey] = days
+        }
+    }
+
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/utils/constants/datastore/AppDataStoreConstants.kt
@@ -36,4 +36,6 @@ object AppDataStoreConstants : DataStoreNamesConstants() {
     const val DATA_STORE_STREAK_REMINDER_ENABLED = "streak_reminder_enabled"
     const val DATA_STORE_SHOW_STREAK_CARD = "show_streak_card"
     const val DATA_STORE_STREAK_HIDE_UNTIL = "streak_hide_until"
+    const val DATA_STORE_AUTO_CLEAN_ENABLED = "auto_clean_enabled"
+    const val DATA_STORE_AUTO_CLEAN_FREQUENCY_DAYS = "auto_clean_frequency_days"
 }


### PR DESCRIPTION
## Summary
- introduce automatic cleaning worker and scheduler
- store auto clean settings in datastore
- trigger scheduler from app initialization

## Testing
- `./gradlew tasks --all`
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6872502e2288832d9cc4898c487b8b2e