### PR TITLE
Add cheerful WhatsApp cleaner empty state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
-import androidx.compose.material.icons.outlined.FolderOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -35,7 +34,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.fab.AnimatedExtendedFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
@@ -47,6 +45,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleanerModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.CleanerInfoCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.DirectoryGrid
+import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.WhatsAppEmptyState
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -94,11 +93,7 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
                 LoadingScreen()
             },
             onEmpty = {
-                NoDataScreen(
-                    icon = Icons.Outlined.FolderOff,
-                    showRetry = true,
-                    onRetry = { viewModel.onEvent(WhatsAppCleanerEvent.LoadMedia) },
-                )
+                WhatsAppEmptyState()
             },
             onSuccess = { data ->
                 WhatsappCleanerSummaryScreenContent(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -43,7 +43,7 @@ class WhatsappCleanerSummaryViewModel(
                     when (result) {
                         is DataState.Loading -> current.copy(screenState = ScreenState.IsLoading())
                         is DataState.Success -> current.copy(
-                            screenState = ScreenState.Success(),
+                            screenState = if (result.data.hasData) ScreenState.Success() else ScreenState.NoData(),
                             data = current.data?.copy(
                                 mediaSummary = result.data,
                                 totalSize = result.data.formattedTotalSize

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/WhatsAppEmptyState.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/WhatsAppEmptyState.kt
@@ -1,0 +1,59 @@
+package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+
+@Composable
+fun WhatsAppEmptyState(
+    adsConfig: AdsConfig = koinInject(qualifier = named(name = "large_banner"))
+) {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.finish_anim))
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(SizeConstants.MediumSize),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        LottieAnimation(
+            composition = composition,
+            iterations = LottieConstants.IterateForever,
+            modifier = Modifier.padding(bottom = SizeConstants.MediumSize)
+        )
+
+        Text(
+            text = stringResource(id = R.string.whatsapp_cleaner_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        LargeVerticalSpacer()
+
+        AdBanner(
+            adsConfig = adsConfig,
+            modifier = Modifier.padding(top = SizeConstants.MediumSize)
+        )
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">This will delete all WhatsApp media files. Continue?</string>
     <string name="cancel">Cancel</string>
     <string name="whatsapp_cleaner">WhatsApp Cleaner</string>
+    <string name="whatsapp_cleaner_empty_message">Your WhatsApp is spotless! There’s nothing left to clean. Enjoy your day!</string>
     <string name="total_files_format">%1$s files</string>
     <string name="delete_selected">Delete Selected</string>
     <string name="sort_options">Sort options</string>


### PR DESCRIPTION
## Summary
- add `WhatsAppEmptyState` composable with finish animation and ad banner
- show new empty state on WhatsApp Cleaner summary screen when there are no files
- trigger `ScreenState.NoData` in view model when summary has no data
- add string resource for the friendly empty message

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687368ecf7f8832dae05ea57a60f71e1