### PR TITLE
Add select all and polish contacts UI

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/actions/ContactsCleanerEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/actions/ContactsCleanerEvent.kt
@@ -11,4 +11,5 @@ sealed interface ContactsCleanerEvent : UiEvent {
     data class ToggleContactSelection(val contact: RawContactInfo) : ContactsCleanerEvent
     data object MergeSelectedContacts : ContactsCleanerEvent
     data object DeleteSelectedContacts : ContactsCleanerEvent
+    data object ToggleSelectAll : ContactsCleanerEvent
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/ui/ContactsCleanerViewModel.kt
@@ -38,6 +38,7 @@ class ContactsCleanerViewModel(
             is ContactsCleanerEvent.ToggleContactSelection -> handleToggleContactSelection(event.contact)
             ContactsCleanerEvent.MergeSelectedContacts -> handleMergeSelectedContacts()
             ContactsCleanerEvent.DeleteSelectedContacts -> handleDeleteSelectedContacts()
+            ContactsCleanerEvent.ToggleSelectAll -> handleToggleSelectAll()
         }
     }
 
@@ -151,5 +152,18 @@ class ContactsCleanerViewModel(
     private fun handleDeleteSelectedContacts() {
         val selected = _uiState.value.data?.duplicates?.flatMap { it.contacts.filter { contact -> contact.isSelected } }
         if (selected?.isNotEmpty() == true) deleteOlder(selected)
+    }
+
+    private fun handleToggleSelectAll() {
+        _uiState.update { current ->
+            val shouldSelect = current.data?.duplicates
+                ?.flatMap { it.contacts }
+                ?.any { !it.isSelected } ?: false
+            val updatedGroups = current.data?.duplicates?.map { group ->
+                val updatedContacts = group.contacts.map { it.copy(isSelected = shouldSelect) }
+                group.copy(contacts = updatedContacts, isSelected = shouldSelect)
+            }
+            current.copy(data = current.data?.copy(duplicates = updatedGroups ?: emptyList()))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `ToggleSelectAll` event
- support select-all logic in view model
- show sticky header with tri-state checkbox
- enhance group rows with assist chip, clickable row and haptic feedback
- show phone/email icons and muted color in detail rows

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c98feee08832d99a8b755a91dd8f6