### PR TITLE
Improve WhatsAppCleanerViewModel thread usage

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/whatsapp/details/ui/WhatsAppDetailsViewModel.kt
@@ -24,7 +24,7 @@ class DetailsViewModel(
 ) {
 
     init {
-        launch(dispatchers.io) {
+        launch {
             dataStore.whatsappGridView.collectLatest { isGrid ->
                 _uiState.updateData(newState = _uiState.value.screenState) { current ->
                     current.copy(isGridView = isGrid)
@@ -47,22 +47,24 @@ class DetailsViewModel(
     }
 
     private fun setFiles(list: List<File>) {
-        val sorted = sort(list)
-        _uiState.update { current ->
-            val data = current.data ?: UiWhatsAppDetailsModel()
-            current.copy(
-                data = data.copy(
-                    files = sorted,
-                    suggested = sort(getJunkCandidates(sorted))
-                ),
-                screenState = if (sorted.isEmpty()) ScreenState.NoData() else ScreenState.Success()
-            )
+        launch(dispatchers.default) {
+            val sorted = sort(list)
+            _uiState.update { current ->
+                val data = current.data ?: UiWhatsAppDetailsModel()
+                current.copy(
+                    data = data.copy(
+                        files = sorted,
+                        suggested = sort(getJunkCandidates(sorted))
+                    ),
+                    screenState = if (sorted.isEmpty()) ScreenState.NoData() else ScreenState.Success()
+                )
+            }
         }
     }
 
     private fun toggleView() {
         val new = !(_uiState.value.data?.isGridView ?: true)
-        launch(dispatchers.io) { dataStore.saveWhatsAppGridView(new) }
+        launch { dataStore.saveWhatsAppGridView(new) }
         _uiState.updateData(ScreenState.Success()) { it.copy(isGridView = new) }
     }
 
@@ -78,14 +80,16 @@ class DetailsViewModel(
                 )
             )
         }
-        _uiState.update { current ->
-            val sorted = sort(current.data?.files ?: emptyList())
-            current.copy(
-                data = current.data?.copy(
-                    files = sorted,
-                    suggested = sort(getJunkCandidates(sorted))
+        launch(dispatchers.default) {
+            _uiState.update { current ->
+                val sorted = sort(current.data?.files ?: emptyList())
+                current.copy(
+                    data = current.data?.copy(
+                        files = sorted,
+                        suggested = sort(getJunkCandidates(sorted))
+                    )
                 )
-            )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid collecting DataStore flows on IO threads
- offload heavy sorting in WhatsApp details view model to `Dispatchers.Default`
- remove redundant IO dispatcher when saving grid preference

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687caade7cec832db8771f18db8554b7