### PR TITLE
Refactor startOfNextWeek with java.time

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -1087,16 +1087,11 @@ class ScannerViewModel(
     }
 
     private fun startOfNextWeek(): Long {
-        val cal = java.util.Calendar.getInstance()
-        val dayOfWeek = cal.get(java.util.Calendar.DAY_OF_WEEK)
-        var daysUntilMonday = (java.util.Calendar.MONDAY - dayOfWeek + 7) % 7
-        if (daysUntilMonday == 0) daysUntilMonday = 7
-        cal.add(java.util.Calendar.DAY_OF_YEAR, daysUntilMonday)
-        cal.set(java.util.Calendar.HOUR_OF_DAY, 0)
-        cal.set(java.util.Calendar.MINUTE, 0)
-        cal.set(java.util.Calendar.SECOND, 0)
-        cal.set(java.util.Calendar.MILLISECOND, 0)
-        return cal.timeInMillis
+        return java.time.LocalDate.now()
+            .with(java.time.temporal.TemporalAdjusters.next(java.time.DayOfWeek.MONDAY))
+            .atStartOfDay(java.time.ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
     }
 
     fun onClipboardClear() {

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -1087,11 +1087,24 @@ class ScannerViewModel(
     }
 
     private fun startOfNextWeek(): Long {
-        return java.time.LocalDate.now()
-            .with(java.time.temporal.TemporalAdjusters.next(java.time.DayOfWeek.MONDAY))
-            .atStartOfDay(java.time.ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            java.time.LocalDate.now()
+                .with(java.time.temporal.TemporalAdjusters.next(java.time.DayOfWeek.MONDAY))
+                .atStartOfDay(java.time.ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
+        } else {
+            val cal = java.util.Calendar.getInstance()
+            val dayOfWeek = cal.get(java.util.Calendar.DAY_OF_WEEK)
+            var daysUntilMonday = (java.util.Calendar.MONDAY - dayOfWeek + 7) % 7
+            if (daysUntilMonday == 0) daysUntilMonday = 7
+            cal.add(java.util.Calendar.DAY_OF_YEAR, daysUntilMonday)
+            cal.set(java.util.Calendar.HOUR_OF_DAY, 0)
+            cal.set(java.util.Calendar.MINUTE, 0)
+            cal.set(java.util.Calendar.SECOND, 0)
+            cal.set(java.util.Calendar.MILLISECOND, 0)
+            cal.timeInMillis
+        }
     }
 
     fun onClipboardClear() {


### PR DESCRIPTION
## Summary
- refactor `startOfNextWeek()` to use `java.time` for clarity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687564c81964832d9a92509189a27baa