### PR TITLE
Fix cancellation handling in file cleaner coroutine flows

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/DeleteFilesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/DeleteFilesUseCase.kt
@@ -3,6 +3,8 @@ package com.d4rk.cleaner.app.clean.scanner.domain.usecases
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.cleaner.app.clean.scanner.domain.`interface`.ScannerRepositoryInterface
 import com.d4rk.cleaner.core.domain.model.network.Errors
+import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.io.File
@@ -10,12 +12,14 @@ import java.io.File
 class DeleteFilesUseCase(
     private val homeRepository : ScannerRepositoryInterface
 ) {
-    operator fun invoke(filesToDelete : Set<File>) : Flow<DataState<Unit , Errors>> = flow {
+    operator fun invoke(filesToDelete: Set<File>): Flow<DataState<Unit, Errors>> = flow {
         runCatching {
             homeRepository.deleteFiles(filesToDelete)
+        }.onSuccess {
             emit(DataState.Success(Unit))
-        }.onFailure {
-            // e -> emit(DataState.Error(e as Errors))
+        }.onFailure { throwable ->
+            if (throwable is CancellationException) throw throwable
+            emit(DataState.Error(error = throwable.toError()))
         }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetLargestFilesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/domain/usecases/GetLargestFilesUseCase.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.cleaner.app.clean.scanner.domain.`interface`.ScannerRepositoryInterface
 import com.d4rk.cleaner.core.domain.model.network.Errors
 import com.d4rk.cleaner.core.utils.extensions.toError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.io.File
@@ -16,6 +17,7 @@ class GetLargestFilesUseCase(private val repository: ScannerRepositoryInterface)
         }.onSuccess { files ->
             emit(DataState.Success(files))
         }.onFailure { throwable ->
+            if (throwable is CancellationException) throw throwable
             emit(DataState.Error(error = throwable.toError()))
         }
     }


### PR DESCRIPTION
## Summary
- ensure `DeleteFilesUseCase` rethrows `CancellationException` and converts failures to `DataState.Error`
- ensure `GetLargestFilesUseCase` rethrows `CancellationException` for proper coroutine cancellation

## Testing
- `./gradlew help`
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cab77aa7c832d80ad1f83cacb7c0e