### PR TITLE
Use lazy transitions in badges and digits

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/apps/manager/ui/AppManagerScreen.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -60,6 +62,18 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
+
+object AppManagerBadgeTransitions {
+    private val fadeScaleSpec = tween<Float>(durationMillis = 500)
+
+    val enter: EnterTransition by lazy {
+        fadeIn(animationSpec = fadeScaleSpec) + scaleIn(animationSpec = fadeScaleSpec)
+    }
+
+    val exit: ExitTransition by lazy {
+        fadeOut() + scaleOut()
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -174,9 +188,8 @@ fun AppManagerScreenContent(viewModel : AppManagerViewModel , screenData : UiApp
                             }
                             AnimatedVisibility(
                                 visible = badgeVisible.value,
-                                enter = fadeIn(animationSpec = tween(durationMillis = 500)) +
-                                        scaleIn(animationSpec = tween(durationMillis = 500)),
-                                exit = fadeOut() + scaleOut()
+                                enter = AppManagerBadgeTransitions.enter,
+                                exit = AppManagerBadgeTransitions.exit
                             ) {
                                 Badge(
                                     modifier = Modifier.animateContentSize()

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/ui/digits/AnimatedDigit.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/ui/digits/AnimatedDigit.kt
@@ -1,6 +1,7 @@
 package com.d4rk.cleaner.core.ui.digits
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -16,6 +17,26 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.material3.LocalContentColor
 
+object AnimatedDigitTransitions {
+    private val animationSpec = tween<Int>(durationMillis = 400)
+
+    val increase: ContentTransform by lazy {
+        (slideInVertically(animationSpec = animationSpec) { fullHeight: Int -> -fullHeight } +
+            fadeIn(animationSpec = animationSpec)).togetherWith(
+            slideOutVertically(animationSpec = animationSpec) { fullHeight: Int -> fullHeight } +
+                fadeOut(animationSpec = animationSpec)
+        ).using(SizeTransform(clip = false))
+    }
+
+    val decrease: ContentTransform by lazy {
+        (slideInVertically(animationSpec = animationSpec) { fullHeight: Int -> fullHeight } +
+            fadeIn(animationSpec = animationSpec)).togetherWith(
+            slideOutVertically(animationSpec = animationSpec) { fullHeight: Int -> -fullHeight } +
+                fadeOut(animationSpec = animationSpec)
+        ).using(SizeTransform(clip = false))
+    }
+}
+
 @Composable
 fun AnimatedDigit(
     digit: Char,
@@ -26,26 +47,10 @@ fun AnimatedDigit(
         targetState = digit,
         transitionSpec = {
             if (targetState > initialState) {
-                (slideInVertically(
-                    animationSpec = tween(durationMillis = 400),
-                    initialOffsetY = { fullHeight: Int -> -fullHeight }
-                ) + fadeIn(animationSpec = tween(durationMillis = 400))).togetherWith(
-                    slideOutVertically(
-                        animationSpec = tween(durationMillis = 400),
-                        targetOffsetY = { fullHeight: Int -> fullHeight }
-                    ) + fadeOut(animationSpec = tween(durationMillis = 400))
-                )
+                AnimatedDigitTransitions.increase
             } else {
-                (slideInVertically(
-                    animationSpec = tween(durationMillis = 400),
-                    initialOffsetY = { fullHeight: Int -> fullHeight }
-                ) + fadeIn(animationSpec = tween(durationMillis = 400))).togetherWith(
-                    slideOutVertically(
-                        animationSpec = tween(durationMillis = 400),
-                        targetOffsetY = { fullHeight: Int -> -fullHeight }
-                    ) + fadeOut(animationSpec = tween(durationMillis = 400))
-                )
-            }.using(sizeTransform = SizeTransform(clip = false))
+                AnimatedDigitTransitions.decrease
+            }
         }
     ) { targetDigit: Char ->
         CompositionLocalProvider(LocalContentColor provides color) {


### PR DESCRIPTION
## Summary
- create `AnimatedDigitTransitions` for digit animations
- create `AppManagerBadgeTransitions` for the animated badge
- hook the new lazy transitions into `AnimatedDigit` and badges

## Testing
- `./gradlew help --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68761469f8b8832dac2a49faa2485bd9