### PR TITLE
Refactor ContactsCleaner to MVVM use-case pattern

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/DeleteOlderContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/DeleteOlderContactsUseCase.kt
@@ -1,0 +1,17 @@
+package com.d4rk.cleaner.app.clean.contacts.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
+import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class DeleteOlderContactsUseCase(private val repository: ContactsRepository) {
+    operator fun invoke(group: List<RawContactInfo>): Flow<DataState<Unit, Errors>> = flow {
+        runCatching { repository.deleteOlder(group) }
+            .onSuccess { emit(DataState.Success(Unit)) }
+            .onFailure { emit(DataState.Error(error = it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/GetDuplicateContactsUseCase.kt
@@ -1,0 +1,18 @@
+package com.d4rk.cleaner.app.clean.contacts.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
+import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class GetDuplicateContactsUseCase(private val repository: ContactsRepository) {
+    operator fun invoke(): Flow<DataState<List<List<RawContactInfo>>, Errors>> = flow {
+        emit(DataState.Loading())
+        runCatching { repository.findDuplicates() }
+            .onSuccess { emit(DataState.Success(it)) }
+            .onFailure { emit(DataState.Error(error = it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/MergeContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/MergeContactsUseCase.kt
@@ -1,0 +1,17 @@
+package com.d4rk.cleaner.app.clean.contacts.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
+import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class MergeContactsUseCase(private val repository: ContactsRepository) {
+    operator fun invoke(group: List<RawContactInfo>): Flow<DataState<Unit, Errors>> = flow {
+        runCatching { repository.mergeContacts(group) }
+            .onSuccess { emit(DataState.Success(Unit)) }
+            .onFailure { emit(DataState.Error(error = it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
@@ -5,16 +5,22 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.DeleteOlderContactsUseCase
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.GetDuplicateContactsUseCase
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.MergeContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.domain.actions.ContactsCleanerAction
 import com.d4rk.cleaner.app.clean.contacts.domain.actions.ContactsCleanerEvent
 import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
 import com.d4rk.cleaner.app.clean.contacts.domain.data.model.UiContactsCleanerModel
+import com.d4rk.cleaner.core.utils.extensions.asUiText
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 
 class ContactsCleanerViewModel(
-    private val repository: ContactsRepository,
+    private val getDuplicatesUseCase: GetDuplicateContactsUseCase,
+    private val deleteOlderUseCase: DeleteOlderContactsUseCase,
+    private val mergeContactsUseCase: MergeContactsUseCase,
     private val dispatchers: DispatcherProvider
 ) : ScreenViewModel<UiContactsCleanerModel, ContactsCleanerEvent, ContactsCleanerAction>(
     initialState = UiStateScreen(data = UiContactsCleanerModel())
@@ -32,43 +38,60 @@ class ContactsCleanerViewModel(
 
     private fun loadDuplicates() {
         launch(context = dispatchers.io) {
-            _uiState.update { it.copy(screenState = ScreenState.IsLoading()) }
-
-            runCatching { repository.findDuplicates() }
-                .onSuccess { groups ->
-                    println("groups.isEmpty() = ${groups.isEmpty()}")
-                    _uiState.update {
-                        it.copy(
-                            screenState = if (groups.isEmpty()) ScreenState.NoData() else ScreenState.Success(),
-                            data = UiContactsCleanerModel(groups)
+            getDuplicatesUseCase().collectLatest { result ->
+                _uiState.update { current ->
+                    when (result) {
+                        is DataState.Loading -> current.copy(screenState = ScreenState.IsLoading())
+                        is DataState.Success -> current.copy(
+                            screenState = if (result.data.isEmpty()) ScreenState.NoData() else ScreenState.Success(),
+                            data = UiContactsCleanerModel(result.data)
                         )
-                    }
-                }
-                .onFailure { e ->
-                    _uiState.update {
-                        it.copy(
+                        is DataState.Error -> current.copy(
                             screenState = ScreenState.Error(),
-                            errors = it.errors + UiSnackbar(
-                                message = UiTextHelper.DynamicString(e.message ?: "error"),
+                            errors = current.errors + UiSnackbar(
+                                message = result.error.asUiText(),
                                 isError = true
                             )
                         )
                     }
                 }
+            }
         }
     }
 
     private fun deleteOlder(group: List<RawContactInfo>) {
         launch(context = dispatchers.io) {
-            repository.deleteOlder(group)
-            onEvent(ContactsCleanerEvent.LoadDuplicates)
+            deleteOlderUseCase(group).collectLatest { result ->
+                if (result is DataState.Error) {
+                    _uiState.update { current ->
+                        current.copy(
+                            errors = current.errors + UiSnackbar(
+                                message = result.error.asUiText(),
+                                isError = true
+                            )
+                        )
+                    }
+                }
+                onEvent(ContactsCleanerEvent.LoadDuplicates)
+            }
         }
     }
 
     private fun merge(group: List<RawContactInfo>) {
         launch(context = dispatchers.io) {
-            repository.mergeContacts(group)
-            onEvent(ContactsCleanerEvent.LoadDuplicates)
+            mergeContactsUseCase(group).collectLatest { result ->
+                if (result is DataState.Error) {
+                    _uiState.update { current ->
+                        current.copy(
+                            errors = current.errors + UiSnackbar(
+                                message = result.error.asUiText(),
+                                isError = true
+                            )
+                        )
+                    }
+                }
+                onEvent(ContactsCleanerEvent.LoadDuplicates)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/ContactsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/ContactsModule.kt
@@ -2,6 +2,9 @@ package com.d4rk.cleaner.core.di.modules
 
 import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
 import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepositoryImpl
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.DeleteOlderContactsUseCase
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.GetDuplicateContactsUseCase
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.MergeContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.ui.ContactsCleanerViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
@@ -10,5 +13,15 @@ import org.koin.dsl.module
 
 val contactsModule: Module = module {
     single<ContactsRepository> { ContactsRepositoryImpl(context = androidContext()) }
-    viewModel { ContactsCleanerViewModel(repository = get(), dispatchers = get()) }
+    single { GetDuplicateContactsUseCase(repository = get()) }
+    single { DeleteOlderContactsUseCase(repository = get()) }
+    single { MergeContactsUseCase(repository = get()) }
+    viewModel {
+        ContactsCleanerViewModel(
+            getDuplicatesUseCase = get(),
+            deleteOlderUseCase = get(),
+            mergeContactsUseCase = get(),
+            dispatchers = get()
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add use cases for contact operations
- refactor ContactsCleanerViewModel to use the new use cases
- provide DI bindings for the use cases

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c092f5620832da14b647078dfdd85