### PR TITLE
Implement contacts selection overhaul

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/actions/ContactsCleanerEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/actions/ContactsCleanerEvent.kt
@@ -7,4 +7,8 @@ sealed interface ContactsCleanerEvent : UiEvent {
     data object LoadDuplicates : ContactsCleanerEvent
     data class DeleteOlder(val group: List<RawContactInfo>) : ContactsCleanerEvent
     data class MergeAll(val group: List<RawContactInfo>) : ContactsCleanerEvent
+    data class ToggleGroupSelection(val group: List<RawContactInfo>) : ContactsCleanerEvent
+    data class ToggleContactSelection(val contact: RawContactInfo) : ContactsCleanerEvent
+    data object MergeSelectedContacts : ContactsCleanerEvent
+    data object DeleteSelectedContacts : ContactsCleanerEvent
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/data/model/RawContactInfo.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/data/model/RawContactInfo.kt
@@ -8,5 +8,6 @@ data class RawContactInfo(
     val accountName: String?,
     val lastUpdated: Long,
     val phones: List<String>,
-    val emails: List<String>
+    val emails: List<String>,
+    val isSelected: Boolean = false
 )

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/data/model/UiContactsCleanerModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/data/model/UiContactsCleanerModel.kt
@@ -1,5 +1,10 @@
 package com.d4rk.cleaner.app.clean.contacts.domain.data.model
 
+data class DuplicateContactGroup(
+    val contacts: List<RawContactInfo>,
+    val isSelected: Boolean = false
+)
+
 data class UiContactsCleanerModel(
-    val duplicates: List<List<RawContactInfo>> = emptyList()
+    val duplicates: List<DuplicateContactGroup> = emptyList()
 )

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -211,6 +211,15 @@
         <item quantity="other">هل تريد حذف %1$d ملف؟</item>
     </plurals>
     <string name="delete">حذف</string>
+    <string name="merge">دمج</string>
+    <plurals name="items_selected">
+        <item quantity="zero">تم تحديد 0 عنصر</item>
+        <item quantity="one">تم تحديد عنصر واحد</item>
+        <item quantity="two">تم تحديد عنصرين</item>
+        <item quantity="few">تم تحديد %d عناصر</item>
+        <item quantity="many">تم تحديد %d عنصراً</item>
+        <item quantity="other">تم تحديد %d عنصر</item>
+    </plurals>
     <string name="original">الأصلي</string>
     <string name="today">النهاردة</string>
     <string name="yesterday">امبارح</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">Да изтрия %1$d елемента?</item>
     </plurals>
     <string name="delete">Изтриване</string>
+    <string name="merge">Обединяване</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d избран елемент</item>
+        <item quantity="other">%d избрани елемента</item>
+    </plurals>
     <string name="original">Оригинал</string>
     <string name="today">Днес</string>
     <string name="yesterday">Вчера</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">কী %1$d আইটেম মুছে ফেলতে চান?</item>
     </plurals>
     <string name="delete">মুছুন</string>
+    <string name="merge">মার্জ করুন</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d আইটেম নির্বাচিত</item>
+        <item quantity="other">%d আইটেম নির্বাচিত</item>
+    </plurals>
     <string name="original">মূল</string>
     <string name="today">আজ</string>
     <string name="yesterday">গতকাল</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">%1$d Elemente löschen?</item>
     </plurals>
     <string name="delete">Löschen</string>
+    <string name="merge">Zusammenführen</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d Element ausgewählt</item>
+        <item quantity="other">%d Elemente ausgewählt</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Heute</string>
     <string name="yesterday">Gestern</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -196,6 +196,11 @@
         <item quantity="other">¿Eliminar %1$d elementos?</item>
     </plurals>
     <string name="delete">Eliminar</string>
+    <string name="merge">Combinar</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Hoy</string>
     <string name="yesterday">Ayer</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -196,6 +196,11 @@
         <item quantity="other">¿Eliminar %1$d elementos?</item>
     </plurals>
     <string name="delete">Eliminar</string>
+    <string name="merge">Combinar</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d elemento seleccionado</item>
+        <item quantity="other">%d elementos seleccionados</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Hoy</string>
     <string name="yesterday">Ayer</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">Tanggalin ang %1$d item?</item>
     </plurals>
     <string name="delete">Burahin</string>
+    <string name="merge">Pagsamahin</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d item ang napili</item>
+        <item quantity="other">%d na item ang napili</item>
+    </plurals>
     <string name="original">Orihinal</string>
     <string name="today">Ngayon</string>
     <string name="yesterday">Kahapon</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -197,6 +197,11 @@
         <item quantity="other">Supprimer %1$d éléments ?</item>
     </plurals>
     <string name="delete">Supprimer</string>
+    <string name="merge">Fusionner</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d élément sélectionné</item>
+        <item quantity="other">%d éléments sélectionnés</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Aujourd\'hui</string>
     <string name="yesterday">Hier</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">%1$d आइटम हटाएँ?</item>
     </plurals>
     <string name="delete">हटाएं</string>
+    <string name="merge">मिलाएँ</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d आइटम चुना गया</item>
+        <item quantity="other">%d आइटम चुने गए</item>
+    </plurals>
     <string name="original">मूल</string>
     <string name="today">आज</string>
     <string name="yesterday">कल</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">Töröljem a(z) %1$d elemet?</item>
     </plurals>
     <string name="delete">Törlés</string>
+    <string name="merge">Egyesítés</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d elem kijelölve</item>
+        <item quantity="other">%d elem kijelölve</item>
+    </plurals>
     <string name="original">Eredeti</string>
     <string name="today">Ma</string>
     <string name="yesterday">Tegnap</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -186,6 +186,11 @@
         <item quantity="other">Hapus %1$d item?</item>
     </plurals>
     <string name="delete">Hapus</string>
+    <string name="merge">Gabungkan</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d item dipilih</item>
+        <item quantity="other">%d item dipilih</item>
+    </plurals>
     <string name="original">Asli</string>
     <string name="today">Hari ini</string>
     <string name="yesterday">Kemarin</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -196,6 +196,11 @@
         <item quantity="other">Eliminare %1$d elementi?</item>
     </plurals>
     <string name="delete">Elimina</string>
+    <string name="merge">Unisci</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d elemento selezionato</item>
+        <item quantity="other">%d elementi selezionati</item>
+    </plurals>
     <string name="original">Originale</string>
     <string name="today">Oggi</string>
     <string name="yesterday">Ieri</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -183,6 +183,11 @@
     <string name="select_all">すべて選択</string>
     <string name="delete_confirmation_title">選択項目を削除</string>
     <string name="delete">削除</string>
+    <string name="merge">統合</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d 件選択済み</item>
+        <item quantity="other">%d 件選択済み</item>
+    </plurals>
     <string name="original">オリジナル</string>
     <string name="today">今日</string>
     <string name="yesterday">昨日</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -186,6 +186,11 @@
         <item quantity="other">%1$d개 항목을 삭제할까요?</item>
     </plurals>
     <string name="delete">삭제</string>
+    <string name="merge">병합</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d개 선택됨</item>
+        <item quantity="other">%d개 선택됨</item>
+    </plurals>
     <string name="original">원본</string>
     <string name="today">오늘</string>
     <string name="yesterday">어제</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -201,6 +201,13 @@
         <item quantity="other">Usunąć %1$d elementów?</item>
     </plurals>
     <string name="delete">Usuń</string>
+    <string name="merge">Scal</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d element zaznaczony</item>
+        <item quantity="few">%d elementy zaznaczone</item>
+        <item quantity="many">%d elementów zaznaczonych</item>
+        <item quantity="other">%d elementów zaznaczonych</item>
+    </plurals>
     <string name="original">Oryginał</string>
     <string name="today">Dzisiaj</string>
     <string name="yesterday">Wczoraj</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -196,6 +196,12 @@
         <item quantity="many">Excluir %1$d itens?</item>
     </plurals>
     <string name="delete">Excluir</string>
+    <string name="merge">Mesclar</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d item selecionado</item>
+        <item quantity="other">%d itens selecionados</item>
+        <item quantity="many">%d itens selecionados</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Hoje</string>
     <string name="yesterday">Ontem</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -196,6 +196,12 @@
         <item quantity="other">Șterge %1$d elemente?</item>
     </plurals>
     <string name="delete">Șterge</string>
+    <string name="merge">Combină</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d element selectat</item>
+        <item quantity="few">%d elemente selectate</item>
+        <item quantity="other">%d de elemente selectate</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Astăzi</string>
     <string name="yesterday">Ieri</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -201,6 +201,13 @@
         <item quantity="other">Удалить %1$d элемента?</item>
     </plurals>
     <string name="delete">Удалить</string>
+    <string name="merge">Объединить</string>
+    <plurals name="items_selected">
+        <item quantity="one">Выбран %d элемент</item>
+        <item quantity="few">Выбрано %d элемента</item>
+        <item quantity="many">Выбрано %d элементов</item>
+        <item quantity="other">Выбрано %d элемента</item>
+    </plurals>
     <string name="original">Оригинал</string>
     <string name="today">Сегодня</string>
     <string name="yesterday">Вчера</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">Ta bort %1$d objekt?</item>
     </plurals>
     <string name="delete">Radera</string>
+    <string name="merge">Slå ihop</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d objekt markerat</item>
+        <item quantity="other">%d objekt markerade</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Idag</string>
     <string name="yesterday">Igår</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -186,6 +186,11 @@
         <item quantity="other">ลบ %1$d รายการหรือไม่?</item>
     </plurals>
     <string name="delete">ลบ</string>
+    <string name="merge">รวม</string>
+    <plurals name="items_selected">
+        <item quantity="one">เลือก %d รายการ</item>
+        <item quantity="other">เลือก %d รายการ</item>
+    </plurals>
     <string name="original">ต้นฉบับ</string>
     <string name="today">วันนี้</string>
     <string name="yesterday">เมื่อวาน</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">%1$d öğeyi sil?</item>
     </plurals>
     <string name="delete">Sil</string>
+    <string name="merge">Birleştir</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d öğe seçildi</item>
+        <item quantity="other">%d öğe seçildi</item>
+    </plurals>
     <string name="original">Orijinal</string>
     <string name="today">Bugün</string>
     <string name="yesterday">Dün</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -201,6 +201,13 @@
         <item quantity="other">Видалити %1$d елементів?</item>
     </plurals>
     <string name="delete">Видалити</string>
+    <string name="merge">Об'єднати</string>
+    <plurals name="items_selected">
+        <item quantity="one">Вибрано %d елемент</item>
+        <item quantity="few">Вибрано %d елементи</item>
+        <item quantity="many">Вибрано %d елементів</item>
+        <item quantity="other">Вибрано %d елемента</item>
+    </plurals>
     <string name="original">Оригінал</string>
     <string name="today">Сьогодні</string>
     <string name="yesterday">Вчора</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">کیا %1$d آئٹمز حذف کریں؟</item>
     </plurals>
     <string name="delete">حذف کریں</string>
+    <string name="merge">ملائیں</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d آئٹم منتخب</item>
+        <item quantity="other">%d آئٹمز منتخب</item>
+    </plurals>
     <string name="original">اصل</string>
     <string name="today">آج</string>
     <string name="yesterday">کل</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -186,6 +186,11 @@
         <item quantity="other">Xóa %1$d mục?</item>
     </plurals>
     <string name="delete">Xóa</string>
+    <string name="merge">Gộp</string>
+    <plurals name="items_selected">
+        <item quantity="one">Đã chọn %d mục</item>
+        <item quantity="other">Đã chọn %d mục</item>
+    </plurals>
     <string name="original">Bản gốc</string>
     <string name="today">Hôm nay</string>
     <string name="yesterday">Hôm qua</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -186,6 +186,11 @@
         <item quantity="other">要刪除 %1$d 個項目嗎？</item>
     </plurals>
     <string name="delete">刪除</string>
+    <string name="merge">合併</string>
+    <plurals name="items_selected">
+        <item quantity="one">已選取 %d 項</item>
+        <item quantity="other">已選取 %d 項</item>
+    </plurals>
     <string name="original">原始</string>
     <string name="today">今天</string>
     <string name="yesterday">昨天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,11 @@
         <item quantity="other">Delete %1$d items?</item>
     </plurals>
     <string name="delete">Delete</string>
+    <string name="merge">Merge</string>
+    <plurals name="items_selected">
+        <item quantity="one">%d item selected</item>
+        <item quantity="other">%d items selected</item>
+    </plurals>
     <string name="original">Original</string>
     <string name="today">Today</string>
     <string name="yesterday">Yesterday</string>


### PR DESCRIPTION
## Summary
- add `isSelected` to contact models
- introduce selection events
- refactor `ContactsCleanerViewModel` to manage selections
- redesign `ContactsCleanerScreen` with expandable cards and bottom action bar
- provide new strings for merge and item counts
- translate new strings across supported languages

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8d63b08c832d84c88cca472edc5b