### PR TITLE
Use plural resources for day-based strings

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/ApkCleanerCard.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -108,7 +109,11 @@ fun ApkCleanerCard(
                     }
                     if (apkFiles.size > preview.size) {
                         Text(
-                            text = stringResource(id = R.string.apk_card_more_format, apkFiles.size - preview.size),
+                            text = pluralStringResource(
+                                id = R.plurals.apk_card_more_format,
+                                count = apkFiles.size - preview.size,
+                                apkFiles.size - preview.size
+                            ),
                             style = MaterialTheme.typography.bodySmall
                         )
                     }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WeeklyCleanStreakCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.cleaner.R
 
@@ -43,7 +44,11 @@ fun WeeklyCleanStreakCard(
 
     val message = when (streakDays) {
         0 -> stringResource(id = R.string.clean_streak_start)
-        in 1..6 -> stringResource(id = R.string.clean_streak_in_progress, streakDays)
+        in 1..6 -> pluralStringResource(
+            id = R.plurals.clean_streak_in_progress,
+            count = streakDays,
+            streakDays
+        )
         else -> stringResource(id = R.string.clean_streak_perfect_week_message)
     }
 

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/components/WhatsAppCleanerCard.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
@@ -170,7 +171,11 @@ private fun MorePreviewTile(count: Int) {
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = stringResource(id = R.string.apk_card_more_format, count),
+                text = pluralStringResource(
+                    id = R.plurals.apk_card_more_format,
+                    count = count,
+                    count
+                ),
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/CleanupReminderWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/CleanupReminderWorker.kt
@@ -71,8 +71,9 @@ class CleanupReminderWorker(
         val message = if (days == null) {
             applicationContext.getString(R.string.cleanup_notification_never_scanned)
         } else {
-            applicationContext.getString(
-                R.string.cleanup_notification_last_scan_format,
+            applicationContext.resources.getQuantityString(
+                R.plurals.cleanup_notification_last_scan_format,
+                days,
                 days,
                 base
             )

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -44,7 +44,14 @@
     <string name="cleanup_storage_ok_4">تبدو جيدة — لا حاجة إلى أي إجراء.</string>
     <string name="cleanup_storage_ok_5">التخزين تحت السيطرة!</string>
     <string name="cleanup_storage_ok_6">نظيف وواضح. أحسنت!</string>
-    <string name="cleanup_notification_last_scan_format">آخر فحص: من %1$d يوم. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="zero">آخر فحص: من %1$d يوم. %2$s</item>
+        <item quantity="one">آخر فحص: من %1$d يوم. %2$s</item>
+        <item quantity="two">آخر فحص: من %1$d يوم. %2$s</item>
+        <item quantity="few">آخر فحص: من %1$d يوم. %2$s</item>
+        <item quantity="many">آخر فحص: من %1$d يوم. %2$s</item>
+        <item quantity="other">آخر فحص: من %1$d يوم. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">لسه ما فحصتش تليفونك. اضغط للبدء.</string>
 
     <!-- Onboarding -->
@@ -88,7 +95,14 @@
     <string name="delete_forever_icon_description">أيقونة حذف نهائيًا</string>
     <string name="clean_streak_title">🧹 سلسلة التنظيف الأسبوعي</string>
     <string name="clean_streak_start">ابدأ سلسلة التنظيف اليوم.</string>
-    <string name="clean_streak_in_progress">%1$d يومًا على التوالي — استمر!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="zero">%1$d يومًا على التوالي — استمر!</item>
+        <item quantity="one">%1$d يومًا على التوالي — استمر!</item>
+        <item quantity="two">%1$d يومًا على التوالي — استمر!</item>
+        <item quantity="few">%1$d يومًا على التوالي — استمر!</item>
+        <item quantity="many">%1$d يومًا على التوالي — استمر!</item>
+        <item quantity="other">%1$d يومًا على التوالي — استمر!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">أسبوع مثالي! 💎 تستحق ذلك.</string>
     <string name="streak_reward_day1">بداية موفقة!</string>
     <string name="streak_reward_day3">هل تعلم أنه يمكنك الفرز حسب الحجم؟</string>
@@ -108,7 +122,14 @@
     <string name="streak_return_toast">ستعود سلسلة التنظيف في المرة القادمة التي تنظف فيها.</string>
     <string name="apk_card_title">تم العثور على مثبّتين قديمين</string>
     <string name="apk_card_subtitle">إزالة ملفات التثبيت المتبقية واستعادة المساحة.</string>
-    <string name="apk_card_more_format">+%1$d إضافية</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="zero">+%1$d إضافية</item>
+        <item quantity="one">+%1$d إضافية</item>
+        <item quantity="two">+%1$d إضافية</item>
+        <item quantity="few">+%1$d إضافية</item>
+        <item quantity="many">+%1$d إضافية</item>
+        <item quantity="other">+%1$d إضافية</item>
+    </plurals>
     <string name="clean_apks">حذف المثبتات</string>
     <string name="whatsapp_card_title">ملفات واتساب</string>
     <string name="whatsapp_card_subtitle">امسح الوسائط التي لم تعد تحتاجها.</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Изглежда добре — не са необходими действия.</string>
     <string name="cleanup_storage_ok_5">Съхранението е под контрол!</string>
     <string name="cleanup_storage_ok_6">Чисто и ясно. Браво!</string>
-    <string name="cleanup_notification_last_scan_format">Последно сканиране: преди %1$d дни. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Последно сканиране: преди %1$d ден. %2$s</item>
+        <item quantity="other">Последно сканиране: преди %1$d дни. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Все още не сте сканирали телефона си. Докоснете, за да започнете.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Икона за изтриване завинаги</string>
     <string name="clean_streak_title">🧹 Седмична серия за почистване</string>
     <string name="clean_streak_start">Започнете серията за почистване днес.</string>
-    <string name="clean_streak_in_progress">%1$d дни подред — продължавайте така!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d ден подред — продължавайте така!</item>
+        <item quantity="other">%1$d дни подред — продължавайте така!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Перфектна седмица! 💎 Заслужихте го.</string>
     <string name="streak_reward_day1">Добро начало!</string>
     <string name="streak_reward_day3">Знаете ли, че можете да сортирате по размер?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Серията за почистване ще се върне при следващото ви почистване.</string>
     <string name="apk_card_title">Намерени стари инсталатори</string>
     <string name="apk_card_subtitle">Премахнете останалите инсталационни файлове и освободете място.</string>
-    <string name="apk_card_more_format">+%1$d още</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d още</item>
+        <item quantity="other">+%1$d още</item>
+    </plurals>
     <string name="clean_apks">Изтрий инсталаторите</string>
     <string name="whatsapp_card_title">Файлове от WhatsApp</string>
     <string name="whatsapp_card_subtitle">Изчистете медията, която вече не ви трябва.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">ভাল লাগছে — কোনও পদক্ষেপের প্রয়োজন নেই।</string>
     <string name="cleanup_storage_ok_5">স্টোরেজ নিয়ন্ত্রণে আছে!</string>
     <string name="cleanup_storage_ok_6">পরিষ্কার ও পরিষ্কার। ভাল!</string>
-    <string name="cleanup_notification_last_scan_format">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</item>
+        <item quantity="other">সর্বশেষ স্ক্যান: %1$d দিন আগে। %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">আপনি এখনও ফোন স্ক্যান করেননি। শুরু করতে ট্যাপ করুন।</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">স্থায়ীভাবে মুছে ফেলার আইকন</string>
     <string name="clean_streak_title">🧹 সাপ্তাহিক পরিষ্কার অভ্যাস</string>
     <string name="clean_streak_start">আজই আপনার পরিষ্কার অভ্যাস শুরু করুন।</string>
-    <string name="clean_streak_in_progress">%1$d দিন পরপর — চালিয়ে যান!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d দিন পরপর — চালিয়ে যান!</item>
+        <item quantity="other">%1$d দিন পরপর — চালিয়ে যান!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">পারফেক্ট সপ্তাহ! 💎 আপনি প্রাপ্য।</string>
     <string name="streak_reward_day1">চমৎকার শুরু!</string>
     <string name="streak_reward_day3">আপনি কি জানেন আকার অনুযায়ী বাছাই করা যায়?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">পরেরবার পরিষ্কার করলে অভ্যাস ফিরে আসবে।</string>
     <string name="apk_card_title">পুরোনো ইনস্টলার পাওয়া গেছে</string>
     <string name="apk_card_subtitle">অবশিষ্ট ইনস্টলার ফাইল মুছে জায়গা উদ্ধার করুন।</string>
-    <string name="apk_card_more_format">+%1$d আরও</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d আরও</item>
+        <item quantity="other">+%1$d আরও</item>
+    </plurals>
     <string name="clean_apks">ইনস্টলার ডিলিট করুন</string>
     <string name="whatsapp_card_title">হোয়াটসঅ্যাপ ফাইল</string>
     <string name="whatsapp_card_subtitle">আপনার দরকার নেই এমন মিডিয়া সরান।</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Sieht gut aus — nichts zu tun.</string>
     <string name="cleanup_storage_ok_5">Der Speicher ist unter Kontrolle!</string>
     <string name="cleanup_storage_ok_6">Sauber und klar. Gut gemacht!</string>
-    <string name="cleanup_notification_last_scan_format">Letzter Scan: vor %1$d Tagen. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Letzter Scan: vor %1$d Tag. %2$s</item>
+        <item quantity="other">Letzter Scan: vor %1$d Tagen. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Du hast dein Handy noch nicht gescannt. Tippe, um zu starten.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Icon \'Endgültig löschen\'</string>
     <string name="clean_streak_title">🧹 Wöchentliche Reinigungsserie</string>
     <string name="clean_streak_start">Beginne deine Reinigungsserie heute.</string>
-    <string name="clean_streak_in_progress">%1$d Tage infolge — weiter so!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d Tag infolge — weiter so!</item>
+        <item quantity="other">%1$d Tage infolge — weiter so!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Perfekte Woche! 💎 Verdient.</string>
     <string name="streak_reward_day1">Guter Start!</string>
     <string name="streak_reward_day3">Wusstest du, dass du nach Größe sortieren kannst?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Die Reinigungsserie kehrt beim nächsten Reinigen zurück.</string>
     <string name="apk_card_title">Alte Installer gefunden</string>
     <string name="apk_card_subtitle">Entferne verbleibende Installationsdateien und gewinne Speicherplatz zurück.</string>
-    <string name="apk_card_more_format">+%1$d weitere</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d weitere</item>
+        <item quantity="other">+%1$d weitere</item>
+    </plurals>
     <string name="clean_apks">Installer löschen</string>
     <string name="whatsapp_card_title">WhatsApp-Dateien</string>
     <string name="whatsapp_card_subtitle">Lösche Medien, die du nicht mehr brauchst.</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Todo se ve bien — no hace falta hacer nada.</string>
     <string name="cleanup_storage_ok_5">¡El almacenamiento está bajo control!</string>
     <string name="cleanup_storage_ok_6">Limpio y despejado. ¡Bien hecho!</string>
-    <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Último escaneo: hace %1$d día. %2$s</item>
+        <item quantity="many">Último escaneo: hace %1$d días. %2$s</item>
+        <item quantity="other">Último escaneo: hace %1$d días. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Icono de borrar para siempre</string>
     <string name="clean_streak_title">🧹 Racha Semanal de Limpieza</string>
     <string name="clean_streak_start">Comienza tu racha de limpieza hoy.</string>
-    <string name="clean_streak_in_progress">%1$d días seguidos — ¡sigue así!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d día seguido — ¡sigue así!</item>
+        <item quantity="many">%1$d días seguidos — ¡sigue así!</item>
+        <item quantity="other">%1$d días seguidos — ¡sigue así!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">¡Semana perfecta! 💎 Te lo ganaste.</string>
     <string name="streak_reward_day1">¡Buen comienzo!</string>
     <string name="streak_reward_day3">¿Sabías que puedes ordenar por tamaño?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">La Racha de Limpieza volverá la próxima vez que limpies.</string>
     <string name="apk_card_title">Instaladores Antiguos Encontrados</string>
     <string name="apk_card_subtitle">Elimina los instaladores sobrantes y recupera espacio.</string>
-    <string name="apk_card_more_format">+%1$d más</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d más</item>
+        <item quantity="many">+%1$d más</item>
+        <item quantity="other">+%1$d más</item>
+    </plurals>
     <string name="clean_apks">Eliminar instaladores</string>
     <string name="whatsapp_card_title">Archivos de WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina los archivos que ya no necesites.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Todo se ve bien — no hace falta hacer nada.</string>
     <string name="cleanup_storage_ok_5">¡El almacenamiento está bajo control!</string>
     <string name="cleanup_storage_ok_6">Limpio y despejado. ¡Bien hecho!</string>
-    <string name="cleanup_notification_last_scan_format">Último escaneo: hace %1$d días. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Último escaneo: hace %1$d día. %2$s</item>
+        <item quantity="many">Último escaneo: hace %1$d días. %2$s</item>
+        <item quantity="other">Último escaneo: hace %1$d días. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Aún no has escaneado tu teléfono. Toca para empezar.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Icono de borrar para siempre</string>
     <string name="clean_streak_title">🧹 Racha Semanal de Limpieza</string>
     <string name="clean_streak_start">Comienza tu racha de limpieza hoy.</string>
-    <string name="clean_streak_in_progress">%1$d días seguidos — ¡sigue así!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d día seguido — ¡sigue así!</item>
+        <item quantity="many">%1$d días seguidos — ¡sigue así!</item>
+        <item quantity="other">%1$d días seguidos — ¡sigue así!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">¡Semana perfecta! 💎 Te lo ganaste.</string>
     <string name="streak_reward_day1">¡Buen comienzo!</string>
     <string name="streak_reward_day3">¿Sabías que puedes ordenar por tamaño?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">La Racha de Limpieza volverá la próxima vez que limpies.</string>
     <string name="apk_card_title">Instaladores Antiguos Encontrados</string>
     <string name="apk_card_subtitle">Elimina los instaladores sobrantes y recupera espacio.</string>
-    <string name="apk_card_more_format">+%1$d más</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d más</item>
+        <item quantity="many">+%1$d más</item>
+        <item quantity="other">+%1$d más</item>
+    </plurals>
     <string name="clean_apks">Eliminar instaladores</string>
     <string name="whatsapp_card_title">Archivos de WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina los archivos que ya no necesites.</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Mukhang maayos — wala nang dapat gawin.</string>
     <string name="cleanup_storage_ok_5">Nasa kontrol ang storage!</string>
     <string name="cleanup_storage_ok_6">Malinis at malinaw. Magaling!</string>
-    <string name="cleanup_notification_last_scan_format">Huling scan: %1$d araw na ang nakalipas. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Huling scan: %1$d araw na ang nakalipas. %2$s</item>
+        <item quantity="other">Huling scan: %1$d araw na ang nakalipas. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Hindi mo pa na-scan ang iyong telepono. Tapikin para magsimula.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Icon ng permanenteng pagtanggal</string>
     <string name="clean_streak_title">🧹 Lingguhang Clean Streak</string>
     <string name="clean_streak_start">Simulan ang Clean Streak mo ngayon.</string>
-    <string name="clean_streak_in_progress">%1$d araw nang sunod-sunod — tuloy lang!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d araw nang sunod-sunod — tuloy lang!</item>
+        <item quantity="other">%1$d araw nang sunod-sunod — tuloy lang!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Perpektong linggo! 💎 Karapat-dapat ka.</string>
     <string name="streak_reward_day1">Magandang simula!</string>
     <string name="streak_reward_day3">Alam mo bang puwedeng mag-sort ayon sa laki?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Babalik ang Clean Streak sa susunod mong paglilinis.</string>
     <string name="apk_card_title">Natagpuan ang mga Lumang Installer</string>
     <string name="apk_card_subtitle">Alisin ang natirang installer files at bawiin ang espasyo.</string>
-    <string name="apk_card_more_format">+%1$d pa</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d pa</item>
+        <item quantity="other">+%1$d pa</item>
+    </plurals>
     <string name="clean_apks">Burahin ang mga Installer</string>
     <string name="whatsapp_card_title">Mga WhatsApp File</string>
     <string name="whatsapp_card_subtitle">Linisin ang media na hindi mo na kailangan.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Tout semble bon — aucune action nécessaire.</string>
     <string name="cleanup_storage_ok_5">Le stockage est sous contrôle !</string>
     <string name="cleanup_storage_ok_6">Propre et net. Bien joué !</string>
-    <string name="cleanup_notification_last_scan_format">Dernière analyse : il y a %1$d jours. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Dernière analyse : il y a %1$d jour. %2$s</item>
+        <item quantity="many">Dernière analyse : il y a %1$d jours. %2$s</item>
+        <item quantity="other">Dernière analyse : il y a %1$d jours. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Vous n’avez pas encore analysé votre téléphone. Appuyez pour commencer.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Icône de suppression définitive</string>
     <string name="clean_streak_title">🧹 Série de Nettoyage Hebdomadaire</string>
     <string name="clean_streak_start">Commencez votre série de nettoyage dès aujourd\'hui.</string>
-    <string name="clean_streak_in_progress">%1$d jours d\'affilée — continuez comme ça !</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d jour d'affilée — continuez comme ça !</item>
+        <item quantity="many">%1$d jours d\'affilée — continuez comme ça !</item>
+        <item quantity="other">%1$d jours d\'affilée — continuez comme ça !</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Semaine parfaite ! 💎 Vous l\'avez méritée.</string>
     <string name="streak_reward_day1">Bon début !</string>
     <string name="streak_reward_day3">Saviez-vous que vous pouvez trier par taille ?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">La série de nettoyage reviendra la prochaine fois que vous nettoierez.</string>
     <string name="apk_card_title">Anciens installateurs trouvés</string>
     <string name="apk_card_subtitle">Supprimez les fichiers d’installation restants et récupérez de l’espace.</string>
-    <string name="apk_card_more_format">+%1$d de plus</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d de plus</item>
+        <item quantity="many">+%1$d de plus</item>
+        <item quantity="other">+%1$d de plus</item>
+    </plurals>
     <string name="clean_apks">Supprimer les installateurs</string>
     <string name="whatsapp_card_title">Fichiers WhatsApp</string>
     <string name="whatsapp_card_subtitle">Nettoyez les médias dont vous n’avez plus besoin.</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -93,7 +93,7 @@
     <string name="clean_streak_title">🧹 Série de Nettoyage Hebdomadaire</string>
     <string name="clean_streak_start">Commencez votre série de nettoyage dès aujourd\'hui.</string>
         <plurals name="clean_streak_in_progress">
-        <item quantity="one">%1$d jour d'affilée — continuez comme ça !</item>
+        <item quantity="one">%1$d jour d\'affilée — continuez comme ça !</item>
         <item quantity="many">%1$d jours d\'affilée — continuez comme ça !</item>
         <item quantity="other">%1$d jours d\'affilée — continuez comme ça !</item>
     </plurals>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">अच्छा लग रहा है — कोई कार्रवाई की जरूरत नहीं।</string>
     <string name="cleanup_storage_ok_5">भंडारण नियंत्रण में है!</string>
     <string name="cleanup_storage_ok_6">साफ़-सुथरा है। शाबाश!</string>
-    <string name="cleanup_notification_last_scan_format">आख़िरी स्कैन: %1$d दिन पहले. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">आख़िरी स्कैन: %1$d दिन पहले. %2$s</item>
+        <item quantity="other">आख़िरी स्कैन: %1$d दिन पहले. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">आपने अभी तक फ़ोन स्कैन नहीं किया है। शुरू करने के लिए टैप करें.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">हमेशा के लिए हटाने का आइकन</string>
     <string name="clean_streak_title">🧹 साप्ताहिक क्लीन स्ट्रीक</string>
     <string name="clean_streak_start">अपनी क्लीन स्ट्रीक आज ही शुरू करें.</string>
-    <string name="clean_streak_in_progress">%1$d दिन लगातार — जारी रखें!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d दिन लगातार — जारी रखें!</item>
+        <item quantity="other">%1$d दिन लगातार — जारी रखें!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">परफेक्ट सप्ताह! 💎 आपने इसे कमाया है.</string>
     <string name="streak_reward_day1">अच्छी शुरुआत!</string>
     <string name="streak_reward_day3">क्या आप जानते हैं कि आप आकार के आधार पर छाँट सकते हैं?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">अगली बार सफाई करने पर क्लीन स्ट्रीक वापस होगी.</string>
     <string name="apk_card_title">पुराने इंस्टॉलर पाए गए</string>
     <string name="apk_card_subtitle">बचे हुए इंस्टॉलर फ़ाइलें हटाएँ और जगह वापस पाएं.</string>
-    <string name="apk_card_more_format">+%1$d और</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d और</item>
+        <item quantity="other">+%1$d और</item>
+    </plurals>
     <string name="clean_apks">इंस्टॉलर हटाएँ</string>
     <string name="whatsapp_card_title">व्हाट्सएप फ़ाइलें</string>
     <string name="whatsapp_card_subtitle">वे मीडिया हटाएँ जिनकी अब ज़रूरत नहीं.</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Jól néz ki — nincs szükség műveletre.</string>
     <string name="cleanup_storage_ok_5">A tárolás ellenőrzés alatt áll!</string>
     <string name="cleanup_storage_ok_6">Tiszta és átlátható. Szép munka!</string>
-    <string name="cleanup_notification_last_scan_format">Utolsó keresés: %1$d napja. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Utolsó keresés: %1$d napja. %2$s</item>
+        <item quantity="other">Utolsó keresés: %1$d napja. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Még nem vizsgáltad át a telefonod. Kezdéshez érints ide.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Végleges törlés ikon</string>
     <string name="clean_streak_title">🧹 Heti tisztítási sorozat</string>
     <string name="clean_streak_start">Kezdd el a tisztítási sorozatot még ma.</string>
-    <string name="clean_streak_in_progress">%1$d nap egymás után — csak így tovább!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d nap egymás után — csak így tovább!</item>
+        <item quantity="other">%1$d nap egymás után — csak így tovább!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Tökéletes hét! 💎 Megérdemelted.</string>
     <string name="streak_reward_day1">Szép kezdet!</string>
     <string name="streak_reward_day3">Tudtad, hogy méret szerint is rendezhetsz?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">A tisztítási sorozat a következő tisztításkor visszatér.</string>
     <string name="apk_card_title">Régi telepítők találhatók</string>
     <string name="apk_card_subtitle">Távolítsa el a megmaradt telepítőfájlokat, és szabadítson fel helyet.</string>
-    <string name="apk_card_more_format">+%1$d további</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d további</item>
+        <item quantity="other">+%1$d további</item>
+    </plurals>
     <string name="clean_apks">Telepítők törlése</string>
     <string name="whatsapp_card_title">WhatsApp fájlok</string>
     <string name="whatsapp_card_subtitle">Törölje a már nem szükséges médiát.</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">Terlihat baik — tidak perlu tindakan.</string>
     <string name="cleanup_storage_ok_5">Penyimpanan terkendali!</string>
     <string name="cleanup_storage_ok_6">Bersih dan jelas. Bagus sekali!</string>
-    <string name="cleanup_notification_last_scan_format">Pemindaian terakhir: %1$d hari lalu. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">Pemindaian terakhir: %1$d hari lalu. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Anda belum pernah memindai ponsel. Ketuk untuk mulai.</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">Ikon hapus permanen</string>
     <string name="clean_streak_title">🧹 Rangkaian Bersih Mingguan</string>
     <string name="clean_streak_start">Mulai rangkaian bersihmu hari ini.</string>
-    <string name="clean_streak_in_progress">%1$d hari berturut-turut — teruskan!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d hari berturut-turut — teruskan!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Minggu sempurna! 💎 Kamu pantas mendapatkannya.</string>
     <string name="streak_reward_day1">Awalan yang bagus!</string>
     <string name="streak_reward_day3">Tahukah kamu bisa mengurutkan berdasarkan ukuran?</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">Rangkaian bersih akan kembali saat kamu membersihkan lagi.</string>
     <string name="apk_card_title">Pemasang Lama Ditemukan</string>
     <string name="apk_card_subtitle">Hapus file pemasang yang tersisa dan kosongkan ruang.</string>
-    <string name="apk_card_more_format">+%1$d lagi</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d lagi</item>
+    </plurals>
     <string name="clean_apks">Hapus Pemasang</string>
     <string name="whatsapp_card_title">File WhatsApp</string>
     <string name="whatsapp_card_subtitle">Bersihkan media yang tidak lagi dibutuhkan.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Sembra tutto a posto — nessuna azione necessaria.</string>
     <string name="cleanup_storage_ok_5">Lo spazio è sotto controllo!</string>
     <string name="cleanup_storage_ok_6">Pulito e ordinato. Ben fatto!</string>
-    <string name="cleanup_notification_last_scan_format">Ultima scansione: %1$d giorni fa. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Ultima scansione: %1$d giorno fa. %2$s</item>
+        <item quantity="many">Ultima scansione: %1$d giorni fa. %2$s</item>
+        <item quantity="other">Ultima scansione: %1$d giorni fa. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Non hai ancora scansionato il telefono. Tocca per iniziare.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Icona elimina per sempre</string>
     <string name="clean_streak_title">🧹 Serie di Pulizia Settimanale</string>
     <string name="clean_streak_start">Inizia la tua serie di pulizia oggi.</string>
-    <string name="clean_streak_in_progress">%1$d giorni di fila — continua così!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d giorno di fila — continua così!</item>
+        <item quantity="many">%1$d giorni di fila — continua così!</item>
+        <item quantity="other">%1$d giorni di fila — continua così!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Settimana perfetta! 💎 Te la sei meritata.</string>
     <string name="streak_reward_day1">Buon inizio!</string>
     <string name="streak_reward_day3">Lo sapevi che puoi ordinare per dimensione?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">La serie di pulizie tornerà la prossima volta che pulirai.</string>
     <string name="apk_card_title">Vecchi installer trovati</string>
     <string name="apk_card_subtitle">Rimuovi i file di installazione residui e recupera spazio.</string>
-    <string name="apk_card_more_format">+%1$d in più</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d in più</item>
+        <item quantity="many">+%1$d in più</item>
+        <item quantity="other">+%1$d in più</item>
+    </plurals>
     <string name="clean_apks">Elimina installatori</string>
     <string name="whatsapp_card_title">File WhatsApp</string>
     <string name="whatsapp_card_subtitle">Elimina i media di cui non hai più bisogno.</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">順調です — 特に作業は不要です。</string>
     <string name="cleanup_storage_ok_5">ストレージは管理されています！</string>
     <string name="cleanup_storage_ok_6">すっきりクリーン。お見事！</string>
-    <string name="cleanup_notification_last_scan_format">最終スキャン: %1$d日前。%2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">最終スキャン: %1$d日前。%2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">まだスキャンしていません。タップして開始してください。</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">完全削除のアイコン</string>
     <string name="clean_streak_title">🧹 週間クリーン記録</string>
     <string name="clean_streak_start">今日からクリーン記録を始めましょう。</string>
-    <string name="clean_streak_in_progress">%1$d日連続 — この調子！</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d日連続 — この調子！</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">完璧な1週間！ 💎 お疲れさまです。</string>
     <string name="streak_reward_day1">いいスタート！</string>
     <string name="streak_reward_day3">サイズで並べ替えできるのをご存知ですか？</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">次回のクリーン時にクリーン記録が戻ります。</string>
     <string name="apk_card_title">古いインストーラーが見つかりました</string>
     <string name="apk_card_subtitle">残っているインストーラーを削除して容量を確保します。</string>
-    <string name="apk_card_more_format">+%1$d 件以上</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d 件以上</item>
+    </plurals>
     <string name="clean_apks">インストーラーを削除</string>
     <string name="whatsapp_card_title">WhatsAppファイル</string>
     <string name="whatsapp_card_subtitle">不要になったメディアを整理します。</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">좋아 보이네요 — 조치가 필요 없어요.</string>
     <string name="cleanup_storage_ok_5">저장공간이 잘 관리되고 있어요!</string>
     <string name="cleanup_storage_ok_6">깔끔하고 명확합니다. 잘하셨어요!</string>
-    <string name="cleanup_notification_last_scan_format">마지막 스캔: %1$d일 전. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">마지막 스캔: %1$d일 전. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">아직 휴대폰을 스캔하지 않았어요. 시작하려면 탭하세요.</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">완전 삭제 아이콘</string>
     <string name="clean_streak_title">🧹 주간 클린 연속 기록</string>
     <string name="clean_streak_start">오늘부터 클린 연속 기록을 시작하세요.</string>
-    <string name="clean_streak_in_progress">%1$d일 연속 — 계속 유지하세요!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d일 연속 — 계속 유지하세요!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">완벽한 한 주! 💎 자격이 있습니다.</string>
     <string name="streak_reward_day1">좋은 시작이에요!</string>
     <string name="streak_reward_day3">크기별로 정렬할 수 있다는 사실, 알고 계셨나요?</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">다음 청소 시 클린 연속 기록이 돌아옵니다.</string>
     <string name="apk_card_title">오래된 설치 프로그램 발견</string>
     <string name="apk_card_subtitle">남은 설치 파일을 삭제하여 공간을 확보하세요.</string>
-    <string name="apk_card_more_format">+%1$d개 더</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d개 더</item>
+    </plurals>
     <string name="clean_apks">설치 프로그램 삭제</string>
     <string name="whatsapp_card_title">WhatsApp 파일</string>
     <string name="whatsapp_card_subtitle">더 이상 필요 없는 미디어를 정리하세요.</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -44,7 +44,12 @@
     <string name="cleanup_storage_ok_4">Wygląda dobrze — nic nie trzeba robić.</string>
     <string name="cleanup_storage_ok_5">Przechowywanie jest pod kontrolą!</string>
     <string name="cleanup_storage_ok_6">Czysto i przejrzyście. Dobra robota!</string>
-    <string name="cleanup_notification_last_scan_format">Ostatnie skanowanie: %1$d dni temu. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Ostatnie skanowanie: %1$d dzień temu. %2$s</item>
+        <item quantity="few">Ostatnie skanowanie: %1$d dni temu. %2$s</item>
+        <item quantity="many">Ostatnie skanowanie: %1$d dni temu. %2$s</item>
+        <item quantity="other">Ostatnie skanowanie: %1$d dni temu. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Nie przeskanowałeś jeszcze telefonu. Stuknij, aby zacząć.</string>
 
     <!-- Onboarding -->
@@ -88,7 +93,12 @@
     <string name="delete_forever_icon_description">Ikona trwałego usunięcia</string>
     <string name="clean_streak_title">🧹 Cotygodniowa seria czyszczenia</string>
     <string name="clean_streak_start">Rozpocznij serię czyszczenia już dziś.</string>
-    <string name="clean_streak_in_progress">%1$d dni z rzędu — tak trzymaj!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d dzień z rzędu — tak trzymaj!</item>
+        <item quantity="few">%1$d dni z rzędu — tak trzymaj!</item>
+        <item quantity="many">%1$d dni z rzędu — tak trzymaj!</item>
+        <item quantity="other">%1$d dni z rzędu — tak trzymaj!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Idealny tydzień! 💎 Zasłużyłeś.</string>
     <string name="streak_reward_day1">Dobry początek!</string>
     <string name="streak_reward_day3">Wiesz, że możesz sortować według rozmiaru?</string>
@@ -108,7 +118,12 @@
     <string name="streak_return_toast">Passa czyszczenia powróci przy następnym czyszczeniu.</string>
     <string name="apk_card_title">Znaleziono stare instalatory</string>
     <string name="apk_card_subtitle">Usuń pozostałe pliki instalatorów i odzyskaj miejsce.</string>
-    <string name="apk_card_more_format">+%1$d więcej</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d więcej</item>
+        <item quantity="few">+%1$d więcej</item>
+        <item quantity="many">+%1$d więcej</item>
+        <item quantity="other">+%1$d więcej</item>
+    </plurals>
     <string name="clean_apks">Usuń instalatory</string>
     <string name="whatsapp_card_title">Pliki WhatsApp</string>
     <string name="whatsapp_card_subtitle">Wyczyść media, których już nie potrzebujesz.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Tudo parece bem — nenhuma ação necessária.</string>
     <string name="cleanup_storage_ok_5">O armazenamento está sob controle!</string>
     <string name="cleanup_storage_ok_6">Limpo e organizado. Muito bem!</string>
-    <string name="cleanup_notification_last_scan_format">Última varredura: há %1$d dias. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Última varredura: há %1$d dia. %2$s</item>
+        <item quantity="other">Última varredura: há %1$d dias. %2$s</item>
+        <item quantity="many">Última varredura: há %1$d dias. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Você ainda não escaneou o telefone. Toque para começar.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Ícone excluir para sempre</string>
     <string name="clean_streak_title">🧹 Sequência Semanal de Limpeza</string>
     <string name="clean_streak_start">Comece sua sequência de limpeza hoje.</string>
-    <string name="clean_streak_in_progress">%1$d dias seguidos — continue assim!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d dia seguido — continue assim!</item>
+        <item quantity="other">%1$d dias seguidos — continue assim!</item>
+        <item quantity="many">%1$d dias seguidos — continue assim!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Semana perfeita! 💎 Você merece.</string>
     <string name="streak_reward_day1">Bom começo!</string>
     <string name="streak_reward_day3">Sabia que dá pra ordenar por tamanho?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">A sequência de limpeza voltará na próxima limpeza.</string>
     <string name="apk_card_title">Instaladores Antigos Encontrados</string>
     <string name="apk_card_subtitle">Remova arquivos de instalador restantes e libere espaço.</string>
-    <string name="apk_card_more_format">+%1$d a mais</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d a mais</item>
+        <item quantity="other">+%1$d a mais</item>
+        <item quantity="many">+%1$d a mais</item>
+    </plurals>
     <string name="clean_apks">Excluir instaladores</string>
     <string name="whatsapp_card_title">Arquivos do WhatsApp</string>
     <string name="whatsapp_card_subtitle">Limpe as mídias de que você não precisa mais.</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -44,7 +44,11 @@
     <string name="cleanup_storage_ok_4">Arată bine — nu e nevoie de acțiune.</string>
     <string name="cleanup_storage_ok_5">Depozitarea este sub control!</string>
     <string name="cleanup_storage_ok_6">Curat și limpede. Bine făcut!</string>
-    <string name="cleanup_notification_last_scan_format">Ultimul scan: acum %1$d zile. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Ultimul scan: acum %1$d zi. %2$s</item>
+        <item quantity="few">Ultimul scan: acum %1$d zile. %2$s</item>
+        <item quantity="other">Ultimul scan: acum %1$d zile. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Nu ți-ai scanat încă telefonul. Atinge pentru a începe.</string>
 
     <!-- Onboarding -->
@@ -88,7 +92,11 @@
     <string name="delete_forever_icon_description">Pictograma ștergere definitivă</string>
     <string name="clean_streak_title">🧹 Serie Săptămânală de Curățare</string>
     <string name="clean_streak_start">Începe seria de curățare chiar azi.</string>
-    <string name="clean_streak_in_progress">%1$d zile la rând — continuă așa!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d zi la rând — continuă așa!</item>
+        <item quantity="few">%1$d zile la rând — continuă așa!</item>
+        <item quantity="other">%1$d zile la rând — continuă așa!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Săptămână perfectă! 💎 Meriți asta.</string>
     <string name="streak_reward_day1">Un început bun!</string>
     <string name="streak_reward_day3">Știai că poți sorta după mărime?</string>
@@ -108,7 +116,11 @@
     <string name="streak_return_toast">Seria de curățare va reveni la următoarea curățare.</string>
     <string name="apk_card_title">Instalatoare vechi găsite</string>
     <string name="apk_card_subtitle">Elimină fișierele de instalare rămase și recuperează spațiu.</string>
-    <string name="apk_card_more_format">+%1$d în plus</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d în plus</item>
+        <item quantity="few">+%1$d în plus</item>
+        <item quantity="other">+%1$d în plus</item>
+    </plurals>
     <string name="clean_apks">Șterge instalatoarele</string>
     <string name="whatsapp_card_title">Fișiere WhatsApp</string>
     <string name="whatsapp_card_subtitle">Curăță fișierele media de care nu mai ai nevoie.</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -44,7 +44,12 @@
     <string name="cleanup_storage_ok_4">Всё отлично — действий не требуется.</string>
     <string name="cleanup_storage_ok_5">Хранилище под контролем!</string>
     <string name="cleanup_storage_ok_6">Чисто и аккуратно. Молодцы!</string>
-    <string name="cleanup_notification_last_scan_format">Последнее сканирование: %1$d дней назад. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Последнее сканирование: %1$d день назад. %2$s</item>
+        <item quantity="few">Последнее сканирование: %1$d дня назад. %2$s</item>
+        <item quantity="many">Последнее сканирование: %1$d дней назад. %2$s</item>
+        <item quantity="other">Последнее сканирование: %1$d дней назад. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Вы ещё не сканировали телефон. Нажмите, чтобы начать.</string>
 
     <!-- Onboarding -->
@@ -88,7 +93,12 @@
     <string name="delete_forever_icon_description">Значок безвозвратного удаления</string>
     <string name="clean_streak_title">🧹 Серия еженедельных очисток</string>
     <string name="clean_streak_start">Начните свою серию очисток сегодня.</string>
-    <string name="clean_streak_in_progress">%1$d дней подряд — так держать!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d день подряд — так держать!</item>
+        <item quantity="few">%1$d дня подряд — так держать!</item>
+        <item quantity="many">%1$d дней подряд — так держать!</item>
+        <item quantity="other">%1$d дней подряд — так держать!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Идеальная неделя! 💎 Вы это заслужили.</string>
     <string name="streak_reward_day1">Хорошее начало!</string>
     <string name="streak_reward_day3">Знаете, что можно сортировать по размеру?</string>
@@ -108,7 +118,12 @@
     <string name="streak_return_toast">Серия очисток вернётся при следующей чистке.</string>
     <string name="apk_card_title">Найдены старые установщики</string>
     <string name="apk_card_subtitle">Удалите оставшиеся установочные файлы и освободите место.</string>
-    <string name="apk_card_more_format">+%1$d ещё</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d ещё</item>
+        <item quantity="few">+%1$d ещё</item>
+        <item quantity="many">+%1$d ещё</item>
+        <item quantity="other">+%1$d ещё</item>
+    </plurals>
     <string name="clean_apks">Удалить установщики</string>
     <string name="whatsapp_card_title">Файлы WhatsApp</string>
     <string name="whatsapp_card_subtitle">Очистите медиа, которые вам больше не нужны.</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Ser bra ut — ingen åtgärd behövs.</string>
     <string name="cleanup_storage_ok_5">Lagring är under kontroll!</string>
     <string name="cleanup_storage_ok_6">Rent och tydligt. Bra gjort!</string>
-    <string name="cleanup_notification_last_scan_format">Senaste skanning: för %1$d dagar sedan. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Senaste skanning: för %1$d dag sedan. %2$s</item>
+        <item quantity="other">Senaste skanning: för %1$d dagar sedan. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Du har inte skannat din telefon än. Tryck för att börja.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Ikon för ta bort permanent</string>
     <string name="clean_streak_title">🧹 Veckovis städsvit</string>
     <string name="clean_streak_start">Starta din städsvit idag.</string>
-    <string name="clean_streak_in_progress">%1$d dagar i rad — fortsätt så!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d dag i rad — fortsätt så!</item>
+        <item quantity="other">%1$d dagar i rad — fortsätt så!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Perfekt vecka! 💎 Det har du förtjänat.</string>
     <string name="streak_reward_day1">Bra start!</string>
     <string name="streak_reward_day3">Visste du att du kan sortera efter storlek?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Städsviten återkommer nästa gång du städar.</string>
     <string name="apk_card_title">Gamla installerare hittades</string>
     <string name="apk_card_subtitle">Ta bort kvarvarande installationsfiler och frigör utrymme.</string>
-    <string name="apk_card_more_format">+%1$d till</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d till</item>
+        <item quantity="other">+%1$d till</item>
+    </plurals>
     <string name="clean_apks">Ta bort installerare</string>
     <string name="whatsapp_card_title">WhatsApp-filer</string>
     <string name="whatsapp_card_subtitle">Rensa bort media du inte längre behöver.</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">ดูดี ไม่มีอะไรต้องทำ</string>
     <string name="cleanup_storage_ok_5">ที่เก็บข้อมูลอยู่ภายใต้การควบคุม!</string>
     <string name="cleanup_storage_ok_6">สะอาดและชัดเจน ทำได้ดี!</string>
-    <string name="cleanup_notification_last_scan_format">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">สแกนครั้งล่าสุด: %1$d วันที่แล้ว %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">คุณยังไม่ได้สแกนโทรศัพท์ แตะเพื่อเริ่มต้น</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">ไอคอนลบถาวร</string>
     <string name="clean_streak_title">🧹 สถิติการล้างประจำสัปดาห์</string>
     <string name="clean_streak_start">เริ่มสถิติการล้างของคุณวันนี้</string>
-    <string name="clean_streak_in_progress">%1$d วันติดต่อกัน — ทำต่อไป!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d วันติดต่อกัน — ทำต่อไป!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">สัปดาห์สมบูรณ์แบบ! 💎 คุณคู่ควร</string>
     <string name="streak_reward_day1">เริ่มต้นได้ดี!</string>
     <string name="streak_reward_day3">คุณรู้ไหมว่าจัดเรียงตามขนาดได้?</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">สถิติการล้างจะกลับมาเมื่อคุณล้างครั้งถัดไป</string>
     <string name="apk_card_title">พบตัวติดตั้งเก่า</string>
     <string name="apk_card_subtitle">ลบไฟล์ติดตั้งที่เหลือและคืนพื้นที่</string>
-    <string name="apk_card_more_format">+%1$d เพิ่มเติม</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d เพิ่มเติม</item>
+    </plurals>
     <string name="clean_apks">ลบตัวติดตั้ง</string>
     <string name="whatsapp_card_title">ไฟล์ WhatsApp</string>
     <string name="whatsapp_card_subtitle">ล้างสื่อที่คุณไม่ต้องการแล้ว</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Gayet iyi — bir işlem gerekmez.</string>
     <string name="cleanup_storage_ok_5">Depolama kontrol altında!</string>
     <string name="cleanup_storage_ok_6">Temiz ve net. Tebrikler!</string>
-    <string name="cleanup_notification_last_scan_format">Son tarama: %1$d gün önce. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Son tarama: %1$d gün önce. %2$s</item>
+        <item quantity="other">Son tarama: %1$d gün önce. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Telefonunu henüz taramadın. Başlamak için dokun.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Kalıcı silme simgesi</string>
     <string name="clean_streak_title">🧹 Haftalık Temizlik Serisi</string>
     <string name="clean_streak_start">Temizlik serini bugün başlat.</string>
-    <string name="clean_streak_in_progress">%1$d gün üst üste — devam et!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d gün üst üste — devam et!</item>
+        <item quantity="other">%1$d gün üst üste — devam et!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Mükemmel hafta! 💎 Hak ettin.</string>
     <string name="streak_reward_day1">Güzel başlangıç!</string>
     <string name="streak_reward_day3">Boyuta göre sıralayabileceğini biliyor muydun?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Temizlik Serisi bir sonraki temizlemende geri döner.</string>
     <string name="apk_card_title">Eski Yükleyiciler Bulundu</string>
     <string name="apk_card_subtitle">Artık kalan yükleyici dosyalarını sil ve alan kazan.</string>
-    <string name="apk_card_more_format">+%1$d daha</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d daha</item>
+        <item quantity="other">+%1$d daha</item>
+    </plurals>
     <string name="clean_apks">Yükleyicileri Sil</string>
     <string name="whatsapp_card_title">WhatsApp Dosyaları</string>
     <string name="whatsapp_card_subtitle">Artık ihtiyaç duymadığın medyaları temizle.</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -44,7 +44,12 @@
     <string name="cleanup_storage_ok_4">Виглядає добре — дій не потрібно.</string>
     <string name="cleanup_storage_ok_5">Зберігання знаходиться під контролем!</string>
     <string name="cleanup_storage_ok_6">Чисто й зрозуміло. Молодці!</string>
-    <string name="cleanup_notification_last_scan_format">Останнє сканування: %1$d днів тому. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Останнє сканування: %1$d день тому. %2$s</item>
+        <item quantity="few">Останнє сканування: %1$d дні тому. %2$s</item>
+        <item quantity="many">Останнє сканування: %1$d днів тому. %2$s</item>
+        <item quantity="other">Останнє сканування: %1$d днів тому. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Ви ще не сканували телефон. Торкніться, щоб почати.</string>
 
     <!-- Onboarding -->
@@ -88,7 +93,12 @@
     <string name="delete_forever_icon_description">Піктограма остаточного видалення</string>
     <string name="clean_streak_title">🧹 Щотижнева серія очищень</string>
     <string name="clean_streak_start">Почніть свою серію очищень сьогодні.</string>
-    <string name="clean_streak_in_progress">%1$d днів поспіль — так тримайте!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d день поспіль — так тримайте!</item>
+        <item quantity="few">%1$d дні поспіль — так тримайте!</item>
+        <item quantity="many">%1$d днів поспіль — так тримайте!</item>
+        <item quantity="other">%1$d днів поспіль — так тримайте!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Досконалий тиждень! 💎 Ви це заслужили.</string>
     <string name="streak_reward_day1">Гарний початок!</string>
     <string name="streak_reward_day3">Чи знали ви, що можна сортувати за розміром?</string>
@@ -108,7 +118,12 @@
     <string name="streak_return_toast">Серія очищень повернеться під час наступного очищення.</string>
     <string name="apk_card_title">Знайдено старі інсталятори</string>
     <string name="apk_card_subtitle">Видаліть залишкові файли інсталятора та звільніть місце.</string>
-    <string name="apk_card_more_format">+%1$d додатково</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d додатково</item>
+        <item quantity="few">+%1$d додатково</item>
+        <item quantity="many">+%1$d додатково</item>
+        <item quantity="other">+%1$d додатково</item>
+    </plurals>
     <string name="clean_apks">Видалити інсталятори</string>
     <string name="whatsapp_card_title">Файли WhatsApp</string>
     <string name="whatsapp_card_subtitle">Очистіть медіа, які більше не потрібні.</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">اچھا لگ رہا ہے — کسی کارروائی کی ضرورت نہیں۔</string>
     <string name="cleanup_storage_ok_5">اسٹوریج کنٹرول میں ہے!</string>
     <string name="cleanup_storage_ok_6">صاف ستھرا، شاباش!</string>
-    <string name="cleanup_notification_last_scan_format">آخری اسکین: %1$d دن پہلے۔ %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">آخری اسکین: %1$d دن پہلے۔ %2$s</item>
+        <item quantity="other">آخری اسکین: %1$d دن پہلے۔ %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">آپ نے ابھی تک فون اسکین نہیں کیا۔ شروع کرنے کے لیے ٹیپ کریں۔</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">ہمیشہ کے لیے حذف کرنے کا آئیکن</string>
     <string name="clean_streak_title">🧹 ہفتہ وار صفائی سلسلہ</string>
     <string name="clean_streak_start">اپنا صفائی سلسلہ آج ہی شروع کریں۔</string>
-    <string name="clean_streak_in_progress">%1$d دن مسلسل — جاری رکھیں!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d دن مسلسل — جاری رکھیں!</item>
+        <item quantity="other">%1$d دن مسلسل — جاری رکھیں!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">کامل ہفتہ! 💎 آپ نے حق دار ہو۔</string>
     <string name="streak_reward_day1">اچھا آغاز!</string>
     <string name="streak_reward_day3">کیا آپ جانتے ہیں کہ آپ سائز کے مطابق ترتیب دے سکتے ہیں؟</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">اگلی صفائی پر صفائی سلسلہ واپس آجائے گا۔</string>
     <string name="apk_card_title">پرانے انسٹالر مل گئے</string>
     <string name="apk_card_subtitle">باقی رہ جانے والی انسٹالر فائلیں ہٹا کر جگہ خالی کریں۔</string>
-    <string name="apk_card_more_format">+%1$d مزید</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d مزید</item>
+        <item quantity="other">+%1$d مزید</item>
+    </plurals>
     <string name="clean_apks">انسٹالرز حذف کریں</string>
     <string name="whatsapp_card_title">واٹس ایپ فائلیں</string>
     <string name="whatsapp_card_subtitle">وہ میڈیا صاف کریں جس کی آپ کو ضرورت نہیں۔</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">Nhìn tốt — không cần hành động.</string>
     <string name="cleanup_storage_ok_5">Lưu trữ đang được kiểm soát!</string>
     <string name="cleanup_storage_ok_6">Sạch sẽ và rõ ràng. Làm tốt!</string>
-    <string name="cleanup_notification_last_scan_format">Lần quét cuối: %1$d ngày trước. %2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">Lần quét cuối: %1$d ngày trước. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">Bạn chưa quét điện thoại. Nhấn để bắt đầu.</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">Biểu tượng xóa vĩnh viễn</string>
     <string name="clean_streak_title">🧹 Chuỗi dọn dẹp hàng tuần</string>
     <string name="clean_streak_start">Bắt đầu chuỗi dọn dẹp của bạn ngay hôm nay.</string>
-    <string name="clean_streak_in_progress">%1$d ngày liên tiếp — tiếp tục nhé!</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d ngày liên tiếp — tiếp tục nhé!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Tuần hoàn hảo! 💎 Bạn xứng đáng.</string>
     <string name="streak_reward_day1">Khởi đầu tốt!</string>
     <string name="streak_reward_day3">Bạn có biết có thể sắp xếp theo kích thước không?</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">Chuỗi dọn dẹp sẽ trở lại lần dọn tiếp theo.</string>
     <string name="apk_card_title">Tìm thấy trình cài đặt cũ</string>
     <string name="apk_card_subtitle">Xóa tệp cài đặt còn sót lại để lấy lại dung lượng.</string>
-    <string name="apk_card_more_format">+%1$d thêm</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d thêm</item>
+    </plurals>
     <string name="clean_apks">Xóa bộ cài</string>
     <string name="whatsapp_card_title">Tệp WhatsApp</string>
     <string name="whatsapp_card_subtitle">Dọn dẹp phương tiện bạn không cần nữa.</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -44,7 +44,9 @@
     <string name="cleanup_storage_ok_4">看起來不錯—無需任何操作。</string>
     <string name="cleanup_storage_ok_5">儲存空間一切掌控！</string>
     <string name="cleanup_storage_ok_6">乾淨清爽，做得好！</string>
-    <string name="cleanup_notification_last_scan_format">上次掃描：%1$d 天前。%2$s</string>
+        <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="other">上次掃描：%1$d 天前。%2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">您尚未掃描手機，點擊即可開始。</string>
 
     <!-- Onboarding -->
@@ -88,7 +90,9 @@
     <string name="delete_forever_icon_description">永久刪除圖示</string>
     <string name="clean_streak_title">🧹 每週清理連擊</string>
     <string name="clean_streak_start">今天就開始你的清理連擊。</string>
-    <string name="clean_streak_in_progress">%1$d 天連續清理 — 保持下去！</string>
+        <plurals name="clean_streak_in_progress">
+        <item quantity="other">%1$d 天連續清理 — 保持下去！</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">完美的一周！ 💎 你值得擁有。</string>
     <string name="streak_reward_day1">不錯的開始！</string>
     <string name="streak_reward_day3">你知道可以按大小排序嗎？</string>
@@ -108,7 +112,9 @@
     <string name="streak_return_toast">下次清理時將恢復清理連續。</string>
     <string name="apk_card_title">找到舊安裝程式</string>
     <string name="apk_card_subtitle">移除遺留的安裝檔並釋放空間。</string>
-    <string name="apk_card_more_format">+%1$d 個以上</string>
+        <plurals name="apk_card_more_format">
+        <item quantity="other">+%1$d 個以上</item>
+    </plurals>
     <string name="clean_apks">刪除安裝檔</string>
     <string name="whatsapp_card_title">WhatsApp 檔案</string>
     <string name="whatsapp_card_subtitle">清除不需要的媒體。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,10 @@
     <string name="cleanup_storage_ok_4">Looking good — no action needed.</string>
     <string name="cleanup_storage_ok_5">Storage is under control!</string>
     <string name="cleanup_storage_ok_6">Clean and clear. Well done!</string>
-    <string name="cleanup_notification_last_scan_format">Last scan: %1$d days ago. %2$s</string>
+    <plurals name="cleanup_notification_last_scan_format">
+        <item quantity="one">Last scan: %1$d day ago. %2$s</item>
+        <item quantity="other">Last scan: %1$d days ago. %2$s</item>
+    </plurals>
     <string name="cleanup_notification_never_scanned">You haven\’t scanned your phone yet. Tap to start.</string>
 
     <!-- Onboarding -->
@@ -88,7 +91,10 @@
     <string name="delete_forever_icon_description">Delete forever icon</string>
     <string name="clean_streak_title">🧹 Weekly Clean Streak</string>
     <string name="clean_streak_start">Start your Clean Streak today.</string>
-    <string name="clean_streak_in_progress">%1$d days in a row — keep it up!</string>
+    <plurals name="clean_streak_in_progress">
+        <item quantity="one">%1$d day in a row — keep it up!</item>
+        <item quantity="other">%1$d days in a row — keep it up!</item>
+    </plurals>
     <string name="clean_streak_perfect_week_message">Perfect week! 💎 You\'ve earned it.</string>
     <string name="streak_reward_day1">Nice start!</string>
     <string name="streak_reward_day3">Did you know you can sort by size?</string>
@@ -108,7 +114,10 @@
     <string name="streak_return_toast">Clean Streak will return next time you clean.</string>
     <string name="apk_card_title">Old Installers Found</string>
     <string name="apk_card_subtitle">Remove leftover installer files and reclaim space.</string>
-    <string name="apk_card_more_format">+%1$d more</string>
+    <plurals name="apk_card_more_format">
+        <item quantity="one">+%1$d more</item>
+        <item quantity="other">+%1$d more</item>
+    </plurals>
     <string name="clean_apks">Delete Installers</string>
     <string name="whatsapp_card_title">WhatsApp Files</string>
     <string name="whatsapp_card_subtitle">Clear out media you no longer need.</string>


### PR DESCRIPTION
## Summary
- convert `clean_streak_in_progress`, `cleanup_notification_last_scan_format`, and `apk_card_more_format` to plural resources
- update all translations with appropriate singular/plural forms
- adjust Kotlin code to use `pluralStringResource` and `getQuantityString`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873348dffac832d8b0e630a0db077ae