### PR TITLE
Improve duplicate contacts detection

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
@@ -4,7 +4,6 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.provider.ContactsContract
-import android.telephony.PhoneNumberUtils
 import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,8 +11,23 @@ import kotlinx.coroutines.withContext
 class ContactsRepositoryImpl(context: Context) : ContactsRepository {
     private val resolver = context.contentResolver
 
+    private fun normalizePhone(number: String): String =
+        number.filterIndexed { index, c -> c.isDigit() || (index == 0 && c == '+') }
+
+    private fun normalizeName(name: String): String =
+        name.filter { it.isLetterOrDigit() }.lowercase()
+
+    private fun samePhoneNumber(a: String, b: String): Boolean {
+        val na = normalizePhone(a)
+        val nb = normalizePhone(b)
+        if (na == nb) return true
+        val da = na.trimStart('+')
+        val db = nb.trimStart('+')
+        return da == db || da.endsWith(db) || db.endsWith(da)
+    }
+
     override suspend fun findDuplicates(): List<List<RawContactInfo>> = withContext(Dispatchers.IO) {
-        val map = mutableMapOf<String, MutableList<RawContactInfo>>()
+        val contacts = mutableListOf<RawContactInfo>()
         val projection = arrayOf(
             ContactsContract.RawContacts._ID,
             ContactsContract.RawContacts.CONTACT_ID,
@@ -22,6 +36,7 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
             ContactsContract.RawContacts.ACCOUNT_TYPE,
             ContactsContract.RawContacts.ACCOUNT_NAME
         )
+
         resolver.query(ContactsContract.RawContacts.CONTENT_URI, projection, null, null, null)?.use { cursor ->
             val idIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts._ID)
             val contactIdIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.CONTACT_ID)
@@ -29,6 +44,7 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
             val updatedIdx = cursor.getColumnIndexOrThrow(ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP)
             val typeIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_TYPE)
             val accIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_NAME)
+
             while (cursor.moveToNext()) {
                 val rawId = cursor.getLong(idIdx)
                 val contactId = cursor.getLong(contactIdIdx)
@@ -47,10 +63,12 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
                 )?.use { pCur ->
                     val numIdx = pCur.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)
                     while (pCur.moveToNext()) {
-                        val num = PhoneNumberUtils.normalizeNumber(pCur.getString(numIdx)) ?: continue
-                        phones.add(num)
+                        val num = pCur.getString(numIdx)
+                        val normalized = normalizePhone(num)
+                        if (normalized.isNotEmpty()) phones.add(normalized)
                     }
                 }
+
                 val emails = mutableListOf<String>()
                 resolver.query(
                     ContactsContract.CommonDataKinds.Email.CONTENT_URI,
@@ -64,12 +82,75 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
                         emails.add(eCur.getString(emIdx).lowercase())
                     }
                 }
-                val key = (phones.sorted().joinToString(",") + "|" + emails.sorted().joinToString(",")).ifEmpty { name.lowercase() }
-                val info = RawContactInfo(contactId, rawId, name, accountType, accountName, updated, phones, emails)
-                map.getOrPut(key) { mutableListOf() }.add(info)
+
+                contacts.add(
+                    RawContactInfo(contactId, rawId, name, accountType, accountName, updated, phones, emails)
+                )
             }
         }
-        map.values.filter { it.size > 1 }
+
+        if (contacts.isEmpty()) return@withContext emptyList()
+
+        val parent = IntArray(contacts.size) { it }
+
+        fun find(x: Int): Int {
+            var r = x
+            while (parent[r] != r) r = parent[r]
+            var i = x
+            while (parent[i] != r) {
+                val p = parent[i]
+                parent[i] = r
+                i = p
+            }
+            return r
+        }
+
+        fun union(a: Int, b: Int) {
+            val ra = find(a)
+            val rb = find(b)
+            if (ra != rb) parent[rb] = ra
+        }
+
+        fun areDuplicates(a: RawContactInfo, b: RawContactInfo): Boolean {
+            a.phones.forEach { pa ->
+                b.phones.forEach { pb ->
+                    if (samePhoneNumber(pa, pb)) return true
+                }
+            }
+
+            if (a.emails.isNotEmpty() && b.emails.isNotEmpty()) {
+                if (a.emails.any { it in b.emails }) return true
+            }
+
+            val nameA = normalizeName(a.displayName)
+            val nameB = normalizeName(b.displayName)
+            if (nameA.isNotEmpty() && nameA == nameB) {
+                if (a.phones.isEmpty() && b.phones.isEmpty() && a.emails.isEmpty() && b.emails.isEmpty()) {
+                    return true
+                }
+                a.phones.forEach { pa ->
+                    b.phones.forEach { pb ->
+                        val digitsA = normalizePhone(pa).trimStart('+')
+                        val digitsB = normalizePhone(pb).trimStart('+')
+                        if (digitsA.endsWith(digitsB) || digitsB.endsWith(digitsA)) return true
+                    }
+                }
+            }
+            return false
+        }
+
+        for (i in contacts.indices) {
+            for (j in i + 1 until contacts.size) {
+                if (areDuplicates(contacts[i], contacts[j])) union(i, j)
+            }
+        }
+
+        val groupsMap = mutableMapOf<Int, MutableList<RawContactInfo>>()
+        contacts.forEachIndexed { index, info ->
+            val root = find(index)
+            groupsMap.getOrPut(root) { mutableListOf() }.add(info)
+        }
+        groupsMap.values.filter { it.size > 1 }
     }
 
     override suspend fun deleteOlder(group: List<RawContactInfo>) = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- add helper functions to normalize names and phone numbers
- rewrite duplicate detection logic to handle more scenarios

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c149e4274832dacbd496454bd8443