### PR TITLE
Refactor contacts duplicate search

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
@@ -26,131 +26,136 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
         return da == db || da.endsWith(db) || db.endsWith(da)
     }
 
-    override suspend fun findDuplicates(): List<List<RawContactInfo>> = withContext(Dispatchers.IO) {
-        val contacts = mutableListOf<RawContactInfo>()
-        val projection = arrayOf(
-            ContactsContract.RawContacts._ID,
-            ContactsContract.RawContacts.CONTACT_ID,
-            ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
-            ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP,
-            ContactsContract.RawContacts.ACCOUNT_TYPE,
-            ContactsContract.RawContacts.ACCOUNT_NAME
-        )
+    override suspend fun findDuplicates(): List<List<RawContactInfo>> {
+        val contacts = withContext(Dispatchers.IO) {
+            val list = mutableListOf<RawContactInfo>()
+            val projection = arrayOf(
+                ContactsContract.RawContacts._ID,
+                ContactsContract.RawContacts.CONTACT_ID,
+                ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
+                ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP,
+                ContactsContract.RawContacts.ACCOUNT_TYPE,
+                ContactsContract.RawContacts.ACCOUNT_NAME
+            )
 
-        resolver.query(ContactsContract.RawContacts.CONTENT_URI, projection, null, null, null)?.use { cursor ->
-            val idIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts._ID)
-            val contactIdIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.CONTACT_ID)
-            val nameIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY)
-            val updatedIdx = cursor.getColumnIndexOrThrow(ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP)
-            val typeIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_TYPE)
-            val accIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_NAME)
+            resolver.query(ContactsContract.RawContacts.CONTENT_URI, projection, null, null, null)?.use { cursor ->
+                val idIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts._ID)
+                val contactIdIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.CONTACT_ID)
+                val nameIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY)
+                val updatedIdx = cursor.getColumnIndexOrThrow(ContactsContract.Contacts.CONTACT_LAST_UPDATED_TIMESTAMP)
+                val typeIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_TYPE)
+                val accIdx = cursor.getColumnIndexOrThrow(ContactsContract.RawContacts.ACCOUNT_NAME)
 
-            while (cursor.moveToNext()) {
-                val rawId = cursor.getLong(idIdx)
-                val contactId = cursor.getLong(contactIdIdx)
-                val name = cursor.getString(nameIdx) ?: ""
-                val updated = cursor.getLong(updatedIdx)
-                val accountType = cursor.getString(typeIdx)
-                val accountName = cursor.getString(accIdx)
+                while (cursor.moveToNext()) {
+                    val rawId = cursor.getLong(idIdx)
+                    val contactId = cursor.getLong(contactIdIdx)
+                    val name = cursor.getString(nameIdx) ?: ""
+                    val updated = cursor.getLong(updatedIdx)
+                    val accountType = cursor.getString(typeIdx)
+                    val accountName = cursor.getString(accIdx)
 
-                val phones = mutableListOf<String>()
-                resolver.query(
-                    ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
-                    arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER),
-                    "${ContactsContract.CommonDataKinds.Phone.RAW_CONTACT_ID}=?",
-                    arrayOf(rawId.toString()),
-                    null
-                )?.use { pCur ->
-                    val numIdx = pCur.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)
-                    while (pCur.moveToNext()) {
-                        val num = pCur.getString(numIdx)
-                        val normalized = normalizePhone(num)
-                        if (normalized.isNotEmpty()) phones.add(normalized)
+                    val phones = mutableListOf<String>()
+                    resolver.query(
+                        ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
+                        arrayOf(ContactsContract.CommonDataKinds.Phone.NUMBER),
+                        "${ContactsContract.CommonDataKinds.Phone.RAW_CONTACT_ID}=?",
+                        arrayOf(rawId.toString()),
+                        null
+                    )?.use { pCur ->
+                        val numIdx = pCur.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Phone.NUMBER)
+                        while (pCur.moveToNext()) {
+                            val num = pCur.getString(numIdx)
+                            val normalized = normalizePhone(num)
+                            if (normalized.isNotEmpty()) phones.add(normalized)
+                        }
                     }
-                }
 
-                val emails = mutableListOf<String>()
-                resolver.query(
-                    ContactsContract.CommonDataKinds.Email.CONTENT_URI,
-                    arrayOf(ContactsContract.CommonDataKinds.Email.ADDRESS),
-                    "${ContactsContract.CommonDataKinds.Email.RAW_CONTACT_ID}=?",
-                    arrayOf(rawId.toString()),
-                    null
-                )?.use { eCur ->
-                    val emIdx = eCur.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS)
-                    while (eCur.moveToNext()) {
-                        emails.add(eCur.getString(emIdx).lowercase())
+                    val emails = mutableListOf<String>()
+                    resolver.query(
+                        ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                        arrayOf(ContactsContract.CommonDataKinds.Email.ADDRESS),
+                        "${ContactsContract.CommonDataKinds.Email.RAW_CONTACT_ID}=?",
+                        arrayOf(rawId.toString()),
+                        null
+                    )?.use { eCur ->
+                        val emIdx = eCur.getColumnIndexOrThrow(ContactsContract.CommonDataKinds.Email.ADDRESS)
+                        while (eCur.moveToNext()) {
+                            emails.add(eCur.getString(emIdx).lowercase())
+                        }
                     }
-                }
 
-                contacts.add(
-                    RawContactInfo(contactId, rawId, name, accountType, accountName, updated, phones, emails)
-                )
-            }
-        }
-
-        if (contacts.isEmpty()) return@withContext emptyList()
-
-        val parent = IntArray(contacts.size) { it }
-
-        fun find(x: Int): Int {
-            var r = x
-            while (parent[r] != r) r = parent[r]
-            var i = x
-            while (parent[i] != r) {
-                val p = parent[i]
-                parent[i] = r
-                i = p
-            }
-            return r
-        }
-
-        fun union(a: Int, b: Int) {
-            val ra = find(a)
-            val rb = find(b)
-            if (ra != rb) parent[rb] = ra
-        }
-
-        fun areDuplicates(a: RawContactInfo, b: RawContactInfo): Boolean {
-            a.phones.forEach { pa ->
-                b.phones.forEach { pb ->
-                    if (samePhoneNumber(pa, pb)) return true
+                    list.add(
+                        RawContactInfo(contactId, rawId, name, accountType, accountName, updated, phones, emails)
+                    )
                 }
             }
+            list
+        }
 
-            if (a.emails.isNotEmpty() && b.emails.isNotEmpty()) {
-                if (a.emails.any { it in b.emails }) return true
+        if (contacts.isEmpty()) return emptyList()
+
+        return withContext(Dispatchers.Default) {
+            val parent = IntArray(contacts.size) { it }
+
+            fun find(x: Int): Int {
+                var r = x
+                while (parent[r] != r) r = parent[r]
+                var i = x
+                while (parent[i] != r) {
+                    val p = parent[i]
+                    parent[i] = r
+                    i = p
+                }
+                return r
             }
 
-            val nameA = normalizeName(a.displayName)
-            val nameB = normalizeName(b.displayName)
-            if (nameA.isNotEmpty() && nameA == nameB) {
-                if (a.phones.isEmpty() && b.phones.isEmpty() && a.emails.isEmpty() && b.emails.isEmpty()) {
-                    return true
-                }
+            fun union(a: Int, b: Int) {
+                val ra = find(a)
+                val rb = find(b)
+                if (ra != rb) parent[rb] = ra
+            }
+
+            fun areDuplicates(a: RawContactInfo, b: RawContactInfo): Boolean {
                 a.phones.forEach { pa ->
                     b.phones.forEach { pb ->
-                        val digitsA = normalizePhone(pa).trimStart('+')
-                        val digitsB = normalizePhone(pb).trimStart('+')
-                        if (digitsA.endsWith(digitsB) || digitsB.endsWith(digitsA)) return true
+                        if (samePhoneNumber(pa, pb)) return true
                     }
                 }
-            }
-            return false
-        }
 
-        for (i in contacts.indices) {
-            for (j in i + 1 until contacts.size) {
-                if (areDuplicates(contacts[i], contacts[j])) union(i, j)
-            }
-        }
+                if (a.emails.isNotEmpty() && b.emails.isNotEmpty()) {
+                    if (a.emails.any { it in b.emails }) return true
+                }
 
-        val groupsMap = mutableMapOf<Int, MutableList<RawContactInfo>>()
-        contacts.forEachIndexed { index, info ->
-            val root = find(index)
-            groupsMap.getOrPut(root) { mutableListOf() }.add(info)
+                val nameA = normalizeName(a.displayName)
+                val nameB = normalizeName(b.displayName)
+                if (nameA.isNotEmpty() && nameA == nameB) {
+                    if (a.phones.isEmpty() && b.phones.isEmpty() && a.emails.isEmpty() && b.emails.isEmpty()) {
+                        return true
+                    }
+                    a.phones.forEach { pa ->
+                        b.phones.forEach { pb ->
+                            val digitsA = normalizePhone(pa).trimStart('+')
+                            val digitsB = normalizePhone(pb).trimStart('+')
+                            if (digitsA.endsWith(digitsB) || digitsB.endsWith(digitsA)) return true
+                        }
+                    }
+                }
+                return false
+            }
+
+            for (i in contacts.indices) {
+                for (j in i + 1 until contacts.size) {
+                    if (areDuplicates(contacts[i], contacts[j])) union(i, j)
+                }
+            }
+
+            val groupsMap = mutableMapOf<Int, MutableList<RawContactInfo>>()
+            contacts.forEachIndexed { index, info ->
+                val root = find(index)
+                groupsMap.getOrPut(root) { mutableListOf() }.add(info)
+            }
+            groupsMap.values.filter { it.size > 1 }
         }
-        groupsMap.values.filter { it.size > 1 }
     }
 
     override suspend fun deleteOlder(group: List<RawContactInfo>) = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- split contact lookup and duplicate detection across proper dispatchers
  - use `Dispatchers.IO` for database queries
  - run CPU‑heavy matching on `Dispatchers.Default`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1bf5fda8832dadde54a694362ecf