### PR TITLE
Fix streak reminder timeframe calculation

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/notifications/work/StreakReminderWorker.kt
@@ -28,12 +28,10 @@ class StreakReminderWorker(
 
         val lastClean = dataStore.lastCleanDay.first()
         val streak = dataStore.streakCount.first()
-        val today = System.currentTimeMillis() / TimeConstants.DAY_MS
-        val lastDay = lastClean / TimeConstants.DAY_MS
-        val diff = today - lastDay
+        val diffMs = System.currentTimeMillis() - lastClean
 
         val message = when {
-            diff >= 1 -> applicationContext.getString(R.string.streak_notification_missed)
+            diffMs >= TimeConstants.DAY_MS -> applicationContext.getString(R.string.streak_notification_missed)
             streak >= 3 && streak <= 7 -> applicationContext.getString(
                 R.string.streak_notification_milestone_format,
                 streak


### PR DESCRIPTION
## Summary
- ensure StreakReminderWorker uses millisecond diff instead of day truncation

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875691215b4832d8b4de511e0535201