### PR TITLE
Improve Contacts Cleaner actions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepository.kt
@@ -5,5 +5,6 @@ import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
 interface ContactsRepository {
     suspend fun findDuplicates(): List<List<RawContactInfo>>
     suspend fun deleteOlder(group: List<RawContactInfo>)
+    suspend fun deleteContacts(contacts: List<RawContactInfo>)
     suspend fun mergeContacts(group: List<RawContactInfo>)
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/data/ContactsRepositoryImpl.kt
@@ -181,6 +181,13 @@ class ContactsRepositoryImpl(context: Context) : ContactsRepository {
         }
     }
 
+    override suspend fun deleteContacts(contacts: List<RawContactInfo>) = withContext(Dispatchers.IO) {
+        contacts.forEach { info ->
+            val uri = ContentUris.withAppendedId(ContactsContract.RawContacts.CONTENT_URI, info.rawContactId)
+            resolver.delete(uri, null, null)
+        }
+    }
+
     override suspend fun mergeContacts(group: List<RawContactInfo>) = withContext(Dispatchers.IO) {
         val keep = group.maxByOrNull { it.lastUpdated } ?: return@withContext
         group.filter { it != keep }.forEach { source ->

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/DeleteContactsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/contacts/domain/usecases/DeleteContactsUseCase.kt
@@ -1,0 +1,17 @@
+package com.d4rk.cleaner.app.clean.contacts.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
+import com.d4rk.cleaner.app.clean.contacts.domain.data.model.RawContactInfo
+import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class DeleteContactsUseCase(private val repository: ContactsRepository) {
+    operator fun invoke(contacts: List<RawContactInfo>): Flow<DataState<Unit, Errors>> = flow {
+        runCatching { repository.deleteContacts(contacts) }
+            .onSuccess { emit(DataState.Success(Unit)) }
+            .onFailure { emit(DataState.Error(error = it.toError())) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/core/di/modules/AppModule.kt
@@ -32,6 +32,7 @@ import com.d4rk.cleaner.app.apps.manager.ui.AppManagerViewModel
 import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepository
 import com.d4rk.cleaner.app.clean.contacts.data.ContactsRepositoryImpl
 import com.d4rk.cleaner.app.clean.contacts.domain.usecases.DeleteOlderContactsUseCase
+import com.d4rk.cleaner.app.clean.contacts.domain.usecases.DeleteContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.domain.usecases.GetDuplicateContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.domain.usecases.MergeContactsUseCase
 import com.d4rk.cleaner.app.clean.contacts.ui.ContactsCleanerViewModel
@@ -142,11 +143,13 @@ val appModule: Module = module {
     single<ContactsRepository> { ContactsRepositoryImpl(context = get()) }
     single { GetDuplicateContactsUseCase(repository = get()) }
     single { DeleteOlderContactsUseCase(repository = get()) }
+    single { DeleteContactsUseCase(repository = get()) }
     single { MergeContactsUseCase(repository = get()) }
     viewModel {
         ContactsCleanerViewModel(
             getDuplicatesUseCase = get(),
             deleteOlderUseCase = get(),
+            deleteContactsUseCase = get(),
             mergeContactsUseCase = get(),
             dispatchers = get()
         )

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -239,6 +239,8 @@
     <string name="contacts_permission_rationale">نحتاج للوصول إلى جهات الاتصال للعثور على المكررات ودمجها. لا تغادر بياناتك جهازك.</string>
     <string name="keep_newest_remove_older">احتفظ بالأحدث واحذف الأقدم</string>
     <string name="merge_all_duplicates">دمج كل المكررات</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">تم رفض الإذن. يمكنك تمكينه من إعدادات النظام.</string>
     <string name="open_settings">افتح الإعدادات</string>
 

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Имаме нужда от достъп до контактите ви, за да намерим и обединим дубликатите. Данните никога не напускат устройството ви.</string>
     <string name="keep_newest_remove_older">Запази най-новия и премахни по-старите</string>
     <string name="merge_all_duplicates">Обедини всички дубликати</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Достъпът е отказан. Можете да го активирате в настройките.</string>
     <string name="open_settings">Отвори настройките</string>
 

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">ডুপ্লিকেট খুঁজে মেশানোর জন্য আমাদের আপনার কন্টাক্ট অ্যাক্সেস দরকার। ডেটা কখনোই আপনার ডিভাইস ছাড়ে না।</string>
     <string name="keep_newest_remove_older">নতুনটি রাখুন, পুরোনো মুছে ফেলুন</string>
     <string name="merge_all_duplicates">সব ডুপ্লিকেট মিশিয়ে দিন</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">অনুমতি প্রত্যাখ্যান করা হয়েছে। সিস্টেম সেটিংসে এটি চালু করতে পারেন।</string>
     <string name="open_settings">সেটিংস খুলুন</string>
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Wir benötigen Zugriff auf deine Kontakte, um Duplikate zu finden und zusammenzuführen. Daten verlassen dein Gerät nie.</string>
     <string name="keep_newest_remove_older">Neuester behalten &amp; ältere entfernen</string>
     <string name="merge_all_duplicates">Alle Duplikate zusammenführen</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Berechtigung verweigert. Du kannst sie in den Systemeinstellungen aktivieren.</string>
     <string name="open_settings">Einstellungen öffnen</string>
 

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -217,6 +217,8 @@
     <string name="contacts_permission_rationale">Necesitamos acceso a tus contactos para encontrar y combinar duplicados. Los datos nunca salen de tu dispositivo.</string>
     <string name="keep_newest_remove_older">Conservar el más reciente y borrar los demás</string>
     <string name="merge_all_duplicates">Combinar todos los duplicados</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permiso denegado. Puedes activarlo en los ajustes del sistema.</string>
     <string name="open_settings">Abrir ajustes</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -218,6 +218,8 @@
     <string name="contacts_permission_rationale">Necesitamos acceso a tus contactos para encontrar y combinar duplicados. Los datos nunca salen de tu dispositivo.</string>
     <string name="keep_newest_remove_older">Conservar el más reciente y borrar los demás</string>
     <string name="merge_all_duplicates">Combinar todos los duplicados</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permiso denegado. Puedes activarlo en los ajustes del sistema.</string>
     <string name="open_settings">Abrir ajustes</string>
 

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Kailangan naming ma-access ang iyong mga contact para mahanap at pagsamahin ang mga dobleng entry. Hindi umaalis ang datos sa iyong device.</string>
     <string name="keep_newest_remove_older">Panatilihin ang pinakabago at alisin ang luma</string>
     <string name="merge_all_duplicates">Pagsamahin lahat ng dobleng contact</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Tinanggihan ang permiso. Maaari mo itong paganahin sa mga setting ng system.</string>
     <string name="open_settings">Buksan ang mga setting</string>
 

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -219,6 +219,8 @@
     <string name="contacts_permission_rationale">Nous avons besoin d\'accéder à vos contacts pour trouver et fusionner les doublons. Les données ne quittent jamais votre appareil.</string>
     <string name="keep_newest_remove_older">Garder le plus récent &amp; supprimer les anciens</string>
     <string name="merge_all_duplicates">Fusionner tous les doublons</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permission refusée. Vous pouvez l\'activer dans les paramètres système.</string>
     <string name="open_settings">Ouvrir les paramètres</string>
 

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">डुप्लीकेट खोजने और मिलाने के लिए हमें आपके संपर्कों की अनुमति चाहिए। डेटा कभी भी आपके डिवाइस से बाहर नहीं जाता।</string>
     <string name="keep_newest_remove_older">नवीनतम रखें और पुराने हटाएँ</string>
     <string name="merge_all_duplicates">सभी डुप्लीकेट मिलाएँ</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">अनुमति अस्वीकृत। आप इसे सिस्टम सेटिंग में सक्षम कर सकते हैं।</string>
     <string name="open_settings">सेटिंग खोलें</string>
 

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Duplikált névjegyek kereséséhez és egyesítéséhez hozzáférésre van szükségünk a névjegyekhez. Az adatok nem hagyják el a készüléket.</string>
     <string name="keep_newest_remove_older">Legújabb megtartása és a régiek törlése</string>
     <string name="merge_all_duplicates">Minden duplikátum egyesítése</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Hozzáférés megtagadva. A rendszerbeállításokban engedélyezhető.</string>
     <string name="open_settings">Beállítások megnyitása</string>
 

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">Kami memerlukan akses ke kontak Anda untuk menemukan dan menggabungkan duplikat. Data tidak pernah meninggalkan perangkat Anda.</string>
     <string name="keep_newest_remove_older">Simpan yang terbaru &amp; hapus yang lama</string>
     <string name="merge_all_duplicates">Gabungkan semua duplikat</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Izin ditolak. Anda dapat mengaktifkannya di pengaturan sistem.</string>
     <string name="open_settings">Buka setelan</string>
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -218,6 +218,8 @@
     <string name="contacts_permission_rationale">Abbiamo bisogno di accedere ai tuoi contatti per trovare e unire i duplicati. I dati non lasciano mai il tuo dispositivo.</string>
     <string name="keep_newest_remove_older">Mantieni il più recente e rimuovi gli altri</string>
     <string name="merge_all_duplicates">Unisci tutti i duplicati</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permesso negato. Puoi abilitarlo nelle impostazioni di sistema.</string>
     <string name="open_settings">Apri impostazioni</string>
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">重複を探して統合するために連絡先へのアクセスが必要です。データが端末の外に送信されることはありません。</string>
     <string name="keep_newest_remove_older">最新を残して古いものを削除</string>
     <string name="merge_all_duplicates">すべての重複を統合</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">権限が拒否されました。システム設定で有効にできます。</string>
     <string name="open_settings">設定を開く</string>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">중복을 찾고 병합하려면 연락처 접근 권한이 필요합니다. 데이터는 절대 기기를 벗어나지 않습니다.</string>
     <string name="keep_newest_remove_older">최신만 남기고 나머지 삭제</string>
     <string name="merge_all_duplicates">모든 중복 병합</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">권한이 거부되었습니다. 시스템 설정에서 활성화할 수 있습니다.</string>
     <string name="open_settings">설정 열기</string>
 

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -225,6 +225,8 @@
     <string name="contacts_permission_rationale">Potrzebujemy dostępu do twoich kontaktów, aby znaleźć i połączyć duplikaty. Dane nigdy nie opuszczą twojego urządzenia.</string>
     <string name="keep_newest_remove_older">Zachowaj najnowszy i usuń starsze</string>
     <string name="merge_all_duplicates">Połącz wszystkie duplikaty</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Odmowa uprawnień. Możesz je włączyć w ustawieniach systemu.</string>
     <string name="open_settings">Otwórz ustawienia</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -218,6 +218,8 @@
     <string name="contacts_permission_rationale">Precisamos acessar seus contatos para localizar e mesclar duplicados. Seus dados nunca saem do dispositivo.</string>
     <string name="keep_newest_remove_older">Manter o mais recente &amp; remover os antigos</string>
     <string name="merge_all_duplicates">Mesclar todos os duplicados</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permissão negada. Você pode ativá-la nas configurações do sistema.</string>
     <string name="open_settings">Abrir configurações</string>
 

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -218,6 +218,8 @@
     <string name="contacts_permission_rationale">Avem nevoie de acces la contacte pentru a găsi și îmbina duplicatele. Datele nu părăsesc niciodată dispozitivul.</string>
     <string name="keep_newest_remove_older">Păstrează cel mai nou și șterge-le pe cele vechi</string>
     <string name="merge_all_duplicates">Combină toate duplicatele</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permisiune refuzată. O poți activa din setările sistemului.</string>
     <string name="open_settings">Deschide setările</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -225,6 +225,8 @@
     <string name="contacts_permission_rationale">Нам нужен доступ к вашим контактам, чтобы найти и объединить дубликаты. Данные никогда не покидают ваше устройство.</string>
     <string name="keep_newest_remove_older">Сохранить новый &amp; удалить старые</string>
     <string name="merge_all_duplicates">Объединить все дубликаты</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Доступ запрещён. Вы можете включить его в настройках системы.</string>
     <string name="open_settings">Открыть настройки</string>
 

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Vi behöver åtkomst till dina kontakter för att hitta och slå ihop dubletter. Data lämnar aldrig din enhet.</string>
     <string name="keep_newest_remove_older">Behåll senaste &amp; ta bort äldre</string>
     <string name="merge_all_duplicates">Slå ihop alla dubletter</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Behörighet nekad. Du kan aktivera den i systeminställningarna.</string>
     <string name="open_settings">Öppna inställningar</string>
 

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">เราต้องการสิทธิ์เข้าถึงรายชื่อของคุณเพื่อค้นหาและรวมรายการซ้ำ ข้อมูลจะไม่ออกจากอุปกรณ์ของคุณ</string>
     <string name="keep_newest_remove_older">เก็บรายการใหม่สุดและลบรายการเก่า</string>
     <string name="merge_all_duplicates">รวมรายการที่ซ้ำทั้งหมด</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">ปฏิเสธการอนุญาต คุณสามารถเปิดได้ในตั้งค่าระบบ</string>
     <string name="open_settings">เปิดการตั้งค่า</string>
 

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">Yinelenenleri bulup birleştirmek için kişilerinizin erişimine ihtiyacımız var. Veriler cihazınızdan dışarı çıkmaz.</string>
     <string name="keep_newest_remove_older">En yeniyi tut, eskileri sil</string>
     <string name="merge_all_duplicates">Tüm yinelenenleri birleştir</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">İzin reddedildi. Sistem ayarlarından etkinleştirebilirsiniz.</string>
     <string name="open_settings">Ayarları aç</string>
 

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -225,6 +225,8 @@
     <string name="contacts_permission_rationale">Нам потрібен доступ до ваших контактів, щоб знаходити та об\'єднувати дублікати. Дані ніколи не залишають ваш пристрій.</string>
     <string name="keep_newest_remove_older">Зберегти новий &amp; видалити старі</string>
     <string name="merge_all_duplicates">Об\'єднати всі дублікати</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Доступ заборонено. Ви можете увімкнути його в налаштуваннях системи.</string>
     <string name="open_settings">Відкрити налаштування</string>
 

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">ڈپلیکیٹ تلاش کرنے اور ملانے کے لیے ہمیں آپ کے کانٹیکٹس تک رسائی چاہیے۔ آپ کا ڈیٹا کبھی بھی آپ کی ڈیوائس سے باہر نہیں جاتا۔</string>
     <string name="keep_newest_remove_older">جدید کو رکھیں اور پرانے حذف کریں</string>
     <string name="merge_all_duplicates">تمام ڈپلیکیٹ ملائیں</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">اجازت مسترد کر دی گئی۔ آپ اسے سسٹم سیٹنگز میں فعال کر سکتے ہیں.</string>
     <string name="open_settings">سیٹنگز کھولیں</string>
 

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">Chúng tôi cần quyền truy cập danh bạ để tìm và gộp các bản trùng. Dữ liệu của bạn không bao giờ rời khỏi thiết bị.</string>
     <string name="keep_newest_remove_older">Giữ mới nhất &amp; xóa bản cũ</string>
     <string name="merge_all_duplicates">Gộp tất cả bản trùng</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Quyền bị từ chối. Bạn có thể bật lại trong cài đặt hệ thống.</string>
     <string name="open_settings">Mở cài đặt</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -204,6 +204,8 @@
     <string name="contacts_permission_rationale">我們需要存取你的聯絡人以找出並合併重複項。資料不會離開你的裝置。</string>
     <string name="keep_newest_remove_older">保留最新 &amp; 刪除較舊</string>
     <string name="merge_all_duplicates">合併所有重複項</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">權限被拒。你可以在系統設定中啟用它。</string>
     <string name="open_settings">開啟設定</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,6 +211,8 @@
     <string name="contacts_permission_rationale">We need access to your contacts to find and merge duplicates. Data never leaves your device.</string>
     <string name="keep_newest_remove_older">Keep Newest &amp; Remove Older</string>
     <string name="merge_all_duplicates">Merge All Duplicates</string>
+    <string name="merge_groups">Merge Groups</string>
+    <string name="keep_newest_in_each">Keep Newest in Each</string>
     <string name="contacts_permission_denied">Permission denied. You can enable it in system settings.</string>
     <string name="open_settings">Open Settings</string>
 


### PR DESCRIPTION
## Summary
- allow deletion of single contacts
- intelligently merge or delete contacts depending on selection
- inject new `DeleteContactsUseCase`
- show context-aware bottom bar labels for contacts cleaner
- add `merge_groups` and `keep_newest_in_each` strings across locales

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c9c6eb148832d977ebb68e01e274f