### PR TITLE
Add cheerful WhatsApp cleaner empty state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.DeleteSweep
-import androidx.compose.material.icons.outlined.FolderOff
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -35,7 +34,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.fab.AnimatedExtendedFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
@@ -47,6 +45,7 @@ import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.DirectoryItem
 import com.d4rk.cleaner.app.clean.whatsapp.summary.domain.model.UiWhatsAppCleanerModel
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.CleanerInfoCard
 import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.DirectoryGrid
+import com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components.WhatsAppEmptyState
 import com.d4rk.cleaner.app.clean.whatsapp.utils.constants.WhatsAppMediaConstants
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -94,11 +93,7 @@ fun WhatsappCleanerSummaryScreen(activity: Activity) {
                 LoadingScreen()
             },
             onEmpty = {
-                NoDataScreen(
-                    icon = Icons.Outlined.FolderOff,
-                    showRetry = true,
-                    onRetry = { viewModel.onEvent(WhatsAppCleanerEvent.LoadMedia) },
-                )
+                WhatsAppEmptyState()
             },
             onSuccess = { data ->
                 WhatsappCleanerSummaryScreenContent(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/WhatsappCleanerSummaryViewModel.kt
@@ -43,7 +43,7 @@ class WhatsappCleanerSummaryViewModel(
                     when (result) {
                         is DataState.Loading -> current.copy(screenState = ScreenState.IsLoading())
                         is DataState.Success -> current.copy(
-                            screenState = ScreenState.Success(),
+                            screenState = if (result.data.hasData) ScreenState.Success() else ScreenState.NoData(),
                             data = current.data?.copy(
                                 mediaSummary = result.data,
                                 totalSize = result.data.formattedTotalSize

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/WhatsAppEmptyState.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/summary/ui/components/WhatsAppEmptyState.kt
@@ -1,0 +1,59 @@
+package com.d4rk.cleaner.app.clean.whatsapp.summary.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.cleaner.R
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
+
+@Composable
+fun WhatsAppEmptyState(
+    adsConfig: AdsConfig = koinInject(qualifier = named(name = "large_banner"))
+) {
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.finish_anim))
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(SizeConstants.MediumSize),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        LottieAnimation(
+            composition = composition,
+            iterations = LottieConstants.IterateForever,
+            modifier = Modifier.padding(bottom = SizeConstants.MediumSize)
+        )
+
+        Text(
+            text = stringResource(id = R.string.whatsapp_cleaner_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        LargeVerticalSpacer()
+
+        AdBanner(
+            adsConfig = adsConfig,
+            modifier = Modifier.padding(top = SizeConstants.MediumSize)
+        )
+    }
+}
+

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -138,6 +138,7 @@
     <string name="clean_whatsapp_warning_message">سيؤدي هذا إلى حذف جميع ملفات وسائط واتساب. المتابعة؟</string>
     <string name="cancel">إلغاء</string>
     <string name="whatsapp_cleaner">منظف واتساب</string>
+    <string name="whatsapp_cleaner_empty_message">واتسابك نظيف تمامًا! لا شيء للتنظيف. استمتع بيومك!</string>
     <string name="total_files_format">%1$s ملفات</string>
     <string name="delete_selected">حذف المحدد</string>
     <string name="sort_options">خيارات الفرز</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Това ще изтрие всички медийни файлове на WhatsApp. Да продължа ли?</string>
     <string name="cancel">Отказ</string>
     <string name="whatsapp_cleaner">WhatsApp почистване</string>
+    <string name="whatsapp_cleaner_empty_message">Вашият WhatsApp е безупречно чист! Няма нищо за почистване. Приятен ден!</string>
     <string name="total_files_format">%1$s файла</string>
     <string name="delete_selected">Изтриване на избраните</string>
     <string name="sort_options">Опции за сортиране</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">এটি সব হোয়াটসঅ্যাপ মিডিয়া ফাইল মুছে ফেলবে। চালিয়ে যাবেন?</string>
     <string name="cancel">বাতিল</string>
     <string name="whatsapp_cleaner">হোয়াটসঅ্যাপ ক্লিনার</string>
+    <string name="whatsapp_cleaner_empty_message">আপনার হোয়াটসঅ্যাপ একদম পরিষ্কার! আর কিছু মুছতে নেই। আপনার দিন ভালো কাটুক!</string>
     <string name="total_files_format">%1$s ফাইল</string>
     <string name="delete_selected">নির্বাচিত মুছে ফেলুন</string>
     <string name="sort_options">সাজানোর অপশন</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Dadurch werden alle WhatsApp-Mediendateien gelöscht. Fortfahren?</string>
     <string name="cancel">Abbrechen</string>
     <string name="whatsapp_cleaner">WhatsApp Cleaner</string>
+    <string name="whatsapp_cleaner_empty_message">Dein WhatsApp ist blitzsauber! Es gibt nichts zu reinigen. Schönen Tag noch!</string>
     <string name="total_files_format">%1$s Dateien</string>
     <string name="delete_selected">Ausgewählte löschen</string>
     <string name="sort_options">Sortieroptionen</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Esto eliminará todos los archivos de medios de WhatsApp. ¿Continuar?</string>
     <string name="cancel">Cancelar</string>
     <string name="whatsapp_cleaner">Limpiador de WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">¡Tu WhatsApp está impecable! No hay nada que limpiar. ¡Disfruta tu día!</string>
     <string name="total_files_format">%1$s archivos</string>
     <string name="delete_selected">Eliminar seleccionados</string>
     <string name="sort_options">Opciones de ordenación</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Esto eliminará todos los archivos de medios de WhatsApp. ¿Continuar?</string>
     <string name="cancel">Cancelar</string>
     <string name="whatsapp_cleaner">Limpiador de WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">¡Tu WhatsApp está impecable! No hay nada que limpiar. ¡Disfruta tu día!</string>
     <string name="total_files_format">%1$s archivos</string>
     <string name="delete_selected">Eliminar seleccionados</string>
     <string name="sort_options">Opciones de ordenación</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Buburahin nito ang lahat ng WhatsApp media files. Magpatuloy?</string>
     <string name="cancel">Kanselahin</string>
     <string name="whatsapp_cleaner">WhatsApp Cleaner</string>
+    <string name="whatsapp_cleaner_empty_message">Malinis na ang WhatsApp mo! Wala nang kailangang linisin. Enjoy sa araw mo!</string>
     <string name="total_files_format">%1$s na file</string>
     <string name="delete_selected">Burahin ang Napili</string>
     <string name="sort_options">Mga opsyon sa pagsasaayos</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Cela supprimera tous les fichiers médias WhatsApp. Continuer ?</string>
     <string name="cancel">Annuler</string>
     <string name="whatsapp_cleaner">Nettoyeur WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Votre WhatsApp est impeccable! Il n’y a plus rien à nettoyer. Bonne journée!</string>
     <string name="total_files_format">%1$s fichiers</string>
     <string name="delete_selected">Supprimer la sélection</string>
     <string name="sort_options">Options de tri</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">इससे सभी व्हाट्सएप मीडिया फ़ाइलें हट जाएँगी। आगे बढ़ें?</string>
     <string name="cancel">रद्द करें</string>
     <string name="whatsapp_cleaner">व्हाट्सएप क्लीनर</string>
+    <string name="whatsapp_cleaner_empty_message">आपका WhatsApp एकदम साफ है! अब कुछ भी साफ़ नहीं करना है। अपना दिन आनंद से बिताएँ!</string>
     <string name="total_files_format">%1$s फ़ाइलें</string>
     <string name="delete_selected">चयनित हटाएँ</string>
     <string name="sort_options">क्रमबद्ध विकल्प</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Ez törli az összes WhatsApp médiát. Folytatja?</string>
     <string name="cancel">Mégse</string>
     <string name="whatsapp_cleaner">WhatsApp Tisztító</string>
+    <string name="whatsapp_cleaner_empty_message">A WhatsApp-od makulátlan! Nincs mit törölni. Szép napot!</string>
     <string name="total_files_format">%1$s fájl</string>
     <string name="delete_selected">Kijelöltek törlése</string>
     <string name="sort_options">Rendezési beállítások</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">Ini akan menghapus semua file media WhatsApp. Lanjutkan?</string>
     <string name="cancel">Batal</string>
     <string name="whatsapp_cleaner">Pembersih WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp Anda bersih! Tidak ada lagi yang perlu dibersihkan. Nikmati hari Anda!</string>
     <string name="total_files_format">%1$s file</string>
     <string name="delete_selected">Hapus yang Dipilih</string>
     <string name="sort_options">Opsi urutan</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Questo eliminerà tutti i file multimediali di WhatsApp. Continuare?</string>
     <string name="cancel">Annulla</string>
     <string name="whatsapp_cleaner">Pulitore WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Il tuo WhatsApp è pulito! Non c’è più nulla da eliminare. Buona giornata!</string>
     <string name="total_files_format">%1$s file</string>
     <string name="delete_selected">Elimina selezionati</string>
     <string name="sort_options">Opzioni di ordinamento</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">すべてのWhatsAppメディアファイルを削除します。続けますか？</string>
     <string name="cancel">キャンセル</string>
     <string name="whatsapp_cleaner">WhatsAppクリーナー</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsAppがきれいになりました！もう掃除するものはありません。良い一日を！</string>
     <string name="total_files_format">%1$s 件のファイル</string>
     <string name="delete_selected">選択したものを削除</string>
     <string name="sort_options">並び替えオプション</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">모든 WhatsApp 미디어 파일이 삭제됩니다. 계속할까요?</string>
     <string name="cancel">취소</string>
     <string name="whatsapp_cleaner">WhatsApp 클리너</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp이 깔끔합니다! 더 이상 정리할 것이 없어요. 좋은 하루 보내세요!</string>
     <string name="total_files_format">%1$s개 파일</string>
     <string name="delete_selected">선택 삭제</string>
     <string name="sort_options">정렬 옵션</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -132,6 +132,7 @@
     <string name="clean_whatsapp_warning_message">Spowoduje to usunięcie wszystkich plików multimedialnych WhatsApp. Kontynuować?</string>
     <string name="cancel">Anuluj</string>
     <string name="whatsapp_cleaner">Czyścik WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Twój WhatsApp jest czysty! Nie ma już nic do czyszczenia. Miłego dnia!</string>
     <string name="total_files_format">%1$s plików</string>
     <string name="delete_selected">Usuń zaznaczone</string>
     <string name="sort_options">Opcje sortowania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Isso excluirá todos os arquivos de mídia do WhatsApp. Continuar?</string>
     <string name="cancel">Cancelar</string>
     <string name="whatsapp_cleaner">Limpador do WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Seu WhatsApp está limpo! Não há mais nada para limpar. Aproveite o seu dia!</string>
     <string name="total_files_format">%1$s arquivos</string>
     <string name="delete_selected">Excluir selecionados</string>
     <string name="sort_options">Opções de ordenação</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -129,6 +129,7 @@
     <string name="clean_whatsapp_warning_message">Aceasta va șterge toate fișierele media WhatsApp. Continui?</string>
     <string name="cancel">Anulează</string>
     <string name="whatsapp_cleaner">Curățător WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp-ul tău este impecabil! Nu mai ai ce curăța. Bucură-te de zi!</string>
     <string name="total_files_format">%1$s fișiere</string>
     <string name="delete_selected">Șterge selecția</string>
     <string name="sort_options">Opțiuni de sortare</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -132,6 +132,7 @@
     <string name="clean_whatsapp_warning_message">Это удалит все медиаданные WhatsApp. Продолжить?</string>
     <string name="cancel">Отмена</string>
     <string name="whatsapp_cleaner">Очистка WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Ваш WhatsApp идеально чист! Больше нечего удалять. Хорошего дня!</string>
     <string name="total_files_format">%1$s файлов</string>
     <string name="delete_selected">Удалить выбранные</string>
     <string name="sort_options">Параметры сортировки</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Detta tar bort alla WhatsApp-mediefiler. Fortsätta?</string>
     <string name="cancel">Avbryt</string>
     <string name="whatsapp_cleaner">WhatsApp-rensare</string>
+    <string name="whatsapp_cleaner_empty_message">Din WhatsApp är helt ren! Det finns inget mer att rensa. Ha en bra dag!</string>
     <string name="total_files_format">%1$s filer</string>
     <string name="delete_selected">Ta bort valda</string>
     <string name="sort_options">Sorteringsalternativ</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">การดำเนินการนี้จะลบไฟล์สื่อ WhatsApp ทั้งหมด ดำเนินการต่อหรือไม่?</string>
     <string name="cancel">ยกเลิก</string>
     <string name="whatsapp_cleaner">ตัวล้าง WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp ของคุณสะอาดหมดจด! ไม่มีอะไรให้ลบแล้ว ขอให้เป็นวันดีๆ!</string>
     <string name="total_files_format">%1$s ไฟล์</string>
     <string name="delete_selected">ลบที่เลือก</string>
     <string name="sort_options">ตัวเลือกการจัดเรียง</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">Bu işlem tüm WhatsApp medya dosyalarını silecek. Devam edilsin mi?</string>
     <string name="cancel">İptal</string>
     <string name="whatsapp_cleaner">WhatsApp Temizleyici</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp'ınız tertemiz! Temizlenecek bir şey kalmadı. İyi günler!</string>
     <string name="total_files_format">%1$s dosya</string>
     <string name="delete_selected">Seçilenleri Sil</string>
     <string name="sort_options">Sıralama seçenekleri</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -132,6 +132,7 @@
     <string name="clean_whatsapp_warning_message">Це видалить усі медіафайли WhatsApp. Продовжити?</string>
     <string name="cancel">Скасувати</string>
     <string name="whatsapp_cleaner">Очищувач WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">Ваш WhatsApp бездоганно чистий! Немає чого прибирати. Гарного дня!</string>
     <string name="total_files_format">%1$s файлів</string>
     <string name="delete_selected">Видалити вибране</string>
     <string name="sort_options">Параметри сортування</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">اس سے تمام واٹس ایپ میڈیا فائلیں حذف ہو جائیں گی۔ کیا جاری رکھیں؟</string>
     <string name="cancel">منسوخ کریں</string>
     <string name="whatsapp_cleaner">واٹس ایپ کلینر</string>
+    <string name="whatsapp_cleaner_empty_message">آپ کا واٹس ایپ بالکل صاف ہے! اب کچھ بھی صاف نہیں کرنا۔ اپنا دن اچھا گزاریں!</string>
     <string name="total_files_format">%1$s فائلیں</string>
     <string name="delete_selected">منتخب حذف کریں</string>
     <string name="sort_options">ترتیب کے اختیارات</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">Thao tác này sẽ xóa tất cả tệp phương tiện WhatsApp. Tiếp tục?</string>
     <string name="cancel">Hủy</string>
     <string name="whatsapp_cleaner">Trình dọn WhatsApp</string>
+    <string name="whatsapp_cleaner_empty_message">WhatsApp của bạn sạch bóng! Không còn gì để dọn. Chúc bạn một ngày vui vẻ!</string>
     <string name="total_files_format">%1$s tệp</string>
     <string name="delete_selected">Xóa mục đã chọn</string>
     <string name="sort_options">Tùy chọn sắp xếp</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -123,6 +123,7 @@
     <string name="clean_whatsapp_warning_message">這將刪除所有 WhatsApp 媒體檔案。是否繼續？</string>
     <string name="cancel">取消</string>
     <string name="whatsapp_cleaner">WhatsApp 清理工具</string>
+    <string name="whatsapp_cleaner_empty_message">你的 WhatsApp 乾淨如新！沒有東西可清理。祝你有美好的一天！</string>
     <string name="total_files_format">%1$s 個檔案</string>
     <string name="delete_selected">刪除已選</string>
     <string name="sort_options">排序選項</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="clean_whatsapp_warning_message">This will delete all WhatsApp media files. Continue?</string>
     <string name="cancel">Cancel</string>
     <string name="whatsapp_cleaner">WhatsApp Cleaner</string>
+    <string name="whatsapp_cleaner_empty_message">Your WhatsApp is spotless! There’s nothing left to clean. Enjoy your day!</string>
     <string name="total_files_format">%1$s files</string>
     <string name="delete_selected">Delete Selected</string>
     <string name="sort_options">Sort options</string>


### PR DESCRIPTION
## Summary
- add `WhatsAppEmptyState` composable with finish animation and ad banner
- show new empty state on WhatsApp Cleaner summary screen when there are no files
- trigger `ScreenState.NoData` in view model when summary has no data
- add string resource for the friendly empty message

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687368ecf7f8832dae05ea57a60f71e1