### PR TITLE
Add reusable transitions for dashboard and select-all

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/SelectAllComposable.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/SelectAllComposable.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.cleaner.R
+import com.d4rk.cleaner.app.clean.analyze.ui.components.SelectAllTransitions
 
 /**
  * Composable function for selecting or deselecting all items.
@@ -53,7 +54,8 @@ fun SelectAllComposable(
             label = { Text(text = stringResource(id = R.string.select_all)) } ,
             leadingIcon = {
                 AnimatedContent(
-                    targetState = selected , label = "Checkmark Animation"
+                    targetState = selected,
+                    transitionSpec = { SelectAllTransitions.fadeScale } , label = "Checkmark Animation"
                 ) { targetChecked ->
                     if (targetChecked) {
                         Icon(

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/SelectAllTransitions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/analyze/ui/components/SelectAllTransitions.kt
@@ -1,0 +1,19 @@
+package com.d4rk.cleaner.app.clean.analyze.ui.components
+
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.togetherWith
+
+object SelectAllTransitions {
+    private const val DURATION = 300
+    private val fadeScaleSpec = tween<Float>(DURATION)
+
+    val fadeScale: ContentTransform by lazy {
+        (fadeIn(animationSpec = fadeScaleSpec) + scaleIn(animationSpec = fadeScaleSpec))
+            .togetherWith(fadeOut(animationSpec = fadeScaleSpec) + scaleOut(animationSpec = fadeScaleSpec))
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/DashboardTransitions.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/DashboardTransitions.kt
@@ -1,0 +1,18 @@
+package com.d4rk.cleaner.app.clean.dashboard.ui
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+
+object DashboardTransitions {
+    val enter: EnterTransition by lazy {
+        fadeIn() + expandVertically()
+    }
+
+    val exit: ExitTransition by lazy {
+        fadeOut() + shrinkVertically()
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/dashboard/ui/ScannerDashboardScreen.kt
@@ -3,10 +3,6 @@ package com.d4rk.cleaner.app.clean.dashboard.ui
 import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -42,6 +38,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.cleaner.R
 import com.d4rk.cleaner.app.apps.manager.domain.data.model.ui.UiAppManagerModel
 import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
+import com.d4rk.cleaner.app.clean.dashboard.ui.DashboardTransitions
 import com.d4rk.cleaner.app.clean.scanner.domain.actions.ScannerEvent
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningState
 import com.d4rk.cleaner.app.clean.scanner.domain.data.model.ui.CleaningType
@@ -187,8 +184,8 @@ fun ScannerDashboardScreen(
         val quickScanIndex = nextIndex()
         AnimatedVisibility(
             visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             QuickScanSummaryCard(
                 modifier = Modifier.animateVisibility(
@@ -204,8 +201,8 @@ fun ScannerDashboardScreen(
         if (showStreakCard) {
             AnimatedVisibility(
                 visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val streakIndex = nextIndex()
                 WeeklyCleanStreakCard(
@@ -219,8 +216,8 @@ fun ScannerDashboardScreen(
         else if (streakHideUntil > System.currentTimeMillis()) {
             AnimatedVisibility(
                 visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 OutlinedCard(
                     modifier = Modifier.fillMaxWidth() , shape = RoundedCornerShape(SizeConstants.ExtraLargeSize)
@@ -239,8 +236,8 @@ fun ScannerDashboardScreen(
 
         AnimatedVisibility(
             visible = showAdTop,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             AdBanner(
                 adsConfig = topAdConfig
@@ -250,8 +247,8 @@ fun ScannerDashboardScreen(
         if (showWhatsAppCard) {
             AnimatedVisibility(
                 visible = showWhatsAppCard,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val whatsappIndex = nextIndex()
                 WhatsAppCleanerCard(
@@ -271,8 +268,8 @@ fun ScannerDashboardScreen(
         if (showApkCard) {
             AnimatedVisibility(
                 visible = showApkCard,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val isCleaningApks = uiState.data?.analyzeState?.state == CleaningState.Cleaning && uiState.data?.analyzeState?.cleaningType == CleaningType.DELETE && uiState.data?.analyzeState?.isAnalyzeScreenVisible == false
                 val apkIndex = nextIndex()
@@ -292,8 +289,8 @@ fun ScannerDashboardScreen(
         if (showClipboardCard) {
             AnimatedVisibility(
                 visible = showClipboardCard,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val clipboardIndex = nextIndex()
                 ClipboardCleanerCard(
@@ -309,8 +306,8 @@ fun ScannerDashboardScreen(
         if (showLargeFilesCard) {
             AnimatedVisibility(
                 visible = showLargeFilesCard,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val largeFilesIndex = nextIndex()
                 LargeFilesCard(
@@ -332,8 +329,8 @@ fun ScannerDashboardScreen(
 
         AnimatedVisibility(
             visible = showAdMid,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             AdBanner(
                 adsConfig = midAdConfig
@@ -343,8 +340,8 @@ fun ScannerDashboardScreen(
         val imageOptimizerIndex = nextIndex()
         AnimatedVisibility(
             visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             ImageOptimizerCard(
                 modifier = Modifier.animateVisibility(
@@ -361,8 +358,8 @@ fun ScannerDashboardScreen(
         val cacheIndex = nextIndex()
         AnimatedVisibility(
             visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             CacheCleanerCard(
                 modifier = Modifier.animateVisibility(
@@ -377,8 +374,8 @@ fun ScannerDashboardScreen(
         promotedApp?.let { app ->
             AnimatedVisibility(
                 visible = uiState.data?.analyzeState?.isAnalyzeScreenVisible == false,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
+                enter = DashboardTransitions.enter,
+                exit = DashboardTransitions.exit
             ) {
                 val promotedIndex = nextIndex()
                 PromotedAppCard(modifier = Modifier.animateVisibility(
@@ -390,8 +387,8 @@ fun ScannerDashboardScreen(
 
         AnimatedVisibility(
             visible = showAdEnd,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically()
+            enter = DashboardTransitions.enter,
+            exit = DashboardTransitions.exit
         ) {
             AdBanner(
                 adsConfig = endAdConfig


### PR DESCRIPTION
## Summary
- introduce `DashboardTransitions` for dashboard item visibility
- create `SelectAllTransitions` for select all toggle animation
- apply new transitions to `ScannerDashboardScreen`
- use `SelectAllTransitions` in `SelectAllComposable`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761cd175dc832dbed91fd5bd206b65