### PR TITLE
Fix dispatcher usage for file grouping

### DIFF
--- a/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/cleaner/app/clean/scanner/ui/ScannerViewModel.kt
@@ -284,7 +284,7 @@ class ScannerViewModel(
 
                             val includeDuplicates = dataStore.deleteDuplicateFiles.first()
                             val (groupedFiles, duplicateOriginals, duplicateGroups) =
-                                withContext(dispatchers.default) {
+                                withContext(dispatchers.io) {
                                     computeGroupedFiles(
                                         scannedFiles = result.data.first,
                                         emptyFolders = result.data.second,


### PR DESCRIPTION
## Summary
- offload file grouping to IO dispatcher

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cac331dd8832d84dcae6ec2e6178c