### PR TITLE
Add localized strings for Move and Clean All

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -78,6 +78,8 @@
     <string name="delete_forever_message">متأكد إنك عايز تحذف الملفات دي بشكل نهائي؟ الخطوة دي مش هينفع ترجع فيها.</string>
     <string name="move_to_trash_title">نقل لسلة المهملات</string>
     <string name="move_to_trash_message">متأكد إنك عايز تنقل الملفات دي لسلة المهملات؟</string>
+    <string name="moving">نقل</string>
+    <string name="clean_all">تنظيف الكل</string>
     <string name="quick_scan">فحص سريع</string>
     <string name="quick_scan_cleaned_format">لقد نظفت %1$s هذا الأسبوع</string>
     <string name="quick_scan_summary_tip">تبدو الأمور جيدة! هل تريد الفحص مجددًا للمزيد من المساحة؟</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Сигурни ли сте, че искате да изтриете тези файлове завинаги? Това действие не може да бъде отменено.</string>
     <string name="move_to_trash_title">Преместване в кошчето</string>
     <string name="move_to_trash_message">Сигурни ли сте, че искате да преместите тези файлове в кошчето?</string>
+    <string name="moving">Премести</string>
+    <string name="clean_all">Изчисти всичко</string>
     <string name="quick_scan">Бързо сканиране</string>
     <string name="quick_scan_cleaned_format">Изчистихте %1$s тази седмица</string>
     <string name="quick_scan_summary_tip">Изглежда добре! Искате ли да сканирате отново за още място?</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">আপনি কি নিশ্চিত যে এই ফাইলগুলি চিরতরে মুছতে চান? এই কাজটি আর ফেরানো যাবে না।</string>
     <string name="move_to_trash_title">ট্র্যাশে সরান</string>
     <string name="move_to_trash_message">আপনি কি নিশ্চিত যে এই ফাইলগুলি ট্র্যাশে সরাতে চান?</string>
+    <string name="moving">সরান</string>
+    <string name="clean_all">সব পরিষ্কার করুন</string>
     <string name="quick_scan">দ্রুত স্ক্যান</string>
     <string name="quick_scan_cleaned_format">আপনি এই সপ্তাহে %1$s পরিষ্কার করেছেন</string>
     <string name="quick_scan_summary_tip">দারুন দেখাচ্ছে! আরও জায়গা পাওয়ার জন্য আবার স্ক্যান করবেন?</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Sind Sie sicher, dass Sie diese Dateien endgültig löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="move_to_trash_title">In den Papierkorb verschieben</string>
     <string name="move_to_trash_message">Möchten Sie diese Dateien wirklich in den Papierkorb verschieben?</string>
+    <string name="moving">Verschieben</string>
+    <string name="clean_all">Alles bereinigen</string>
     <string name="quick_scan">Schnellscan</string>
     <string name="quick_scan_cleaned_format">Du hast diese Woche %1$s bereinigt</string>
     <string name="quick_scan_summary_tip">Sieht gut aus! Nochmals scannen für mehr Platz?</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">¿Estás seguro de que quieres eliminar estos archivos para siempre? Esta acción no se puede deshacer.</string>
     <string name="move_to_trash_title">Mover a la papelera</string>
     <string name="move_to_trash_message">¿Estás seguro de que quieres mover estos archivos a la papelera?</string>
+    <string name="moving">Mover</string>
+    <string name="clean_all">Limpiar todo</string>
     <string name="quick_scan">Análisis rápido</string>
     <string name="quick_scan_cleaned_format">Has limpiado %1$s esta semana</string>
     <string name="quick_scan_summary_tip">¡Todo se ve bien! ¿Quieres escanear de nuevo para liberar espacio?</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">¿Estás seguro/a de que quieres eliminar estos archivos para siempre? Esta acción no se puede deshacer.</string>
     <string name="move_to_trash_title">Mover a la papelera</string>
     <string name="move_to_trash_message">¿Estás seguro/a de que quieres mover estos archivos a la papelera?</string>
+    <string name="moving">Mover</string>
+    <string name="clean_all">Limpiar todo</string>
     <string name="quick_scan">Escaneo rápido</string>
     <string name="quick_scan_cleaned_format">Limpiaste %1$s esta semana</string>
     <string name="quick_scan_summary_tip">¡Se ve bien! ¿Quieres escanear de nuevo para liberar más espacio?</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Sigurado ka bang gusto mong burahin ang mga file na ito nang tuluyan? Hindi na maibabalik ang aksyong ito.</string>
     <string name="move_to_trash_title">Ilipat sa Trash</string>
     <string name="move_to_trash_message">Sigurado ka bang gusto mong ilipat ang mga file na ito sa trash?</string>
+    <string name="moving">Ilipat</string>
+    <string name="clean_all">I-clear Lahat</string>
     <string name="quick_scan">Mabilisang Scan</string>
     <string name="quick_scan_cleaned_format">Nilinis mo ang %1$s ngayong linggo</string>
     <string name="quick_scan_summary_tip">Mukhang maayos! Gusto mo bang mag-scan ulit para sa dagdag na espasyo?</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">Êtes-vous sûr de vouloir supprimer définitivement ces fichiers ? Cette action est irréversible.</string>
     <string name="move_to_trash_title">Mettre à la corbeille</string>
     <string name="move_to_trash_message">Êtes-vous sûr de vouloir mettre ces fichiers à la corbeille ?</string>
+    <string name="moving">Déplacer</string>
+    <string name="clean_all">Tout nettoyer</string>
     <string name="quick_scan">Analyse rapide</string>
     <string name="quick_scan_cleaned_format">Vous avez nettoyé %1$s cette semaine</string>
     <string name="quick_scan_summary_tip">C\'est bien ! Vous voulez scanner à nouveau pour gagner plus d\'espace ?</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">क्या आप वाकई इन फ़ाइलों को हमेशा के लिए हटाना चाहते हैं? यह कार्रवाई पूर्ववत नहीं की जा सकती।</string>
     <string name="move_to_trash_title">ट्रैश में ले जाएं</string>
     <string name="move_to_trash_message">क्या आप वाकई इन फ़ाइलों को ट्रैश में ले जाना चाहते हैं?</string>
+    <string name="moving">स्थानांतरित करें</string>
+    <string name="clean_all">सभी साफ़ करें</string>
     <string name="quick_scan">त्वरित स्कैन</string>
     <string name="quick_scan_cleaned_format">आपने इस हफ्ते %1$s साफ़ किया</string>
     <string name="quick_scan_summary_tip">सब अच्छा लग रहा है! अतिरिक्त जगह के लिए फिर से स्कैन करना चाहेंगे?</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Biztosan véglegesen törölni szeretnéd ezeket a fájlokat? Ez a művelet nem vonható vissza.</string>
     <string name="move_to_trash_title">Áthelyezés a kukába</string>
     <string name="move_to_trash_message">Biztosan át szeretnéd helyezni ezeket a fájlokat a kukába?</string>
+    <string name="moving">Áthelyezés</string>
+    <string name="clean_all">Mindent tisztíts</string>
     <string name="quick_scan">Gyors vizsgálat</string>
     <string name="quick_scan_cleaned_format">Ezen a héten %1$s-t tisztítottál</string>
     <string name="quick_scan_summary_tip">Jól néz ki! Újraszkenneljük extra helyért?</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">Apakah Anda yakin ingin menghapus file-file ini selamanya? Tindakan ini tidak dapat dibatalkan.</string>
     <string name="move_to_trash_title">Pindahkan ke Sampah</string>
     <string name="move_to_trash_message">Apakah Anda yakin ingin memindahkan file-file ini ke sampah?</string>
+    <string name="moving">Pindahkan</string>
+    <string name="clean_all">Bersihkan Semua</string>
     <string name="quick_scan">Pindai Cepat</string>
     <string name="quick_scan_cleaned_format">Kamu membersihkan %1$s minggu ini</string>
     <string name="quick_scan_summary_tip">Kelihatan bagus! Ingin memindai lagi untuk ruang ekstra?</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">Sei sicuro di voler eliminare questi file definitivamente? Questa azione non può essere annullata.</string>
     <string name="move_to_trash_title">Sposta nel cestino</string>
     <string name="move_to_trash_message">Sei sicuro di voler spostare questi file nel cestino?</string>
+    <string name="moving">Sposta</string>
+    <string name="clean_all">Pulisci tutto</string>
     <string name="quick_scan">Scansione rapida</string>
     <string name="quick_scan_cleaned_format">Hai pulito %1$s questa settimana</string>
     <string name="quick_scan_summary_tip">Tutto bene! Vuoi scansionare di nuovo per liberare spazio?</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">これらのファイルを完全に削除しますか？この操作は元に戻せません。</string>
     <string name="move_to_trash_title">ゴミ箱に移動</string>
     <string name="move_to_trash_message">これらのファイルをゴミ箱に移動しますか？</string>
+    <string name="moving">移動</string>
+    <string name="clean_all">すべてクリーン</string>
     <string name="quick_scan">クイックスキャン</string>
     <string name="quick_scan_cleaned_format">今週は %1$s をクリーンしました</string>
     <string name="quick_scan_summary_tip">いい感じです！ さらに空き容量を探してもう一度スキャンしますか？</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">이 파일을 영구적으로 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
     <string name="move_to_trash_title">휴지통으로 이동</string>
     <string name="move_to_trash_message">이 파일을 휴지통으로 이동하시겠습니까?</string>
+    <string name="moving">이동</string>
+    <string name="clean_all">모두 정리</string>
     <string name="quick_scan">빠른 검사</string>
     <string name="quick_scan_cleaned_format">이번 주에 %1$s을(를) 정리했어요</string>
     <string name="quick_scan_summary_tip">좋아 보이네요! 공간 확보를 위해 다시 스캔할까요?</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -76,6 +76,8 @@
     <string name="delete_forever_message">Czy na pewno chcesz usunąć te pliki na zawsze? Tej czynności nie można cofnąć.</string>
     <string name="move_to_trash_title">Przenieś do kosza</string>
     <string name="move_to_trash_message">Czy na pewno chcesz przenieść te pliki do kosza?</string>
+    <string name="moving">Przenieś</string>
+    <string name="clean_all">Wyczyść wszystko</string>
     <string name="quick_scan">Szybkie skanowanie</string>
     <string name="quick_scan_cleaned_format">Wyczyściłeś %1$s w tym tygodniu</string>
     <string name="quick_scan_summary_tip">Wygląda dobrze! Zeskanować ponownie, by zwolnić więcej miejsca?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">Tem certeza de que deseja excluir esses arquivos para sempre? Esta ação não pode ser desfeita.</string>
     <string name="move_to_trash_title">Mover para a Lixeira</string>
     <string name="move_to_trash_message">Tem certeza de que deseja mover esses arquivos para a lixeira?</string>
+    <string name="moving">Mover</string>
+    <string name="clean_all">Limpar Tudo</string>
     <string name="quick_scan">Verificação Rápida</string>
     <string name="quick_scan_cleaned_format">Você limpou %1$s esta semana</string>
     <string name="quick_scan_summary_tip">Tudo certo! Quer escanear de novo para liberar espaço?</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -75,6 +75,8 @@
     <string name="delete_forever_message">Sigur doriți să ștergeți aceste fișiere definitiv? Această acțiune nu poate fi anulată.</string>
     <string name="move_to_trash_title">Mută în coș</string>
     <string name="move_to_trash_message">Sigur doriți să mutați aceste fișiere în coș?</string>
+    <string name="moving">Mută</string>
+    <string name="clean_all">Curăță tot</string>
     <string name="quick_scan">Scanare rapidă</string>
     <string name="quick_scan_cleaned_format">Ai curățat %1$s în această săptămână</string>
     <string name="quick_scan_summary_tip">Arată bine! Vrei să scanezi din nou pentru spațiu suplimentar?</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -76,6 +76,8 @@
     <string name="delete_forever_message">Вы уверены, что хотите удалить эти файлы навсегда? Это действие нельзя отменить.</string>
     <string name="move_to_trash_title">Переместить в корзину</string>
     <string name="move_to_trash_message">Вы уверены, что хотите переместить эти файлы в корзину?</string>
+    <string name="moving">Переместить</string>
+    <string name="clean_all">Очистить всё</string>
     <string name="quick_scan">Быстрое сканирование</string>
     <string name="quick_scan_cleaned_format">Вы очистили %1$s на этой неделе</string>
     <string name="quick_scan_summary_tip">Всё отлично! Сканируем ещё раз для большего пространства?</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Är du säker på att du vill radera dessa filer permanent? Denna åtgärd kan inte ångras.</string>
     <string name="move_to_trash_title">Flytta till papperskorgen</string>
     <string name="move_to_trash_message">Är du säker på att du vill flytta dessa filer till papperskorgen?</string>
+    <string name="moving">Flytta</string>
+    <string name="clean_all">Rensa allt</string>
     <string name="quick_scan">Snabbskanning</string>
     <string name="quick_scan_cleaned_format">Du rensade %1$s den här veckan</string>
     <string name="quick_scan_summary_tip">Ser bra ut! Vill du skanna igen för extra utrymme?</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">คุณแน่ใจหรือไม่ว่าต้องการลบไฟล์เหล่านี้อย่างถาวร? การกระทำนี้ไม่สามารถเลิกทำได้</string>
     <string name="move_to_trash_title">ย้ายไปที่ถังขยะ</string>
     <string name="move_to_trash_message">คุณแน่ใจหรือไม่ว่าต้องการย้ายไฟล์เหล่านี้ไปที่ถังขยะ?</string>
+    <string name="moving">ย้าย</string>
+    <string name="clean_all">ล้างทั้งหมด</string>
     <string name="quick_scan">สแกนด่วน</string>
     <string name="quick_scan_cleaned_format">คุณทำความสะอาด %1$s ในสัปดาห์นี้</string>
     <string name="quick_scan_summary_tip">ดูดีมาก! ต้องการสแกนอีกครั้งเพื่อเพิ่มพื้นที่ไหม?</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">Bu dosyaları kalıcı olarak silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.</string>
     <string name="move_to_trash_title">Çöp Kutusuna Taşı</string>
     <string name="move_to_trash_message">Bu dosyaları çöp kutusuna taşımak istediğinizden emin misiniz?</string>
+    <string name="moving">Taşı</string>
+    <string name="clean_all">Hepsini Temizle</string>
     <string name="quick_scan">Hızlı Tarama</string>
     <string name="quick_scan_cleaned_format">Bu hafta %1$s temizledin</string>
     <string name="quick_scan_summary_tip">İyi görünüyor! Daha fazla alan için tekrar taramak ister misin?</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -76,6 +76,8 @@
     <string name="delete_forever_message">Ви впевнені, що хочете видалити ці файли назавжди? Цю дію неможливо скасувати.</string>
     <string name="move_to_trash_title">Перемістити до кошика</string>
     <string name="move_to_trash_message">Ви впевнені, що хочете перемістити ці файли до кошика?</string>
+    <string name="moving">Перемістити</string>
+    <string name="clean_all">Очистити все</string>
     <string name="quick_scan">Швидке сканування</string>
     <string name="quick_scan_cleaned_format">Ви очистили %1$s цього тижня</string>
     <string name="quick_scan_summary_tip">Все виглядає добре! Бажаєте просканувати ще раз для додаткового місця?</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -74,6 +74,8 @@
     <string name="delete_forever_message">کیا آپ واقعی ان فائلوں کو ہمیشہ کے لیے حذف کرنا چاہتے ہیں؟ اس کارروائی کو واپس نہیں کیا جا سکتا۔</string>
     <string name="move_to_trash_title">ردی کی ٹوکری میں منتقل کریں</string>
     <string name="move_to_trash_message">کیا آپ واقعی ان فائلوں کو ردی کی ٹوکری میں منتقل کرنا چاہتے ہیں؟</string>
+    <string name="moving">منتقل کریں</string>
+    <string name="clean_all">سب صاف کریں</string>
     <string name="quick_scan">فوری اسکین</string>
     <string name="quick_scan_cleaned_format">آپ نے اس ہفتے %1$s صاف کیا</string>
     <string name="quick_scan_summary_tip">سب ٹھیک لگ رہا ہے! مزید جگہ کے لیے دوبارہ اسکین کرنا چاہیں؟</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">Bạn có chắc chắn muốn xóa vĩnh viễn các tệp này không? Hành động này không thể hoàn tác.</string>
     <string name="move_to_trash_title">Chuyển vào thùng rác</string>
     <string name="move_to_trash_message">Bạn có chắc chắn muốn chuyển các tệp này vào thùng rác không?</string>
+    <string name="moving">Di chuyển</string>
+    <string name="clean_all">Dọn sạch tất cả</string>
     <string name="quick_scan">Quét nhanh</string>
     <string name="quick_scan_cleaned_format">Bạn đã dọn %1$s tuần này</string>
     <string name="quick_scan_summary_tip">Trông ổn! Quét lại để có thêm dung lượng nhé?</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -73,6 +73,8 @@
     <string name="delete_forever_message">您確定要永久刪除這些檔案嗎？此操作無法復原。</string>
     <string name="move_to_trash_title">移至垃圾桶</string>
     <string name="move_to_trash_message">您確定要將這些檔案移至垃圾桶嗎？</string>
+    <string name="moving">移動</string>
+    <string name="clean_all">全部清理</string>
     <string name="quick_scan">快速掃描</string>
     <string name="quick_scan_cleaned_format">你本週已清理 %1$s</string>
     <string name="quick_scan_summary_tip">看起來不錯！再掃描一次多釋出空間？</string>


### PR DESCRIPTION
## Summary
- add translations for new `moving` and `clean_all` strings across all locales

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687961b04520832da58d75de543edb00