### PR TITLE
Add automatic cleaning preference

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/settings/cleaning/ui/CleaningSettingsList.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/settings/cleaning/ui/CleaningSettingsList.kt
@@ -21,6 +21,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVertical
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.core.data.datastore.DataStore
+import com.d4rk.cleaner.app.auto.AutoCleanScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -47,6 +48,7 @@ fun CleaningSettingsList(paddingValues : PaddingValues) {
     val clipboardClean : Boolean by dataStore.clipboardClean.collectAsState(initial = false)
     val streakReminderEnabled: Boolean by dataStore.streakReminderEnabled.collectAsState(initial = false)
     val showStreakCardPref: Boolean by dataStore.showStreakCard.collectAsState(initial = true)
+    val autoCleanEnabled: Boolean by dataStore.autoCleanEnabled.collectAsState(initial = false)
 
     LazyColumn(
         modifier = Modifier
@@ -280,6 +282,27 @@ fun CleaningSettingsList(paddingValues : PaddingValues) {
                         if (isChecked) {
                             Toast.makeText(context, context.getString(R.string.streak_return_toast), Toast.LENGTH_SHORT).show()
                         }
+                    }
+                }
+            }
+        }
+
+        item {
+            PreferenceCategoryItem(title = stringResource(id = R.string.automatic_cleanup))
+            SmallVerticalSpacer()
+
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = SizeConstants.LargeSize)
+                    .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
+            ) {
+                SwitchPreferenceItem(
+                    title = stringResource(id = R.string.enable_automatic_cleaning),
+                    checked = autoCleanEnabled,
+                ) { isChecked ->
+                    CoroutineScope(Dispatchers.IO).launch {
+                        dataStore.saveAutoCleanEnabled(isChecked)
+                        if (isChecked) AutoCleanScheduler.schedule(context, dataStore) else AutoCleanScheduler.cancel(context)
                     }
                 }
             }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -279,6 +279,8 @@
     <string name="clipboard_clean">تنظيف الحافظة</string>
     <string name="summary_preference_settings_delete_duplicates">حذف الملفات المكررة أثناء التنظيف</string>
 
+    <string name="automatic_cleanup">التنظيف التلقائي</string>
+    <string name="enable_automatic_cleaning">تمكين التنظيف التلقائي</string>
     <!-- Permissions -->
     <string name="request_delete_packages">طلب حذف الحزم [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">بيسمح للتطبيق يطلب حذف الحزم. ده ممكن يستخدم لإلغاء تثبيت تطبيقات تانية من الجهاز.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Почистване на клипборда</string>
     <string name="summary_preference_settings_delete_duplicates">Изтрийте дублиращи се файлове по време на почистване</string>
 
+    <string name="automatic_cleanup">Автоматично почистване</string>
+    <string name="enable_automatic_cleaning">Активирайте автоматичното почистване</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Заявка за изтриване на пакети [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Позволява на приложението да изисква изтриването на пакети. Това може да се използва за деинсталиране на други приложения от устройството.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">ক্লিপবোর্ড পরিষ্কার করুন</string>
     <string name="summary_preference_settings_delete_duplicates">পরিষ্কারের সময় সদৃশ ফাইলগুলি মুছুন</string>
 
+    <string name="automatic_cleanup">স্বয়ংক্রিয় ক্লিনআপ</string>
+    <string name="enable_automatic_cleaning">স্বয়ংক্রিয় পরিষ্কার সক্ষম করুন</string>
     <!-- Permissions -->
     <string name="request_delete_packages">প্যাকেজ মোছার অনুরোধ [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">অ্যাপটিকে প্যাকেজ মোছার অনুরোধ করার অনুমতি দেয়। এটি ডিভাইস থেকে অন্যান্য অ্যাপ আনইনস্টল করতে ব্যবহার করা যেতে পারে</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Zwischenablage bereinigen</string>
     <string name="summary_preference_settings_delete_duplicates">Löschen Sie doppelte Dateien während der Reinigung</string>
 
+    <string name="automatic_cleanup">Automatische Aufräumarbeiten</string>
+    <string name="enable_automatic_cleaning">Aktivieren Sie die automatische Reinigung</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Löschen von Paketen anfordern [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Ermöglicht der App, das Löschen von Paketen anzufordern. Dies kann verwendet werden, um andere Apps vom Gerät zu deinstallieren</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -270,6 +270,8 @@
     <string name="clipboard_clean">Limpiar portapapeles</string>
     <string name="summary_preference_settings_delete_duplicates">Eliminar archivos duplicados durante la limpieza</string>
 
+    <string name="automatic_cleanup">Limpieza automática</string>
+    <string name="enable_automatic_cleaning">Habilitar la limpieza automática</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar eliminación de paquetes [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Permite que la app solicite la eliminación de paquetes. Esto se puede usar para desinstalar otras apps del dispositivo.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -270,6 +270,8 @@
     <string name="clipboard_clean">Limpiar portapapeles</string>
     <string name="summary_preference_settings_delete_duplicates">Eliminar archivos duplicados durante la limpieza</string>
 
+    <string name="automatic_cleanup">Limpieza automática</string>
+    <string name="enable_automatic_cleaning">Habilitar la limpieza automática</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar eliminación de paquetes [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Permite que la aplicación solicite la eliminación de paquetes. Esto se puede usar para desinstalar otras aplicaciones del dispositivo.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Linisin ang clipboard</string>
     <string name="summary_preference_settings_delete_duplicates">Tanggalin ang mga dobleng file sa panahon ng paglilinis</string>
 
+    <string name="automatic_cleanup">Awtomatikong paglilinis</string>
+    <string name="enable_automatic_cleaning">Paganahin ang awtomatikong paglilinis</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Humiling ng pagbura ng mga package [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Pinapayagan ang app na humiling ng pagbura ng mga package. Maaari itong gamitin para i-uninstall ang iba pang mga app mula sa device</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -271,6 +271,8 @@
     <string name="clipboard_clean">Nettoyer le presse-papiers</string>
     <string name="summary_preference_settings_delete_duplicates">Supprimer les fichiers en double pendant le nettoyage</string>
 
+    <string name="automatic_cleanup">Nettoyage automatique</string>
+    <string name="enable_automatic_cleaning">Activer le nettoyage automatique</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Demander la suppression de paquets [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Permet à l\'application de demander la suppression de paquets. Peut être utilisé pour désinstaller d\'autres applications de l\'appareil.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">क्लिपबोर्ड साफ़ करें</string>
     <string name="summary_preference_settings_delete_duplicates">सफाई के दौरान डुप्लिकेट फ़ाइलों को हटाएं</string>
 
+    <string name="automatic_cleanup">स्वत: सफाई</string>
+    <string name="enable_automatic_cleaning">स्वचालित सफाई सक्षम करें</string>
     <!-- Permissions -->
     <string name="request_delete_packages">पैकेज हटाने का अनुरोध करें [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">ऐप को पैकेज हटाने का अनुरोध करने की अनुमति देता है। इसका उपयोग डिवाइस से अन्य ऐप्स को अनइंस्टॉल करने के लिए किया जा सकता है</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Vágólap tisztítása</string>
     <string name="summary_preference_settings_delete_duplicates">Törölje a duplikált fájlokat a tisztítás során</string>
 
+    <string name="automatic_cleanup">Automatikus takarítás</string>
+    <string name="enable_automatic_cleaning">Engedélyezze az automatikus tisztítást</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Csomagok törlésének kérése [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Lehetővé teszi az alkalmazás számára, hogy csomagok törlését kérje. Ezzel más alkalmazásokat is el lehet távolítani az eszközről</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">Bersihkan clipboard</string>
     <string name="summary_preference_settings_delete_duplicates">Hapus file duplikat selama pembersihan</string>
 
+    <string name="automatic_cleanup">Pembersihan Otomatis</string>
+    <string name="enable_automatic_cleaning">Aktifkan pembersihan otomatis</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Minta hapus paket [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Mengizinkan aplikasi untuk meminta penghapusan paket. Ini dapat digunakan untuk mencopot pemasangan aplikasi lain dari perangkat</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -270,6 +270,8 @@
     <string name="clipboard_clean">Pulisci appunti</string>
     <string name="summary_preference_settings_delete_duplicates">Elimina file duplicati durante la pulizia</string>
 
+    <string name="automatic_cleanup">Pulizia automatica</string>
+    <string name="enable_automatic_cleaning">Abilita la pulizia automatica</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Richiedi eliminazione pacchetti [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Consente all\'app di richiedere l\'eliminazione di pacchetti. Può essere utilizzato per disinstallare altre app dal dispositivo</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">クリップボードをクリア</string>
     <string name="summary_preference_settings_delete_duplicates">クリーニング中に複製ファイルを削除します</string>
 
+    <string name="automatic_cleanup">自動クリーンアップ</string>
+    <string name="enable_automatic_cleaning">自動クリーニングを有効にします</string>
     <!-- Permissions -->
     <string name="request_delete_packages">パッケージ削除のリクエスト [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">アプリがパッケージの削除をリクエストできるようにします。これにより、デバイスから他のアプリをアンインストールできます</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">클립보드 정리</string>
     <string name="summary_preference_settings_delete_duplicates">청소 중에 중복 파일을 삭제하십시오</string>
 
+    <string name="automatic_cleanup">자동 정리</string>
+    <string name="enable_automatic_cleaning">자동 청소를 활성화합니다</string>
     <!-- Permissions -->
     <string name="request_delete_packages">패키지 삭제 요청 [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">앱이 패키지 삭제를 요청할 수 있도록 허용합니다. 이를 사용하여 기기에서 다른 앱을 제거할 수 있습니다.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -273,6 +273,8 @@
     <string name="clipboard_clean">Wyczyść schowek</string>
     <string name="summary_preference_settings_delete_duplicates">Usuń zduplikowane pliki podczas czyszczenia</string>
 
+    <string name="automatic_cleanup">Automatyczne czyszczenie</string>
+    <string name="enable_automatic_cleaning">Włącz automatyczne czyszczenie</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Żądanie usunięcia pakietów [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Pozwala aplikacji żądać usunięcia pakietów. Może to być użyte do odinstalowania innych aplikacji z urządzenia</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -270,6 +270,8 @@
     <string name="clipboard_clean">Limpar área de transferência</string>
     <string name="summary_preference_settings_delete_duplicates">Excluir arquivos duplicados durante a limpeza</string>
 
+    <string name="automatic_cleanup">Limpeza automática</string>
+    <string name="enable_automatic_cleaning">Ativar limpeza automática</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Solicitar exclusão de pacotes [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Permite que o aplicativo solicite a exclusão de pacotes. Isso pode ser usado para desinstalar outros aplicativos do dispositivo</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -270,6 +270,8 @@
     <string name="clipboard_clean">Curăță clipboard</string>
     <string name="summary_preference_settings_delete_duplicates">Ștergeți fișierele duplicate în timpul curățării</string>
 
+    <string name="automatic_cleanup">Curățare automată</string>
+    <string name="enable_automatic_cleaning">Activați curățarea automată</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Solicită ștergerea pachetelor [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Permite aplicației să solicite ștergerea pachetelor. Aceasta poate fi utilizată pentru a dezinstala alte aplicații de pe dispozitiv</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -273,6 +273,8 @@
     <string name="clipboard_clean">Очистить буфер обмена</string>
     <string name="summary_preference_settings_delete_duplicates">Удалить дубликаты файлов во время очистки</string>
 
+    <string name="automatic_cleanup">Автоматическая очистка</string>
+    <string name="enable_automatic_cleaning">Включить автоматическую очистку</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Запросить удаление пакетов [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Позволяет приложению запрашивать удаление пакетов. Это можно использовать для удаления других приложений с устройства</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Rensa urklipp</string>
     <string name="summary_preference_settings_delete_duplicates">Ta bort duplicerade filer under rengöring</string>
 
+    <string name="automatic_cleanup">Automatisk sanering</string>
+    <string name="enable_automatic_cleaning">Aktivera automatisk rengöring</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Begär radering av paket [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Tillåter appen att begära radering av paket. Detta kan användas för att avinstallera andra appar från enheten</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">ล้างคลิปบอร์ด</string>
     <string name="summary_preference_settings_delete_duplicates">ลบไฟล์ที่ซ้ำกันระหว่างการทำความสะอาด</string>
 
+    <string name="automatic_cleanup">การล้างข้อมูลอัตโนมัติ</string>
+    <string name="enable_automatic_cleaning">เปิดใช้งานการทำความสะอาดอัตโนมัติ</string>
     <!-- Permissions -->
     <string name="request_delete_packages">ร้องขอการลบแพ็คเกจ [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">อนุญาตให้แอปสามารถร้องขอการลบแพ็คเกจได้ ซึ่งสามารถใช้เพื่อถอนการติดตั้งแอปอื่นๆ ออกจากอุปกรณ์</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Panoyu temizle</string>
     <string name="summary_preference_settings_delete_duplicates">Temizlik sırasında yinelenen dosyaları silin</string>
 
+    <string name="automatic_cleanup">Otomatik temizlik</string>
+    <string name="enable_automatic_cleaning">Otomatik temizliği etkinleştirin</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Paket silme isteği [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Uygulamanın paketlerin silinmesini istemesine izin verir. Bu, cihazdan diğer uygulamaları kaldırmak için kullanılabilir</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -273,6 +273,8 @@
     <string name="clipboard_clean">Очищення буфера обміну</string>
     <string name="summary_preference_settings_delete_duplicates">Видалити повторювані файли під час очищення</string>
 
+    <string name="automatic_cleanup">Автоматичне очищення</string>
+    <string name="enable_automatic_cleaning">Увімкнути автоматичне очищення</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Запит на видалення пакетів [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Дозволяє додатку запитувати видалення пакетів. Це може використовуватися для видалення інших додатків з пристрою</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">کلپ بورڈ صاف کریں</string>
     <string name="summary_preference_settings_delete_duplicates">صفائی کے دوران ڈپلیکیٹ فائلوں کو حذف کریں</string>
 
+    <string name="automatic_cleanup">خودکار صفائی</string>
+    <string name="enable_automatic_cleaning">خودکار صفائی کو فعال کریں</string>
     <!-- Permissions -->
     <string name="request_delete_packages">پیکیجز حذف کرنے کی درخواست کریں [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">ایپ کو پیکیجز کو حذف کرنے کی درخواست کرنے کی اجازت دیتا ہے۔ اسے آلے سے دیگر ایپس کو ان انسٹال کرنے کے لیے استعمال کیا جا سکتا ہے۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">Dọn dẹp bảng tạm</string>
     <string name="summary_preference_settings_delete_duplicates">Xóa các tệp trùng lặp trong khi làm sạch</string>
 
+    <string name="automatic_cleanup">Tự động dọn dẹp</string>
+    <string name="enable_automatic_cleaning">Bật làm sạch tự động</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Yêu cầu xóa gói [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Cho phép ứng dụng yêu cầu xóa các gói. Điều này có thể được sử dụng để gỡ cài đặt các ứng dụng khác khỏi thiết bị</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -264,6 +264,8 @@
     <string name="clipboard_clean">清理剪貼簿</string>
     <string name="summary_preference_settings_delete_duplicates">清理過程中刪除重複檔案</string>
 
+    <string name="automatic_cleanup">自動清理</string>
+    <string name="enable_automatic_cleaning">啟用自動清潔</string>
     <!-- Permissions -->
     <string name="request_delete_packages">請求刪除套件 [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">允許應用程式請求刪除套件。這可用於從裝置解除安裝其他應用程式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,8 @@
     <string name="clipboard_clean">Clipboard clean</string>
     <string name="summary_preference_settings_delete_duplicates">Delete duplicate files during cleaning</string>
 
+    <string name="automatic_cleanup">Automatic Cleanup</string>
+    <string name="enable_automatic_cleaning">Enable automatic cleaning</string>
     <!-- Permissions -->
     <string name="request_delete_packages">Request delete packages [REQUEST_DELETE_PACKAGES]</string>
     <string name="summary_preference_permissions_request_delete_packages">Allows the app to request the deletion of packages. This can be used to uninstall other apps from the device</string>


### PR DESCRIPTION
## Summary
- add new "Automatic Cleanup" category in Cleaning Settings
- include switch to enable/disable automatic cleaning
- wire toggle to DataStore and scheduler
- provide translations for all locales

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873296ca5c4832d87b9e9c5f7a0462e